### PR TITLE
CI: tag releases against the built commit

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -179,6 +179,7 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION_TAG }}
+          target_commitish: ${{ github.sha }}
           name: ${{ env.VERSION_TAG }}
           prerelease: true
           overwrite_files: true

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -249,6 +249,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.VERSION_TAG }}
+          target_commitish: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.merge_commit_sha }}
           name: ${{ env.VERSION_TAG }}
           prerelease: false
           overwrite_files: true


### PR DESCRIPTION
Releases were tagged at **default-branch HEAD at publish time** instead of the commit the workflow actually built — that's how `v2.3.2`'s tag ended up on a post-rename commit and skewed the generate-notes ranges.

- **beta-prerelease:** `target_commitish: github.sha` (the pushed commit)
- **stable-release:** the PR's `merge_commit_sha` (or `inputs.ref` on manual dispatch)

The macOS jobs attach assets to the by-then-existing tag, where `target_commitish` is ignored — left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)