### PR TITLE
Update Transifex link to renamed slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Want to help translate **Apps2Samsung**? Community translations are always appre
 
 You can contribute here:
 
-- [Transifex](https://app.transifex.com/madebypatrick/jellyfin2samsung)
+- [Transifex](https://app.transifex.com/madebypatrick/apps2samsung)
 - [Crowdin](https://crowdin.com/project/jellyfin2samsung)
 
 You can help by translating missing strings, improving existing translations, or reviewing your language.


### PR DESCRIPTION
Transifex project slug was renamed to `apps2samsung` in the dashboard — this updates the README link. Crowdin keeps its original slug (Crowdin doesn't support slug renames); its display name is renamed dashboard-side instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)