### PR TITLE
Bump version to v2.4.0

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -85,7 +85,7 @@ namespace Apps2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.3.2";
+        public string AppVersion { get; set; } = "v2.4.0";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";


### PR DESCRIPTION
First release with `Apps2Samsung`-named binaries and artifacts (#361). Merge this so the next beta/stable builds tag as `v2.4.0` — without it, the rename would ship confusingly as another `v2.3.2-beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)