### PR TITLE
Fix malformed third-party-apps.json (empty Release dropdown)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
@@ -84,8 +84,8 @@
     { "matchName": "Club Info Board", "previewImage": "https://iili.io/fsviHQV.png" },
     { "matchName": "Doom", "previewImage": "https://iili.io/fyofVqu.png" },
     { "matchName": "TransportTycoonDeluxe", "previewImage": "https://iili.io/qFBP2vn.png" },
-    { "matchName": "Nuvio", "previewImage": "https://nuvioapp.space/assets/newss/Screenshot%202026-04-05%20at%203.17.41%E2%80%AFPM.png" }
-    { "matchName": "VLC-Tizen-tv", "previewImage": "https://iili.io/CfGNeqb.png" }
+    { "matchName": "Nuvio", "previewImage": "https://nuvioapp.space/assets/newss/Screenshot%202026-04-05%20at%203.17.41%E2%80%AFPM.png" },
+    { "matchName": "VLC-Tizen-tv", "previewImage": "https://iili.io/CfGNeqb.png" },
     { "matchName": "Flixor-Tizen", "previewImage": "https://iili.io/CfGjV44.webp" }
   ]
 }


### PR DESCRIPTION
Fixes #369.

The two entries added in 94c1fc5 (`VLC-Tizen-tv`, `Flixor-Tizen`) were missing trailing commas → the bundled manifest failed JSON parsing → `GetAsync()` returned an empty `ProviderManifest` → the Release dropdown only contained "Custom WGT File".

Trace from a v2.4.0 install confirms it:
```
ProviderManifest: parse failed: '{' is invalid after a value. Path: $.communityApps[8] | LineNumber: 87
```

Not rename-related — v2.3.1.1's bundled copy predates the broken commit, which is why downgrading appears to 'fix' it.

Note: a `main` branch with a valid manifest at `/third-party-apps.json` is being added so the app's remote-first fetch heals already-shipped binaries immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)