### PR TITLE
Bump version to v2.5.0

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -86,7 +86,7 @@ namespace Apps2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.4.0";
+        public string AppVersion { get; set; } = "v2.5.0";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";


### PR DESCRIPTION
Minor bump for the release-list feature (#375): community apps as individual entries + the 'Show all Jellyfin versions' toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)