### PR TITLE
Fix slow jellyfin boot after auto-login injection

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/API/JellyfinApiClient.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/API/JellyfinApiClient.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Jellyfin2Samsung.Helpers.API
@@ -76,6 +77,27 @@ namespace Jellyfin2Samsung.Helpers.API
             {
                 Trace.WriteLine("Failed to fetch /System/Info/Public: " + ex);
                 return null;
+            }
+        }
+
+        /// <summary>
+        /// Quick reachability probe used before baking an address into auto-login credentials.
+        /// The Jellyfin web client probes each stored server address with a 20s timeout on
+        /// startup, so any address we inject that the TV can't actually reach adds ~20s to
+        /// every cold boot. We only ship addresses that answer within a short budget.
+        /// </summary>
+        public async Task<bool> IsAddressReachableAsync(string serverUrl, TimeSpan timeout)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(timeout);
+                string url = UrlHelper.CombineUrl(serverUrl, "/System/Info/Public");
+                using var resp = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cts.Token);
+                return resp.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -85,7 +85,7 @@ namespace Jellyfin2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.3.1.0";
+        public string AppVersion { get; set; } = "v2.3.1.1";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";

--- a/Jellyfin2Samsung-CrossOS/Helpers/Jellyfin/Patches/JellyfinIndex.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Jellyfin/Patches/JellyfinIndex.cs
@@ -77,12 +77,15 @@ namespace Jellyfin2Samsung.Helpers.Jellyfin.Patches
                 servers.Add(serverUrl);
 
             // Add LocalAddress (IP-based) as fallback when the primary URL uses mDNS (.local)
-            // Samsung TVs (Tizen) cannot reliably resolve mDNS hostnames, especially after network disruptions
+            // Samsung TVs (Tizen) cannot reliably resolve mDNS hostnames, especially after network disruptions.
+            // Only add it if it actually responds: a dead entry here makes the server-select path
+            // stall ~20s on the web client's startup probe (fetchWithTimeout: 20000ms).
             var localAddress = UrlHelper.NormalizeServerUrl(AppSettings.Default.JellyfinServerLocalAddress);
             if (!string.IsNullOrEmpty(localAddress) &&
                 localAddress != serverUrl &&
                 UrlHelper.IsValidHttpUrl(localAddress) &&
-                !servers.Any(s => s?.GetValue<string>() == localAddress))
+                !servers.Any(s => s?.GetValue<string>() == localAddress) &&
+                await _apiClient.IsAddressReachableAsync(localAddress, System.TimeSpan.FromSeconds(3)))
             {
                 servers.Add(localAddress);
                 Trace.WriteLine($"[UpdateServerAddress] Added LocalAddress fallback: {localAddress}");
@@ -144,6 +147,20 @@ namespace Jellyfin2Samsung.Helpers.Jellyfin.Patches
 
             var html = await File.ReadAllTextAsync(indexPath);
 
+            // Only ship a LocalAddress if it's actually reachable AND distinct from the URL we
+            // authenticated against. localAddress is the server's self-reported LAN IP from
+            // /System/Info/Public and may be on a different subnet/VLAN, behind a reverse proxy,
+            // or a Docker bridge IP. The web client probes each address with a 20s timeout on
+            // startup, so an unreachable LocalAddress adds ~20s to every cold boot.
+            bool localReachable = false;
+            if (!string.IsNullOrEmpty(localAddress) &&
+                UrlHelper.IsValidHttpUrl(localAddress) &&
+                !string.Equals(UrlHelper.NormalizeServerUrl(localAddress), serverUrl, System.StringComparison.OrdinalIgnoreCase))
+            {
+                localReachable = await _apiClient.IsAddressReachableAsync(localAddress, System.TimeSpan.FromSeconds(3));
+                Trace.WriteLine($"[InjectAutoLogin] LocalAddress {localAddress} reachable: {localReachable}");
+            }
+
             // Create the credentials object that Jellyfin web expects
             // Using the REAL server ID (GUID) from /System/Info/Public to prevent ServerMismatch
             var credentialsScript = new StringBuilder();
@@ -163,10 +180,18 @@ namespace Jellyfin2Samsung.Helpers.Jellyfin.Patches
             credentialsScript.AppendLine("      Servers: [{");
             credentialsScript.AppendLine("        Name: serverName || serverUrl,");
             credentialsScript.AppendLine("        ManualAddress: serverUrl,");
-            credentialsScript.AppendLine("        LocalAddress: localAddress || serverUrl,");
+            // serverUrl is the address the installer just authenticated against -> known good.
+            // Default LocalAddress to it too unless we verified a distinct LAN IP is reachable,
+            // so the client can never stall 20s probing a dead address.
+            credentialsScript.AppendLine(localReachable
+                ? "        LocalAddress: localAddress || serverUrl,"
+                : "        LocalAddress: serverUrl,");
             credentialsScript.AppendLine("        Id: serverId,");
             credentialsScript.AppendLine("        UserId: userId,");
             credentialsScript.AppendLine("        AccessToken: accessToken,");
+            // ConnectionMode: Local=0, Remote=1, Manual=2. Point at the verified URL so the
+            // web client tries it first and connects immediately instead of probing modes.
+            credentialsScript.AppendLine("        LastConnectionMode: 2,");
             credentialsScript.AppendLine("        DateLastAccessed: new Date().getTime()");
             credentialsScript.AppendLine("      }]");
             credentialsScript.AppendLine("    };");

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.3.1.0](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.0)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.3.1.1-beta](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
# Pull Request Template

## Branch
- [x] I branched off beta (not master) to develop this feature/fix

## Description

Slow Jellyfin boot (40-60s) after auto-login injection (JellyfinIndex.cs)

---

## Type of Change

- [x] Bug fix (non-breaking change)
---

## Checklist

- [x] My code follows the existing project structure and style  
- [x] I have tested my changes manually  
- [x] I have added necessary documentation (if applicable)  
- [x] I have verified that the installer still works with the underlying CLI  
