### PR TITLE
Rebrand: Jellyfin2Samsung → Apps2Samsung (display-level)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-First off—thank you for your interest in contributing to **Samsung‑Jellyfin‑Installer**! This project exists thanks to community support and we welcome improvements, big or small. Whether you'd like to report a bug, suggest a feature, or contribute code, your help is appreciated.
+First off—thank you for your interest in contributing to **Apps2Samsung**! This project exists thanks to community support and we welcome improvements, big or small. Whether you'd like to report a bug, suggest a feature, or contribute code, your help is appreciated.
 
 ---
 
@@ -54,7 +54,7 @@ We welcome pull requests! Please:
 1. Fork the repository.  
 2. Clone your fork locally:  
    ```bash
-   git clone https://github.com/your-username/Samsung-Jellyfin-Installer.git
+   git clone https://github.com/your-username/Apps2Samsung.git
    ```  
 3. Open the solution in Visual Studio or your preferred IDE. Ensure you have:
    - Microsoft Edge WebView2 Runtime  
@@ -82,7 +82,7 @@ We welcome pull requests! Please:
 ### Staying Up to Date
 - Periodically sync with upstream:
   ```bash
-  git remote add upstream https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer.git
+  git remote add upstream https://github.com/Apps2Samsung/Apps2Samsung.git
   git fetch upstream
   git rebase upstream/beta
   ```
@@ -97,7 +97,7 @@ This repository is licensed under the **MIT License**. By contributing, you agre
 
 ## 6. Code of Conduct
 
