### PR TITLE
Release v2.3.2 — updater migration patch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guidelines
 
-First off—thank you for your interest in contributing to **Samsung‑Jellyfin‑Installer**! This project exists thanks to community support and we welcome improvements, big or small. Whether you'd like to report a bug, suggest a feature, or contribute code, your help is appreciated.
+First off—thank you for your interest in contributing to **Apps2Samsung**! This project exists thanks to community support and we welcome improvements, big or small. Whether you'd like to report a bug, suggest a feature, or contribute code, your help is appreciated.
 
 ---
 
@@ -54,7 +54,7 @@ We welcome pull requests! Please:
 1. Fork the repository.  
 2. Clone your fork locally:  
    ```bash
-   git clone https://github.com/your-username/Samsung-Jellyfin-Installer.git
+   git clone https://github.com/your-username/Apps2Samsung.git
    ```  
 3. Open the solution in Visual Studio or your preferred IDE. Ensure you have:
    - Microsoft Edge WebView2 Runtime  
@@ -82,7 +82,7 @@ We welcome pull requests! Please:
 ### Staying Up to Date
 - Periodically sync with upstream:
   ```bash
-  git remote add upstream https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer.git
+  git remote add upstream https://github.com/Apps2Samsung/Apps2Samsung.git
   git fetch upstream
   git rebase upstream/beta
   ```
@@ -97,7 +97,7 @@ This repository is licensed under the **MIT License**. By contributing, you agre
 
 ## 6. Code of Conduct
 
