### PR TITLE
Bump version to v2.3.2

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -85,7 +85,7 @@ namespace Jellyfin2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.3.1.1";
+        public string AppVersion { get; set; } = "v2.3.2";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";


### PR DESCRIPTION
Version bump for the updater-migration patch release (#360). CI extracts the version from `AppSettings.cs`, so this is what makes the next beta/stable builds tag as `v2.3.2`.

Release flow reminder:
1. Merge this → `beta` prerelease `v2.3.2-beta` builds automatically (still old `Jellyfin2Samsung` artifact names — intended)
2. Open & merge a `beta → master` PR → stable `v2.3.2` publishes — existing installs pick up the migration-capable updater via auto-update
3. Later: merge #361 + bump to v2.4.0 → first `Apps2Samsung`-named release

🤖 Generated with [Claude Code](https://claude.com/claude-code)