### PR TITLE
CI: PR-based release notes (generate-notes API + release.yml)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+# Configuration for GitHub's auto-generated release notes
+# (used by the generate-notes API call in the release workflows).
+# PRs are grouped by label; unlabeled PRs land under "Other changes".
+changelog:
+  exclude:
+    labels:
+      - skip-changelog   # add this label to hide a PR from release notes
+      - release          # the beta → master release PRs themselves
+    authors:
+      - dependabot
+  categories:
+    - title: 🚀 New features
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Bug fixes
+      labels:
+        - bug
+        - fix
+    - title: 🌍 Translations
+      labels:
+        - translations
+        - l10n
+    - title: 🧰 Maintenance & CI
+      labels:
+        - chore
+        - ci
+        - dependencies
+        - documentation
+    - title: 🔀 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -44,15 +44,27 @@ jobs:
           echo "VERSION_TAG=${VERSION}-beta" >> $GITHUB_ENV
 
       # ---------------- RELEASE NOTES ----------------
+      # PR-based notes via GitHub's generate-notes API (categorised by
+      # .github/release.yml) instead of a raw `git log` dump.
       - name: Generate changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LAST_TAG=$(git tag --sort=-creatordate | grep beta | head -n 1)
-          RANGE="${LAST_TAG:+$LAST_TAG..HEAD}"
+          LAST_TAG=$(git tag --sort=-creatordate | grep beta | grep -vx "$VERSION_TAG" | head -n 1)
 
-          {
-            echo "## ✅ What's New & Improved"
-            git log ${RANGE:-HEAD} --pretty=format:"- %s"
-          } > CHANGELOG.md
+          ARGS=(-f tag_name="$VERSION_TAG" -f target_commitish="$GITHUB_SHA")
+          if [ -n "$LAST_TAG" ]; then
+            ARGS+=(-f previous_tag_name="$LAST_TAG")
+          fi
+
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" "${ARGS[@]}" --jq .body > CHANGELOG.md; then
+            echo "Generated PR-based notes (since ${LAST_TAG:-the beginning})"
+          else
+            # Fallback: filtered commit log (no [skip ci] noise, no dupes)
+            echo "## ✅ What's New & Improved" > CHANGELOG.md
+            git log ${LAST_TAG:+$LAST_TAG..HEAD} --pretty=format:"- %s" \
+              | grep -iv '\[skip ci\]' | awk '!seen[$0]++' >> CHANGELOG.md
+          fi
 
       - name: Prepare release notes
         run: |

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -101,24 +101,32 @@ jobs:
           fi
 
       # ---------------- CHANGELOG (from last stable tag) ----------------
+      # PR-based notes via GitHub's generate-notes API (categorised by
+      # .github/release.yml) instead of a raw `git log` dump.
       - name: Generate changelog
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LAST_STABLE=$(git tag \
             | grep -E '^v[0-9]+(\.[0-9]+){1,3}$' \
+            | grep -vx "$VERSION_TAG" \
             | sort -V \
             | tail -n 1)
 
-          if [ -z "$LAST_STABLE" ]; then
-            RANGE="HEAD"
-          else
-            RANGE="$LAST_STABLE..HEAD"
+          ARGS=(-f tag_name="$VERSION_TAG" -f target_commitish="$GITHUB_SHA")
+          if [ -n "$LAST_STABLE" ]; then
+            ARGS+=(-f previous_tag_name="$LAST_STABLE")
           fi
 
-          {
-            echo "## ✅ What's New & Improved"
-            git log $RANGE --pretty=format:"- %s"
-          } > CHANGELOG.md
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" "${ARGS[@]}" --jq .body > CHANGELOG.md; then
+            echo "Generated PR-based notes (since ${LAST_STABLE:-the beginning})"
+          else
+            # Fallback: filtered commit log (no [skip ci] noise, no dupes)
+            echo "## ✅ What's New & Improved" > CHANGELOG.md
+            git log ${LAST_STABLE:+$LAST_STABLE..HEAD} --pretty=format:"- %s" \
+              | grep -iv '\[skip ci\]' | awk '!seen[$0]++' >> CHANGELOG.md
+          fi
 
       # ---------------- RELEASE NOTES ----------------
       - name: Prepare release notes


### PR DESCRIPTION
Release notes currently dump `git log --pretty=- %s` — raw commit subjects with `[skip ci]` chores and squash-duplicate lines (see v2.4.0's notes).

## Changes

- **Both workflows** (beta prerelease + stable) now call GitHub's [generate-notes API](https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release): PR titles with links, no duplicates, "New Contributors" + "Full Changelog" footer
- **`.github/release.yml`** categorises PRs by label (🚀 feature/enhancement, 🐛 bug/fix, 🌍 translations, 🧰 chore/ci) — unlabeled PRs land under 🔀 Other changes; `skip-changelog` and `release` labels hide a PR entirely
- **Fallback** if the API call fails: the old git log, but filtered (`[skip ci]` removed, deduped)
- Platform table + antivirus notice keep working as before (notes are prepended the same way)

## Optional habits that make this shine
- Label PRs (`bug`, `enhancement`, `chore`…) → categorised notes for free
- Add the `release` label to `beta → master` release PRs so they don't list themselves

🤖 Generated with [Claude Code](https://claude.com/claude-code)