### PR TITLE
Fix header banner: 'Jellyfin Installer' → 'App Installer for Samsung (Tizen)'

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -40,7 +40,7 @@
                     CornerRadius="8">
 				<StackPanel Spacing="12" HorizontalAlignment="Center">
 					<TextBlock
-                               Text="Jellyfin Installer for Samsung (Tizen)"
+                               Text="App Installer for Samsung (Tizen)"
 								HorizontalAlignment="Center"
 								Foreground="White"
 								FontWeight="Medium"/>


### PR DESCRIPTION
Caught in the v2.4.0-beta visual check: the main window's header banner was a hardcoded string in `MainWindow.axaml` ("Jellyfin Installer for Samsung (Tizen)"), so the slug-based rename sweeps missed it. Now reads **App Installer for Samsung (Tizen)** under the Apps2Samsung window title.

Checked the other views + `en.json` for similar literals — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)