-Please abide by our [Code of Conduct](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/blob/master/CODE_OF_CONDUCT.md). Maintain a respectful, welcoming environment for all contributors.
+Please abide by our [Code of Conduct](https://github.com/Apps2Samsung/Apps2Samsung/blob/beta/.github/CODE_OF_CONDUCT.md). Maintain a respectful, welcoming environment for all contributors.
 
 ---
 
@@ -108,4 +108,4 @@ Please abide by our [Code of Conduct](https://github.com/PatrickSt1991/Samsung-J
 - **Wiki**: for documentation  
 - **[Sponsor Page / ko-fi](https://ko-fi.com/patrickst)**: if you'd like to support the project financially  
 
-Thanks again for your contributions—together, we can make installation smoother and more reliable for Jellyfin users on Samsung Tizen TVs!  
+Thanks again for your contributions—together, we can make app installation smoother and more reliable on Samsung Tizen TVs!  

--- a/.github/ISSUE_TEMPLATE/generic-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/generic-bug-report.md
@@ -7,7 +7,7 @@ assignees: PatrickSt1991
 ---
 
 **Have you checked the wiki?**
-[Samsung Jellyfin Installer Wiki](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/wiki/FAQ)
+[Apps2Samsung Wiki](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ)
 
 **Have you included the log files in this issue?**
 - Yes  

--- a/.github/ISSUE_TEMPLATE/tizen-6--bug.md
+++ b/.github/ISSUE_TEMPLATE/tizen-6--bug.md
@@ -8,7 +8,7 @@ assignees: PatrickSt1991
 ---
 
 **Have you checked the wiki?**
-[Samsung Jellyfin Installer Wiki](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/wiki/FAQ)
+[Apps2Samsung Wiki](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ)
 
 **Have you included the log files in this issue?**
 - Yes  

--- a/.github/ISSUE_TEMPLATE/tizen-6-5--bug.md
+++ b/.github/ISSUE_TEMPLATE/tizen-6-5--bug.md
@@ -8,7 +8,7 @@ assignees: PatrickSt1991
 ---
 
 **Have you checked the wiki?**
-[Samsung Jellyfin Installer Wiki](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/wiki/FAQ)
+[Apps2Samsung Wiki](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ)
 
 **Have you included the log files in this issue?**
 - Yes  

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in **Samsung‑Jellyfin‑Installer**, please report it via the [GitHub Issues](https://github.com/PatrickSt1991/Samsung-Jellyfin-Installer/issues) page.  
+If you discover a security vulnerability in **Apps2Samsung**, please report it via the [GitHub Issues](https://github.com/Apps2Samsung/Apps2Samsung/issues) page.  
 
 Include as much information as possible:
 - Version of the installer you are using

--- a/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
@@ -85,5 +85,7 @@
     { "matchName": "Doom", "previewImage": "https://iili.io/fyofVqu.png" },
     { "matchName": "TransportTycoonDeluxe", "previewImage": "https://iili.io/qFBP2vn.png" },
     { "matchName": "Nuvio", "previewImage": "https://nuvioapp.space/assets/newss/Screenshot%202026-04-05%20at%203.17.41%E2%80%AFPM.png" }
+    { "matchName": "VLC-Tizen-tv", "previewImage": "https://iili.io/CfGNeqb.png" }
+    { "matchName": "Flixor-Tizen", "previewImage": "https://iili.io/CfGjV44.webp" }
   ]
 }

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -85,7 +85,7 @@ namespace Jellyfin2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.3.1.1";
+        public string AppVersion { get; set; } = "v2.3.2";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -184,11 +184,11 @@ namespace Jellyfin2Samsung.Helpers.Core
         /// </summary>
         public static class Updater
         {
-            public const string RepoOwner = "Jellyfin2Samsung";
-            public const string RepoName = "Samsung-Jellyfin-Installer";
-            public const string AtomFeedUrl = "https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases.atom";
-            public const string ReleasesPageUrl = "https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases";
-            public const string LatestReleaseApiUrl = "https://api.github.com/repos/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/latest";
+            public const string RepoOwner = "Apps2Samsung";
+            public const string RepoName = "Apps2Samsung";
+            public const string AtomFeedUrl = "https://github.com/Apps2Samsung/Apps2Samsung/releases.atom";
+            public const string ReleasesPageUrl = "https://github.com/Apps2Samsung/Apps2Samsung/releases";
+            public const string LatestReleaseApiUrl = "https://api.github.com/repos/Apps2Samsung/Apps2Samsung/releases/latest";
             public const int UpdateCheckTimeoutSeconds = 10;
         }
 

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/PlatformService.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/PlatformService.cs
@@ -182,7 +182,7 @@ namespace Jellyfin2Samsung.Helpers.Core
                 Platform.Windows =>
                     $"Windows:\n" +
                     $"  netstat -ano | findstr {port}\n\n" +
-                    $"  New-NetFirewallRule -DisplayName \"Jellyfin2Samsung Logs\" \\\n" +
+                    $"  New-NetFirewallRule -DisplayName \"Apps2Samsung Logs\" \\\n" +
                     $"    -Direction Inbound -Protocol TCP -LocalPort {port} -Action Allow\n",
 
                 Platform.Linux =>
@@ -191,7 +191,7 @@ namespace Jellyfin2Samsung.Helpers.Core
                 Platform.MacOS =>
                     "macOS:\n" +
                     "  System Settings -> Network -> Firewall -> Options\n" +
-                    "  Allow incoming connections for Jellyfin2Samsung\n",
+                    "  Allow incoming connections for Apps2Samsung\n",
 
                 _ => "Ensure your firewall allows inbound TCP connections.\n"
             };

--- a/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
@@ -15,7 +15,7 @@ namespace Jellyfin2Samsung.Services
     public class ProviderManifestService
     {
         private const string RemoteUrl =
-            "https://raw.githubusercontent.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/main/third-party-apps.json";
+            "https://raw.githubusercontent.com/Apps2Samsung/Apps2Samsung/main/third-party-apps.json";
 
         private static readonly Uri BundledUri =
             new("avares://Jellyfin2Samsung/Assets/third-party-apps.json");

--- a/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
@@ -299,8 +299,13 @@ namespace Jellyfin2Samsung.Services
                     throw new InvalidOperationException("Could not find application files in the update package.");
                 }
 
+                // The update may ship a different executable name than the one
+                // currently running (rebrand) — relaunch whatever the package contains.
+                var newExeName = FindExecutableName(extractedAppDir)
+                    ?? throw new InvalidOperationException("Could not find the application executable in the update package.");
+
                 // Create update script
-                var scriptPath = CreateUpdateScript(extractedAppDir, appDir, backupDir);
+                var scriptPath = CreateUpdateScript(extractedAppDir, appDir, backupDir, newExeName);
 
                 // Launch the update script and exit
                 LaunchUpdateScript(scriptPath);
@@ -322,26 +327,41 @@ namespace Jellyfin2Samsung.Services
             await TarFile.ExtractToDirectoryAsync(gzipStream, destinationDir, overwriteFiles: true, cancellationToken);
         }
 
+        /// <summary>
+        /// Executable base names this updater recognises, newest first.
+        /// The project was rebranded from Jellyfin2Samsung to Apps2Samsung —
+        /// accepting both keeps automatic updates working across the rename.
+        /// </summary>
+        private static readonly string[] ExeBaseNameCandidates = { "Apps2Samsung", "Jellyfin2Samsung" };
+
+        private static string? FindExecutableName(string directory)
+        {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            foreach (var baseName in ExeBaseNameCandidates)
+            {
+                var exeName = isWindows ? $"{baseName}.exe" : baseName;
+                if (File.Exists(Path.Combine(directory, exeName)))
+                    return exeName;
+            }
+            return null;
+        }
+
         private string? FindApplicationDirectory(string extractedDir)
         {
             // Check if the main executable is directly in the extracted directory
-            var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? "Jellyfin2Samsung.exe"
-                : "Jellyfin2Samsung";
-
-            if (File.Exists(Path.Combine(extractedDir, exeName)))
+            if (FindExecutableName(extractedDir) != null)
                 return extractedDir;
 
             // Check subdirectories
             foreach (var subDir in Directory.GetDirectories(extractedDir))
             {
-                if (File.Exists(Path.Combine(subDir, exeName)))
+                if (FindExecutableName(subDir) != null)
                     return subDir;
 
                 // Check one level deeper
                 foreach (var subSubDir in Directory.GetDirectories(subDir))
                 {
-                    if (File.Exists(Path.Combine(subSubDir, exeName)))
+                    if (FindExecutableName(subSubDir) != null)
                         return subSubDir;
                 }
             }
@@ -349,13 +369,19 @@ namespace Jellyfin2Samsung.Services
             return null;
         }
 
-        private string CreateUpdateScript(string sourceDir, string targetDir, string backupDir)
+        private string CreateUpdateScript(string sourceDir, string targetDir, string backupDir, string exeName)
         {
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var scriptExtension = isWindows ? ".bat" : ".sh";
             var scriptPath = Path.Combine(Path.GetTempPath(), $"jellyfin2samsung_update{scriptExtension}");
 
-            var exeName = isWindows ? "Jellyfin2Samsung.exe" : "Jellyfin2Samsung";
+            // When the executable name changes across the update (rebrand), remove
+            // the leftover binaries of the previous name so the user doesn't end up
+            // with two executables side by side. A full backup is taken first.
+            var newBaseName = Path.GetFileNameWithoutExtension(exeName);
+            var staleBaseNames = ExeBaseNameCandidates
+                .Where(b => !b.Equals(newBaseName, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
             var processId = Environment.ProcessId;
 
             string scriptContent;
@@ -379,6 +405,9 @@ xcopy ""{targetDir}\*"" ""{backupDir}\"" /E /H /Y /Q
 
 echo Installing update...
 xcopy ""{sourceDir}\*"" ""{targetDir}\"" /E /H /Y /Q
+
+echo Removing old binaries...
+{string.Join("\r\n", staleBaseNames.Select(b => $@"del /q ""{Path.Combine(targetDir, b)}.*"" 2>nul"))}
 
 echo Starting application...
 start """" ""{Path.Combine(targetDir, exeName)}""
@@ -405,6 +434,10 @@ cp -r ""{targetDir}/""* ""{backupDir}/""
 
 echo ""Installing update...""
 cp -rf ""{sourceDir}/""* ""{targetDir}/""
+
+echo ""Removing old binaries...""
+{string.Join("\n", staleBaseNames.Select(b => $@"rm -f ""{Path.Combine(targetDir, b)}"" ""{Path.Combine(targetDir, b)}.""*"))}
+
 chmod +x ""{Path.Combine(targetDir, exeName)}""
 
 echo ""Starting application...""

--- a/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
@@ -24,8 +24,8 @@ namespace Jellyfin2Samsung.Services
     public class UpdaterService : IUpdaterService
     {
         private readonly HttpClient _httpClient;
-        private const string RepoOwner = "Jellyfin2Samsung";
-        private const string RepoName = "Samsung-Jellyfin-Installer";
+        private const string RepoOwner = "Apps2Samsung";
+        private const string RepoName = "Apps2Samsung";
         private const string AtomFeedUrl = $"https://github.com/{RepoOwner}/{RepoName}/releases.atom";
         private const string ReleasesApiUrl = $"https://api.github.com/repos/{RepoOwner}/{RepoName}/releases/latest";
 

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -8,7 +8,7 @@
         Width="580"
         Height="410"
         WindowStartupLocation="CenterScreen"
-        Title="Jellyfin2Samsung">
+        Title="Apps2Samsung">
 	<Window.Resources>
 		<helpers:TvLogStatusToBrushConverter x:Key="TvLogStatusToBrushConverter"/>
 		<helpers:StringEqualsConverter x:Key="StringEquals"/>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# Jellyfin2Samsung
+# Apps2Samsung
+
+*Install any app on your Samsung TV.*
 
 <p align="center">
   <img src=".github/jellyfin-tizen-logo.svg" width="220" />
 </p>
 <p align="center">
-  <img src="https://img.shields.io/github/v/release/Jellyfin2Samsung/Samsung-Jellyfin-Installer?label=stable&style=for-the-badge" />
-  <img src="https://img.shields.io/github/v/release/Jellyfin2Samsung/Samsung-Jellyfin-Installer?include_prereleases&label=beta&style=for-the-badge" />
+  <img src="https://img.shields.io/github/v/release/Apps2Samsung/Apps2Samsung?label=stable&style=for-the-badge" />
+  <img src="https://img.shields.io/github/v/release/Apps2Samsung/Apps2Samsung?include_prereleases&label=beta&style=for-the-badge" />
   <img src="https://img.shields.io/badge/Tizen-TV-blue?style=for-the-badge" />
   <img src="https://img.shields.io/badge/OS-Windows%20%7C%20Linux%20%7C%20macOS-brightgreen?style=for-the-badge" />
   <a href="https://discord.gg/7mga3zh8Cv">
@@ -14,7 +16,8 @@
 </p>
 
 <p align="center">
-  <b>Jellyfin 2 Samsung</b> is a small cross-platform tool that helps you install <a href="https://jellyfin.org">Jellyfin</a> on <b>Samsung Smart TVs running Tizen OS</b>.
+  <b>Apps2Samsung</b> is a small cross-platform tool that side-loads <b>any app</b> onto <b>Samsung devices running Tizen OS</b> — Smart TVs, projectors and smart monitors —
+  <a href="https://jellyfin.org">Jellyfin</a>, Moonlight, Moonfin, Litefin and the whole <a href="https://github.com/Apps2Samsung/tizen-community-packages">community catalog</a>, or your own <code>.wgt</code>.
   <br/>
   It handles device detection, certificates, and installation so you don’t have to fight with Tizen Studio or manual sideloading.
   <br/><br/>
@@ -31,24 +34,24 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.3.1.1](https://github.com/Apps2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
+| **Stable** | [v2.3.1.1](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
 | **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 
-👉 All releases: https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases
+👉 All releases: https://github.com/Apps2Samsung/Apps2Samsung/releases
 
 ---
 
 ## 🚀 How It Works (Short Version)
 
-Before you begin, ensure your Samsung TV is in Developer Mode. This is required to install applications like Jellyfin.
+Before you begin, ensure your Samsung TV is in Developer Mode. This is required to install apps on it.
 
-👉 [How to enable Developer Mode on your TV](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/wiki/FAQ#-how-to-enable-developer-mode-on-your-tv)
+👉 [How to enable Developer Mode on your TV](https://github.com/Apps2Samsung/Apps2Samsung/wiki/FAQ#-how-to-enable-developer-mode-on-your-tv)
 
 1. Run the tool on your computer
 2. Select your Samsung TV
-3. Pick a Jellyfin version
+3. Pick an app (Jellyfin, the community catalog, or a custom `.wgt`)
 4. Install
 
 That’s it. No manual certificate handling required in most cases.
@@ -56,7 +59,7 @@ That’s it. No manual certificate handling required in most cases.
 🎥 Full walkthrough:  
 https://www.youtube.com/watch?v=_8mSV5pW-ic
 
-**NixOS:** Clone the [`Samsung2Jellyfin` branch](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer.git) and run `nix-shell` — the shell environment will automatically build and launch the tool.
+**NixOS:** Clone the repository and run `nix-shell` — the shell environment will automatically build and launch the tool.
 
 ---
 
@@ -70,21 +73,14 @@ All detailed documentation lives in the wiki:
 - 🔮 [Alternative Install Methods](../../wiki/Alternatives)
 - 🗑️ [Uninstall / Remove](../../wiki/Remove)
 
----
-
-## ⚠️ Older Samsung TVs (Orsay OS)
-
-Samsung TVs running **Orsay OS** are not supported.
-
-Use this installer instead:  
-https://github.com/PatrickSt1991/Jellyfin-Orsay-Installer
+> Orsay-based TVs (pre-2015 models) are no longer supported.
 
 ---
 
 ## 📦 Community Packages
 
 Community-shared and older `.wgt` builds can be found here:  
-https://github.com/PatrickSt1991/tizen-community-packages
+https://github.com/Apps2Samsung/tizen-community-packages
 
 ---
 
@@ -98,7 +94,7 @@ Contributions of all kinds are welcome — whether it’s bug reports, feature r
 
 ## 🌍 Translations
 
-Want to help translate **Jellyfin2Samsung**? Community translations are always appreciated.
+Want to help translate **Apps2Samsung**? Community translations are always appreciated.
 
 You can contribute here:
 
@@ -123,8 +119,8 @@ If this tool helped you, consider supporting its development:
 
 This project is made possible by the people who contribute their time, knowledge, and feedback.
 
-<a href="https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=Jellyfin2Samsung/Samsung-Jellyfin-Installer" />
+<a href="https://github.com/Apps2Samsung/Apps2Samsung/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Apps2Samsung/Apps2Samsung" />
 </a>
 
 Special thanks to:
@@ -134,4 +130,3 @@ Special thanks to:
   https://github.com/Moonfin-Client/Smart-TV
 - **@MoazSalem** — for the Litefin client and related work  
   https://github.com/MoazSalem/litefin/
-

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Want to help translate **Apps2Samsung**? Community translations are always appre
 
 You can contribute here:
 
-- [Transifex](https://app.transifex.com/madebypatrick/jellyfin2samsung)
+- [Transifex](https://app.transifex.com/madebypatrick/apps2samsung)
 - [Crowdin](https://crowdin.com/project/jellyfin2samsung)
 
 You can help by translating missing strings, improving existing translations, or reviewing your language.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.3.1.1](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
+| **Stable** | [v2.3.1.1](https://github.com/Apps2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
 | **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.3.1.0](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.0)                                        | Recommended for most users   |
-| **Beta**   | [v2.3.1.1-beta](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1-beta)                                            | Includes new features        |
+| **Stable** | [v2.3.1.1](https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
+| **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.3.1.1](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.3.1.1)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.3.2-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.3.2-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-jellyfin2samsung.madebypatrick.nl
+apps2samsung.madebypatrick.nl

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <title>Apps2Samsung — Install any app on your Samsung TV</title>
-  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads any app onto Samsung Smart TVs — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Free and open source." />
+  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Free and open source." />
   <meta name="keywords" content="Samsung TV app installer, install apps Samsung TV, Samsung TV sideload, Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Moonlight Samsung TV, Moonfin, Litefin, AVPlay, Tizen community apps, Apps2Samsung, Jellyfin2Samsung, Patrick Stel" />
   <link rel="canonical" href="https://apps2samsung.madebypatrick.nl/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Apps2Samsung — Install any app on your Samsung TV" />
   <meta property="og:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto your Samsung TV. Runs on Windows, macOS and Linux." />
-  <meta property="og:image" content="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png" />
+  <meta property="og:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png" />
   <meta property="og:url" content="https://apps2samsung.madebypatrick.nl/" />
   <meta property="og:type" content="website" />
 
@@ -20,7 +20,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Apps2Samsung — Install any app on your Samsung TV">
   <meta name="twitter:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto Samsung TVs from Windows, macOS or Linux.">
-  <meta name="twitter:image" content="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png">
+  <meta name="twitter:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png">
 
   <!-- Favicon -->
   <link rel="icon" href="/favicon.ico">
@@ -32,16 +32,16 @@
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Apps2Samsung",
-    "alternateName": ["Jellyfin2Samsung", "Samsung Jellyfin Installer", "Samsung TV App Installer"],
+    "alternateName": ["Jellyfin2Samsung", "Samsung Jellyfin Installer"],
     "operatingSystem": "Windows, macOS, Linux",
     "applicationCategory": "UtilitiesApplication",
     "author": {
       "@type": "Person",
       "name": "Patrick Stel"
     },
-    "description": "Cross-platform desktop installer that side-loads any app onto Samsung Smart TVs — Jellyfin, Moonlight and the whole community Tizen catalog.",
+    "description": "Cross-platform desktop installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight and the whole community Tizen catalog.",
     "url": "https://apps2samsung.madebypatrick.nl/",
-    "image": "https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png"
+    "image": "https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png"
   }
   </script>
 
@@ -176,9 +176,9 @@
 </head>
 <body>
   <main>
-    <img class="logo" src="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.svg" alt="Apps2Samsung — Samsung TV app installer">
+    <img class="logo" src="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.svg" alt="Apps2Samsung — Samsung TV app installer">
     <h1>Apps2Samsung</h1>
-    <h2>Install any app on your Samsung TV — Jellyfin, Moonlight and the whole community catalog, from Windows, macOS or Linux</h2>
+    <h2>Install any app on your Samsung TV, projector or smart monitor — Jellyfin, Moonlight and the whole community catalog, from Windows, macOS or Linux</h2>
 
     <!-- Responsive YouTube Embed -->
     <div class="video-wrapper">
@@ -200,7 +200,7 @@
 
     <p>
       <a id="downloadBtn" class="btn" href="#" target="_blank" rel="noopener">⬇️ <span id="downloadLabel">Download</span></a>
-      <a class="btn" href="https://github.com/Apps2Samsung/Samsung-TV-App-Installer" target="_blank" rel="noopener">🧰 Source Code</a>
+      <a class="btn" href="https://github.com/Apps2Samsung/Apps2Samsung" target="_blank" rel="noopener">🧰 Source Code</a>
     </p>
 
     <h3>All downloads</h3>
@@ -244,7 +244,7 @@
 
   <script>
   (async function(){
-    const owner='Apps2Samsung', repo='Samsung-TV-App-Installer';
+    const owner='Apps2Samsung', repo='Apps2Samsung';
     const els={
       ver:   document.getElementById('latestVersion'),
       date:  document.getElementById('releaseDate'),

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,51 +4,52 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>Samsung Jellyfin Installer — Cross-platform installer for Jellyfin &amp; Tizen apps</title>
-  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads Jellyfin and a curated library of community Tizen apps onto Samsung Smart TVs. Free and open source." />
-  <meta name="keywords" content="Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Samsung TV sideload, Moonfin, Litefin, AVPlay, Tizen community apps, Jellyfin2Samsung, Patrick Stel" />
-  <link rel="canonical" href="https://jellyfin2samsung.github.io/Samsung-Jellyfin-Installer/" />
+  <title>Apps2Samsung — Install any app on your Samsung TV</title>
+  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads any app onto Samsung Smart TVs — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Free and open source." />
+  <meta name="keywords" content="Samsung TV app installer, install apps Samsung TV, Samsung TV sideload, Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Moonlight Samsung TV, Moonfin, Litefin, AVPlay, Tizen community apps, Apps2Samsung, Jellyfin2Samsung, Patrick Stel" />
+  <link rel="canonical" href="https://apps2samsung.madebypatrick.nl/" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Samsung Jellyfin Installer — Cross-platform Tizen app installer" />
-  <meta property="og:description" content="Side-load Jellyfin, Moonfin, Litefin, AVPlay builds and community Tizen apps onto your Samsung TV. Runs on Windows, macOS and Linux." />
-  <meta property="og:image" content="https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/raw/master/.github/jellyfin-tizen-logo.png" />
-  <meta property="og:url" content="https://jellyfin2samsung.github.io/Samsung-Jellyfin-Installer/" />
+  <meta property="og:title" content="Apps2Samsung — Install any app on your Samsung TV" />
+  <meta property="og:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto your Samsung TV. Runs on Windows, macOS and Linux." />
+  <meta property="og:image" content="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png" />
+  <meta property="og:url" content="https://apps2samsung.madebypatrick.nl/" />
   <meta property="og:type" content="website" />
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Samsung Jellyfin Installer — Cross-platform Tizen app installer">
-  <meta name="twitter:description" content="Side-load Jellyfin, Moonfin, Litefin, AVPlay and community Tizen apps onto Samsung TVs from Windows, macOS or Linux.">
-  <meta name="twitter:image" content="https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/raw/master/.github/jellyfin-tizen-logo.png">
+  <meta name="twitter:title" content="Apps2Samsung — Install any app on your Samsung TV">
+  <meta name="twitter:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto Samsung TVs from Windows, macOS or Linux.">
+  <meta name="twitter:image" content="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png">
 
   <!-- Favicon -->
   <link rel="icon" href="/favicon.ico">
+  <meta name="theme-color" content="#0a120f">
 
   <!-- Structured Data -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
-    "name": "Samsung Jellyfin Installer",
-    "alternateName": "Jellyfin2Samsung",
+    "name": "Apps2Samsung",
+    "alternateName": ["Jellyfin2Samsung", "Samsung Jellyfin Installer", "Samsung TV App Installer"],
     "operatingSystem": "Windows, macOS, Linux",
     "applicationCategory": "UtilitiesApplication",
     "author": {
       "@type": "Person",
       "name": "Patrick Stel"
     },
-    "description": "Cross-platform desktop installer that side-loads Jellyfin and community Tizen apps onto Samsung Smart TVs.",
-    "url": "https://jellyfin2samsung.github.io/Samsung-Jellyfin-Installer/",
-    "image": "https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/raw/master/.github/jellyfin-tizen-logo.png"
+    "description": "Cross-platform desktop installer that side-loads any app onto Samsung Smart TVs — Jellyfin, Moonlight and the whole community Tizen catalog.",
+    "url": "https://apps2samsung.madebypatrick.nl/",
+    "image": "https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.png"
   }
   </script>
 
   <style>
     body {
       font-family: system-ui, -apple-system, sans-serif;
-      background: #0b0f1a;
-      color: #eef1ff;
+      background: #0a120f;
+      color: #edf5f1;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -71,21 +72,21 @@
       margin-bottom: 12px;
     }
     h1 { font-size: 2.2rem; margin: .5em 0 .2em; }
-    h2 { color: #a0a8d5; font-weight: 500; margin: 0 0 1.2em; }
-    h3 { color: #c5cbf0; font-size: 1.05rem; font-weight: 600; margin: 1.6em 0 .6em; letter-spacing: .02em; text-transform: uppercase; }
+    h2 { color: #9ab8ac; font-weight: 500; margin: 0 0 1.2em; }
+    h3 { color: #bcd9cd; font-size: 1.05rem; font-weight: 600; margin: 1.6em 0 .6em; letter-spacing: .02em; text-transform: uppercase; }
     .btn {
       display: inline-block;
       padding: 10px 18px;
       margin: 6px;
       border-radius: 999px;
       text-decoration: none;
-      color: #0b0f1a;
-      background: linear-gradient(90deg,#7c8cff,#61dafb);
+      color: #0a120f;
+      background: linear-gradient(90deg,#10b981,#2dd4bf);
       font-weight: 600;
       transition: transform 0.15s ease;
     }
     .btn:hover { filter: brightness(1.1); transform: translateY(-2px); }
-    .meta { margin: 1em 0; color: #96a0c3; }
+    .meta { margin: 1em 0; color: #8aa89b; }
     .chip {
       display: inline-block;
       border: 1px dashed rgba(255,255,255,0.2);
@@ -95,16 +96,16 @@
       font-size: .9em;
     }
     .chip.solid {
-      border: 1px solid rgba(124,140,255,0.4);
-      background: rgba(124,140,255,0.08);
-      color: #c5cbf0;
+      border: 1px solid rgba(16,185,129,0.4);
+      background: rgba(16,185,129,0.08);
+      color: #bcd9cd;
     }
     /* highlight the visitor's detected OS */
     .chip.detected {
-      border: 1px solid rgba(97,218,251,0.7);
-      background: rgba(97,218,251,0.15);
-      color: #eef1ff;
-      box-shadow: 0 0 0 1px rgba(97,218,251,0.25);
+      border: 1px solid rgba(45,212,191,0.7);
+      background: rgba(45,212,191,0.15);
+      color: #edf5f1;
+      box-shadow: 0 0 0 1px rgba(45,212,191,0.25);
     }
     .grid {
       display: grid;
@@ -121,8 +122,8 @@
       font-size: .9em;
       line-height: 1.4;
     }
-    .card strong { color: #eef1ff; display: block; margin-bottom: 2px; }
-    .card span { color: #96a0c3; }
+    .card strong { color: #edf5f1; display: block; margin-bottom: 2px; }
+    .card span { color: #8aa89b; }
     /* download list rows */
     .dl-grid {
       display: grid;
@@ -132,8 +133,8 @@
       margin: 8px 0 4px;
     }
     .dl-grid .card.detected {
-      border: 1px solid rgba(97,218,251,0.5);
-      background: rgba(97,218,251,0.06);
+      border: 1px solid rgba(45,212,191,0.5);
+      background: rgba(45,212,191,0.06);
     }
     .dlrow {
       display: flex;
@@ -145,16 +146,16 @@
       border-top: 1px solid rgba(255,255,255,0.06);
     }
     .dlrow:first-of-type { border-top: 0; padding-top: 0; }
-    .dlrow .arch { color: #c5cbf0; font-weight: 600; min-width: 92px; }
+    .dlrow .arch { color: #bcd9cd; font-weight: 600; min-width: 92px; }
     .dlrow a {
-      color: #61dafb;
+      color: #2dd4bf;
       text-decoration: none;
-      border-bottom: 1px solid rgba(97,218,251,0.3);
+      border-bottom: 1px solid rgba(45,212,191,0.3);
       font-size: .92em;
     }
-    .dlrow a:hover { border-bottom-color: #61dafb; }
-    .dlrow .sz { color: #6b7494; font-size: .8em; }
-    .note { color: #6b7494; font-size: .8em; margin-top: 6px; }
+    .dlrow a:hover { border-bottom-color: #2dd4bf; }
+    .dlrow .sz { color: #5f7a6e; font-size: .8em; }
+    .note { color: #5f7a6e; font-size: .8em; margin-top: 6px; }
     /* Responsive video container */
     .video-wrapper {
       position: relative;
@@ -175,9 +176,9 @@
 </head>
 <body>
   <main>
-    <img class="logo" src="https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer/raw/master/.github/jellyfin-tizen-logo.svg" alt="Jellyfin for Samsung Tizen">
-    <h1>Samsung Jellyfin Installer</h1>
-    <h2>Cross-platform installer for Jellyfin and community Tizen apps on Samsung Smart TVs</h2>
+    <img class="logo" src="https://github.com/Apps2Samsung/Samsung-TV-App-Installer/raw/master/.github/jellyfin-tizen-logo.svg" alt="Apps2Samsung — Samsung TV app installer">
+    <h1>Apps2Samsung</h1>
+    <h2>Install any app on your Samsung TV — Jellyfin, Moonlight and the whole community catalog, from Windows, macOS or Linux</h2>
 
     <!-- Responsive YouTube Embed -->
     <div class="video-wrapper">
@@ -199,7 +200,7 @@
 
     <p>
       <a id="downloadBtn" class="btn" href="#" target="_blank" rel="noopener">⬇️ <span id="downloadLabel">Download</span></a>
-      <a class="btn" href="https://github.com/Jellyfin2Samsung/Samsung-Jellyfin-Installer" target="_blank" rel="noopener">🧰 Source Code</a>
+      <a class="btn" href="https://github.com/Apps2Samsung/Samsung-TV-App-Installer" target="_blank" rel="noopener">🧰 Source Code</a>
     </p>
 
     <h3>All downloads</h3>
@@ -229,25 +230,21 @@
       <div class="card"><strong>🌍 Localised UI</strong><span>Multiple languages with full RTL support.</span></div>
     </div>
 
-    <div style="background:rgba(124,140,255,0.1);border:1px solid rgba(124,140,255,0.3);border-radius:12px;padding:20px;margin:2em 0;text-align:left">
-      <p style="margin:0;color:#eef1ff;font-size:.95em">
-        📺 <strong>Got an older Samsung TV?</strong><br/>
-        <span style="color:#a0a8d5">If your TV runs Orsay OS (pre-2015 models), you'll need the </span>
-        <a href="https://github.com/Jellyfin2Samsung/Jellyfin-Orsay-Installer/releases"
-           target="_blank" rel="noopener"
-           style="color:#61dafb;font-weight:600;text-decoration:none;border-bottom:2px solid rgba(97,218,251,0.3)">Jellyfin Orsay Installer</a>
-        <span style="color:#a0a8d5"> instead.</span>
-      </p>
-    </div>
+    <p class="note" style="margin:2em 0 0">
+      Orsay-based TVs (pre-2015 models) are no longer supported. The unmaintained
+      <a href="https://github.com/Apps2Samsung/Jellyfin-Orsay-Installer/releases"
+         target="_blank" rel="noopener" style="color:#2dd4bf">legacy Orsay installer</a>
+      remains available as-is.
+    </p>
 
-    <p style="color:#96a0c3;font-size:.9em">
+    <p style="color:#8aa89b;font-size:.9em">
       © <span id="year"></span> Patrick Stel — Hosted on GitHub Pages
     </p>
   </main>
 
   <script>
   (async function(){
-    const owner='Jellyfin2Samsung', repo='Samsung-Jellyfin-Installer';
+    const owner='Apps2Samsung', repo='Samsung-TV-App-Installer';
     const els={
       ver:   document.getElementById('latestVersion'),
       date:  document.getElementById('releaseDate'),
@@ -373,7 +370,7 @@
         }
         html+='</div>';
       }
-      els.all.innerHTML = html || `<div class="card"><span>No platform builds found — <a href="${releasesUrl()}" style="color:#61dafb">see the release page</a>.</span></div>`;
+      els.all.innerHTML = html || `<div class="card"><span>No platform builds found — <a href="${releasesUrl()}" style="color:#2dd4bf">see the release page</a>.</span></div>`;
 
       // Note when the architecture is only a best guess (Safari/Firefox on Mac).
       if(os==='macos' && !sure){
@@ -384,7 +381,7 @@
       els.date.textContent='n/a';
       els.dl.href=releasesUrl();
       els.label.textContent='View downloads on GitHub';
-      els.all.innerHTML=`<div class="card"><span>Couldn\u2019t load builds right now — <a href="${releasesUrl()}" style="color:#61dafb">open the latest release</a>.</span></div>`;
+      els.all.innerHTML=`<div class="card"><span>Couldn\u2019t load builds right now — <a href="${releasesUrl()}" style="color:#2dd4bf">open the latest release</a>.</span></div>`;
     }
 
     document.getElementById('year').textContent=new Date().getFullYear();


### PR DESCRIPTION
## Stable release v2.3.2

Cutting `beta` → `master` to publish the **migration patch** ahead of the Apps2Samsung artifact rename (v2.4.0).

### What's in it
- **Self-updater accepts both executable names** (#360) — required so installs can auto-update across the upcoming rename to `Apps2Samsung`-named artifacts
- Display-level rebrand (#359): README, in-app update URLs, window title `Apps2Samsung`
- Version bump to v2.3.2 (#362)

### Notes
- Artifacts in this release still use the **old** `Jellyfin2Samsung-v…` naming — intentional, so every existing install can take this update normally
- Next: merge #361 + bump to v2.4.0 → first release with `Apps2Samsung-v…` artifacts. Anyone updating directly from ≤v2.3.1.1 to v2.4.0 (skipping this patch) gets a one-time "download manually" error — answer in issues with the release link

🤖 Generated with [Claude Code](https://claude.com/claude-code)