-Please abide by our [Code of Conduct](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/blob/master/CODE_OF_CONDUCT.md). Maintain a respectful, welcoming environment for all contributors.
+Please abide by our [Code of Conduct](https://github.com/Apps2Samsung/Apps2Samsung/blob/beta/.github/CODE_OF_CONDUCT.md). Maintain a respectful, welcoming environment for all contributors.
 
 ---
 
@@ -108,4 +108,4 @@ Please abide by our [Code of Conduct](https://github.com/PatrickSt1991/Samsung-J
 - **Wiki**: for documentation  
 - **[Sponsor Page / ko-fi](https://ko-fi.com/patrickst)**: if you'd like to support the project financially  
 
-Thanks again for your contributions—together, we can make installation smoother and more reliable for Jellyfin users on Samsung Tizen TVs!  
+Thanks again for your contributions—together, we can make app installation smoother and more reliable on Samsung Tizen TVs!  

--- a/.github/ISSUE_TEMPLATE/generic-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/generic-bug-report.md
@@ -7,7 +7,7 @@ assignees: PatrickSt1991
 ---
 
 **Have you checked the wiki?**
-[Samsung Jellyfin Installer Wiki](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/wiki/FAQ)
+[Apps2Samsung Wiki](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ)
 
 **Have you included the log files in this issue?**
 - Yes  

--- a/.github/ISSUE_TEMPLATE/tizen-6--bug.md
+++ b/.github/ISSUE_TEMPLATE/tizen-6--bug.md
@@ -8,7 +8,7 @@ assignees: PatrickSt1991
 ---
 
 **Have you checked the wiki?**
-[Samsung Jellyfin Installer Wiki](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/wiki/FAQ)
+[Apps2Samsung Wiki](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ)
 
 **Have you included the log files in this issue?**
 - Yes  

--- a/.github/ISSUE_TEMPLATE/tizen-6-5--bug.md
+++ b/.github/ISSUE_TEMPLATE/tizen-6-5--bug.md
@@ -8,7 +8,7 @@ assignees: PatrickSt1991
 ---
 
 **Have you checked the wiki?**
-[Samsung Jellyfin Installer Wiki](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/wiki/FAQ)
+[Apps2Samsung Wiki](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ)
 
 **Have you included the log files in this issue?**
 - Yes  

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in **Samsung‑Jellyfin‑Installer**, please report it via the [GitHub Issues](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/issues) page.  
+If you discover a security vulnerability in **Apps2Samsung**, please report it via the [GitHub Issues](https://github.com/Apps2Samsung/Apps2Samsung/issues) page.  
 
 Include as much information as possible:
 - Version of the installer you are using

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -184,11 +184,11 @@ namespace Jellyfin2Samsung.Helpers.Core
         /// </summary>
         public static class Updater
         {
-            public const string RepoOwner = "Jellyfin2Samsung";
-            public const string RepoName = "Samsung-Jellyfin-Installer";
-            public const string AtomFeedUrl = "https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases.atom";
-            public const string ReleasesPageUrl = "https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases";
-            public const string LatestReleaseApiUrl = "https://api.github.com/repos/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/latest";
+            public const string RepoOwner = "Apps2Samsung";
+            public const string RepoName = "Apps2Samsung";
+            public const string AtomFeedUrl = "https://github.com/Apps2Samsung/Apps2Samsung/releases.atom";
+            public const string ReleasesPageUrl = "https://github.com/Apps2Samsung/Apps2Samsung/releases";
+            public const string LatestReleaseApiUrl = "https://api.github.com/repos/Apps2Samsung/Apps2Samsung/releases/latest";
             public const int UpdateCheckTimeoutSeconds = 10;
         }
 

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/PlatformService.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/PlatformService.cs
@@ -182,7 +182,7 @@ namespace Jellyfin2Samsung.Helpers.Core
                 Platform.Windows =>
                     $"Windows:\n" +
                     $"  netstat -ano | findstr {port}\n\n" +
-                    $"  New-NetFirewallRule -DisplayName \"Jellyfin2Samsung Logs\" \\\n" +
+                    $"  New-NetFirewallRule -DisplayName \"Apps2Samsung Logs\" \\\n" +
                     $"    -Direction Inbound -Protocol TCP -LocalPort {port} -Action Allow\n",
 
                 Platform.Linux =>
@@ -191,7 +191,7 @@ namespace Jellyfin2Samsung.Helpers.Core
                 Platform.MacOS =>
                     "macOS:\n" +
                     "  System Settings -> Network -> Firewall -> Options\n" +
-                    "  Allow incoming connections for Jellyfin2Samsung\n",
+                    "  Allow incoming connections for Apps2Samsung\n",
 
                 _ => "Ensure your firewall allows inbound TCP connections.\n"
             };

--- a/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
@@ -15,7 +15,7 @@ namespace Jellyfin2Samsung.Services
     public class ProviderManifestService
     {
         private const string RemoteUrl =
-            "https://raw.githubusercontent.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/main/third-party-apps.json";
+            "https://raw.githubusercontent.com/Apps2Samsung/Apps2Samsung/main/third-party-apps.json";
 
         private static readonly Uri BundledUri =
             new("avares://Jellyfin2Samsung/Assets/third-party-apps.json");

--- a/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
@@ -24,8 +24,8 @@ namespace Jellyfin2Samsung.Services
     public class UpdaterService : IUpdaterService
     {
         private readonly HttpClient _httpClient;
-        private const string RepoOwner = "Jellyfin2Samsung";
-        private const string RepoName = "Samsung-Jellyfin-Installer";
+        private const string RepoOwner = "Apps2Samsung";
+        private const string RepoName = "Apps2Samsung";
         private const string AtomFeedUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases.atom";
         private const string ReleasesApiUrl = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
 

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -8,7 +8,7 @@
         Width="580"
         Height="410"
         WindowStartupLocation="CenterScreen"
-        Title="Jellyfin2Samsung">
+        Title="Apps2Samsung">
 	<Window.Resources>
 		<helpers:TvLogStatusToBrushConverter x:Key="TvLogStatusToBrushConverter"/>
 		<helpers:StringEqualsConverter x:Key="StringEquals"/>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Jellyfin2Samsung
+# Apps2Samsung
+
+*Install any app on your Samsung TV.*
 
 <p align="center">
   <img src=".github/jellyfin-tizen-logo.svg" width="220" />
 </p>
 <p align="center">
-  <img src="https://img.shields.io/github/v/release/Jellyfin2Samsung/Samsung-Jellyfin-Installer?label=stable&style=for-the-badge" />
-  <img src="https://img.shields.io/github/v/release/Jellyfin2Samsung/Samsung-Jellyfin-Installer?include_prereleases&label=beta&style=for-the-badge" />
+  <img src="https://img.shields.io/github/v/release/Apps2Samsung/Apps2Samsung?label=stable&style=for-the-badge" />
+  <img src="https://img.shields.io/github/v/release/Apps2Samsung/Apps2Samsung?include_prereleases&label=beta&style=for-the-badge" />
   <img src="https://img.shields.io/badge/Tizen-TV-blue?style=for-the-badge" />
   <img src="https://img.shields.io/badge/OS-Windows%20%7C%20Linux%20%7C%20macOS-brightgreen?style=for-the-badge" />
   <a href="https://discord.gg/7mga3zh8Cv">
@@ -14,7 +16,8 @@
 </p>
 
 <p align="center">
-  <b>Jellyfin 2 Samsung</b> is a small cross-platform tool that helps you install <a href="https://jellyfin.org">Jellyfin</a> on <b>Samsung Smart TVs running Tizen OS</b>.
+  <b>Apps2Samsung</b> is a small cross-platform tool that side-loads <b>any app</b> onto <b>Samsung devices running Tizen OS</b> — Smart TVs, projectors and smart monitors —
+  <a href="https://jellyfin.org">Jellyfin</a>, Moonlight, Moonfin, Litefin and the whole <a href="https://github.com/Apps2Samsung/tizen-community-packages">community catalog</a>, or your own <code>.wgt</code>.
   <br/>
   It handles device detection, certificates, and installation so you don’t have to fight with Tizen Studio or manual sideloading.
   <br/><br/>
@@ -31,24 +34,24 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.3.1.1](https://github.com/Apps2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
+| **Stable** | [v2.3.1.1](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
 | **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 
-👉 All releases: https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases
+👉 All releases: https://github.com/Apps2Samsung/Apps2Samsung/releases
 
 ---
 
 ## 🚀 How It Works (Short Version)
 
-Before you begin, ensure your Samsung TV is in Developer Mode. This is required to install applications like Jellyfin.
+Before you begin, ensure your Samsung TV is in Developer Mode. This is required to install apps on it.
 
-👉 [How to enable Developer Mode on your TV](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/wiki/FAQ#-how-to-enable-developer-mode-on-your-tv)
+👉 [How to enable Developer Mode on your TV](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ#-how-to-enable-developer-mode-on-your-tv)
 
 1. Run the tool on your computer
 2. Select your Samsung TV
-3. Pick a Jellyfin version
+3. Pick an app (Jellyfin, the community catalog, or a custom `.wgt`)
 4. Install
 
 That’s it. No manual certificate handling required in most cases.
@@ -56,7 +59,7 @@ That’s it. No manual certificate handling required in most cases.
 🎥 Full walkthrough:  
 https://www.youtube.com/watch?v=_8mSV5pW-ic
 
-**NixOS:** Clone the [`Samsung2Jellyfin` branch](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer.git) and run `nix-shell` — the shell environment will automatically build and launch the tool.
+**NixOS:** Clone the repository and run `nix-shell` — the shell environment will automatically build and launch the tool.
 
 ---
 
@@ -70,21 +73,14 @@ All detailed documentation lives in the wiki:
 - 🔮 [Alternative Install Methods](../../wiki/Alternatives)
 - 🗑️ [Uninstall / Remove](../../wiki/Remove)
 
----
-
-## ⚠️ Older Samsung TVs (Orsay OS)
-
-Samsung TVs running **Orsay OS** are not supported.
-
-Use this installer instead:  
-https://github.com/PatrickSt1991/Jellyfin-Orsay-Installer
+> Orsay-based TVs (pre-2015 models) are no longer supported.
 
 ---
 
 ## 📦 Community Packages
 
 Community-shared and older `.wgt` builds can be found here:  
-https://github.com/PatrickSt1991/tizen-community-packages
+https://github.com/Apps2Samsung/tizen-community-packages
 
 ---
 
@@ -98,7 +94,7 @@ Contributions of all kinds are welcome — whether it’s bug reports, feature r
 
 ## 🌍 Translations
 
-Want to help translate **Jellyfin2Samsung**? Community translations are always appreciated.
+Want to help translate **Apps2Samsung**? Community translations are always appreciated.
 
 You can contribute here:
 
@@ -123,8 +119,8 @@ If this tool helped you, consider supporting its development:
 
 This project is made possible by the people who contribute their time, knowledge, and feedback.
 
-<a href="https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Jellyfin2Samsung/Samsung-Jellyfin-Installer" />
+<a href="https://github.com/Apps2Samsung/Apps2Samsung/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Apps2Samsung/Apps2Samsung" />
 </a>
 
 Special thanks to:
@@ -134,4 +130,3 @@ Special thanks to:
   https://github.com/Moonfin-Client/Smart-TV
 - **@MoazSalem** — for the Litefin client and related work  
   https://github.com/MoazSalem/litefin/
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Apps2Samsung — Install any app on your Samsung TV</title>
-  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads any app onto Samsung Smart TVs — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Free and open source." />
+  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Free and open source." />
   <meta name="keywords" content="Samsung TV app installer, install apps Samsung TV, Samsung TV sideload, Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Moonlight Samsung TV, Moonfin, Litefin, AVPlay, Tizen community apps, Apps2Samsung, Jellyfin2Samsung, Patrick Stel" />
   <link rel="canonical" href="https://apps2samsung.madebypatrick.nl/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Apps2Samsung — Install any app on your Samsung TV" />
   <meta property="og:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto your Samsung TV. Runs on Windows, macOS and Linux." />
-  <meta property="og:image" content="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png" />
+  <meta property="og:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png" />
   <meta property="og:url" content="https://apps2samsung.madebypatrick.nl/" />
   <meta property="og:type" content="website" />
 
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Apps2Samsung — Install any app on your Samsung TV">
   <meta name="twitter:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto Samsung TVs from Windows, macOS or Linux.">
-  <meta name="twitter:image" content="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png">
+  <meta name="twitter:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png">
 
   <!-- Favicon -->
   <link rel="icon" href="/favicon.ico">
@@ -32,16 +32,16 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Apps2Samsung",
-    "alternateName": ["Jellyfin2Samsung", "Samsung Jellyfin Installer", "Samsung TV App Installer"],
+    "alternateName": ["Jellyfin2Samsung", "Samsung Jellyfin Installer"],
     "operatingSystem": "Windows, macOS, Linux",
     "applicationCategory": "UtilitiesApplication",
     "author": {
       "@type": "Person",
       "name": "Patrick Stel"
     },
-    "description": "Cross-platform desktop installer that side-loads any app onto Samsung Smart TVs — Jellyfin, Moonlight and the whole community Tizen catalog.",
+    "description": "Cross-platform desktop installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight and the whole community Tizen catalog.",
     "url": "https://apps2samsung.madebypatrick.nl/",
-    "image": "https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png"
+    "image": "https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png"
   }
   </script>
 
@@ -176,9 +176,9 @@
 </head>
 <body>
   <main>
-    <img class="logo" src="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.svg" alt="Apps2Samsung — Samsung TV app installer">
+    <img class="logo" src="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.svg" alt="Apps2Samsung — Samsung TV app installer">
     <h1>Apps2Samsung</h1>
-    <h2>Install any app on your Samsung TV — Jellyfin, Moonlight and the whole community catalog, from Windows, macOS or Linux</h2>
+    <h2>Install any app on your Samsung TV, projector or smart monitor — Jellyfin, Moonlight and the whole community catalog, from Windows, macOS or Linux</h2>
 
     <!-- Responsive YouTube Embed -->
     <div class="video-wrapper">
@@ -200,7 +200,7 @@
 
     <p>
       <a id="downloadBtn" class="btn" href="#" target="_blank" rel="noopener">⬇️ <span id="downloadLabel">Download</span></a>
-      <a class="btn" href="https://github.com/Apps2Samsung/Samsung-TV-App-Installer" target="_blank" rel="noopener">🧰 Source Code</a>
+      <a class="btn" href="https://github.com/Apps2Samsung/Apps2Samsung" target="_blank" rel="noopener">🧰 Source Code</a>
     </p>
 
     <h3>All downloads</h3>
@@ -244,7 +244,7 @@
 
   <script>
   (async function(){
-    const owner='Apps2Samsung', repo='Samsung-TV-App-Installer';
+    const owner='Apps2Samsung', repo='Apps2Samsung';
     const els={
       ver:   document.getElementById('latestVersion'),
       date:  document.getElementById('releaseDate'),


### PR DESCRIPTION
## What

Display-level rebrand of the project from **Jellyfin2Samsung** to **Apps2Samsung**, repositioning the tool as an installer for *any* app on Samsung Tizen devices (TVs, projectors, smart monitors) with Jellyfin as the most popular catalog entry.

### Changes
- **README** — new title + tagline, app-agnostic intro, badges/links moved to `Apps2Samsung/Apps2Samsung`, Orsay section reduced to a one-line note, Special-thanks credits kept
- **Community health files** — CONTRIBUTING, SECURITY, issue templates: old `PatrickSt1991/…` and `Jellyfin2Samsung/…` slugs updated
- **In-app URLs** — `Constants.cs`, `UpdaterService.cs`, `ProviderManifestService.cs` now point at the renamed repo (old URLs kept working via GitHub redirects; this is cleanup)
- **Window title** — `Jellyfin2Samsung` → `Apps2Samsung`
- **docs/** — landing page: repo slug fixes, projector/smart-monitor wording

### Deliberately NOT in this PR (needs separate sign-off — cascades into winget/homebrew/self-updater)
- `<AssemblyName>` / `<RootNamespace>` / C# namespaces
- `avares://Jellyfin2Samsung/…` resource URIs (bound to assembly name)
- CFBundle identifiers, `jellyfin2samsung.desktop`, `app.manifest`, `shell.nix`
- Workflow `PRODUCT_NAME` / release artifact names (old installed clients' self-updater expects current naming)
- `crowdin.yml` + Transifex/Crowdin links (slugs must be renamed in their dashboards first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)