### PR TITLE
Release v2.5.0 — community apps & version-list toggle

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -45,6 +45,7 @@
   "CheckingTizenSdb": "Checking Tizen SDB...",
   "InitializationFailed": "Initialization failed...",
   "lblForceLogin": "Force Samsung certificate",
+  "lblShowAllJellyfinVersions": "Show all Jellyfin versions",
   "DeveloperModeRequired": "Samsung TV is not in developer mode...",
   "DeveloperIPMismatch": "Samsung Developer mode IP doesn't match this devices local IP, do you wish to continue?",
   "DeveloperIPReversed": "IP is in reversed order on the TV, please re-enable developer mode and type your local IP in reversed order. (ex: 192.168.1.2 → 2.1.168.192)",

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
@@ -45,6 +45,7 @@
   "CheckingTizenSdb": "Tizen SDB controleren...",
   "InitializationFailed": "Initialisatie mislukt...",
   "lblForceLogin": "Forceer Samsung-certificaat",
+  "lblShowAllJellyfinVersions": "Toon alle Jellyfin-versies",
   "DeveloperModeRequired": "Samsung TV staat niet in ontwikkelaarsmodus...",
   "DeveloperIPMismatch": "Samsung ontwikkelaarsmodus IP komt niet overeen met het lokale IP van dit apparaat, wilt u doorgaan?",
   "DeveloperIPReversed": "IP is in reversed order on the TV, please re-enable developer mode and type your local IP in reversed order. (ex: 192.168.1.2 → 2.1.168.192)",

--- a/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
@@ -73,19 +73,50 @@
       "url": "https://api.github.com/repos/PatrickSt1991/tizen-community-packages/releases",
       "prefix": "",
       "displayName": "Tizen Community",
-      "take": 1
+      "take": 1,
+      "expandAssets": true
     }
   ],
   "communityApps": [
-    { "matchName": "Moonlight", "previewImage": "https://iili.io/fsvn6mJ.png" },
-    { "matchName": "Fireplace", "previewImage": "https://raw.githubusercontent.com/thonythony/fireplace/refs/heads/master/icon.jpg" },
-    { "matchName": "TVApp", "previewImage": "https://iili.io/fsvaHsn.png" },
-    { "matchName": "Twitch", "previewImage": "https://iili.io/fsvUNu2.md.gif" },
-    { "matchName": "Club Info Board", "previewImage": "https://iili.io/fsviHQV.png" },
-    { "matchName": "Doom", "previewImage": "https://iili.io/fyofVqu.png" },
-    { "matchName": "TransportTycoonDeluxe", "previewImage": "https://iili.io/qFBP2vn.png" },
-    { "matchName": "Nuvio", "previewImage": "https://nuvioapp.space/assets/newss/Screenshot%202026-04-05%20at%203.17.41%E2%80%AFPM.png" },
-    { "matchName": "VLC-Tizen-tv", "previewImage": "https://iili.io/CfGNeqb.png" },
-    { "matchName": "Flixor-Tizen", "previewImage": "https://iili.io/CfGjV44.webp" }
+    {
+      "matchName": "Moonlight",
+      "previewImage": "https://iili.io/fsvn6mJ.png"
+    },
+    {
+      "matchName": "Fireplace",
+      "previewImage": "https://raw.githubusercontent.com/thonythony/fireplace/refs/heads/master/icon.jpg"
+    },
+    {
+      "matchName": "TVApp",
+      "previewImage": "https://iili.io/fsvaHsn.png"
+    },
+    {
+      "matchName": "Twitch",
+      "previewImage": "https://iili.io/fsvUNu2.md.gif"
+    },
+    {
+      "matchName": "Club Info Board",
+      "previewImage": "https://iili.io/fsviHQV.png"
+    },
+    {
+      "matchName": "Doom",
+      "previewImage": "https://iili.io/fyofVqu.png"
+    },
+    {
+      "matchName": "TransportTycoonDeluxe",
+      "previewImage": "https://iili.io/qFBP2vn.png"
+    },
+    {
+      "matchName": "Nuvio",
+      "previewImage": "https://nuvioapp.space/assets/newss/Screenshot%202026-04-05%20at%203.17.41%E2%80%AFPM.png"
+    },
+    {
+      "matchName": "VLC-Tizen-tv",
+      "previewImage": "https://iili.io/CfGNeqb.png"
+    },
+    {
+      "matchName": "Flixor-Tizen",
+      "previewImage": "https://iili.io/CfGjV44.webp"
+    }
   ]
 }

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -86,7 +86,7 @@ namespace Apps2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.4.0";
+        public string AppVersion { get; set; } = "v2.5.0";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -37,6 +37,7 @@ namespace Apps2Samsung.Helpers
         public string UserCustomIP { get; set; } = "";
         public string SavedNetworkInterfaceName { get; set; } = "";
         public bool ForceSamsungLogin { get; set; } = false;
+        public bool ShowAllJellyfinVersions { get; set; } = false;
         public bool RTLReading { get; set; } = false;
         public string JellyfinIP { get; set; } = "";
         public string JellyfinBasePath { get; set; } = "";

--- a/Jellyfin2Samsung-CrossOS/Models/ProviderManifest.cs
+++ b/Jellyfin2Samsung-CrossOS/Models/ProviderManifest.cs
@@ -22,6 +22,11 @@ namespace Apps2Samsung.Models
         public string Prefix { get; set; } = "";
         public string DisplayName { get; set; } = "";
         public int Take { get; set; } = 1;
+        /// <summary>
+        /// When true, every .wgt asset of the fetched release becomes its own
+        /// entry in the release list (used for the community package bundle).
+        /// </summary>
+        public bool ExpandAssets { get; set; }
         public ProviderBuildInfo? BuildInfo { get; set; }
     }
 

--- a/Jellyfin2Samsung-CrossOS/ViewModels/JellyfinConfigViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/JellyfinConfigViewModel.cs
@@ -175,6 +175,9 @@ namespace Apps2Samsung.ViewModels
         private bool forceSamsungLogin;
 
         [ObservableProperty]
+        private bool showAllJellyfinVersions;
+
+        [ObservableProperty]
         private bool rtlReading;
 
         [ObservableProperty]
@@ -321,6 +324,7 @@ namespace Apps2Samsung.ViewModels
         public string LblRememberIp => _localizationService.GetString("lblRememberIp");
         public string LblDeletePrevious => _localizationService.GetString("lblDeletePrevious");
         public string LblForceLogin => _localizationService.GetString("lblForceLogin");
+        public string LblShowAllJellyfinVersions => _localizationService.GetString("lblShowAllJellyfinVersions");
         public string LblRTL => _localizationService.GetString("lblRTL");
         public string LblKeepWGTFile => _localizationService.GetString("lblKeepWGTFile");
         public string LblSettingsHeader => _localizationService.GetString("lblSettings");
@@ -459,6 +463,7 @@ namespace Apps2Samsung.ViewModels
             OnPropertyChanged(nameof(LblRememberIp));
             OnPropertyChanged(nameof(LblDeletePrevious));
             OnPropertyChanged(nameof(LblForceLogin));
+            OnPropertyChanged(nameof(LblShowAllJellyfinVersions));
             OnPropertyChanged(nameof(LblRTL));
             OnPropertyChanged(nameof(LblKeepWGTFile));
             OnPropertyChanged(nameof(LblSettingsHeader));
@@ -1480,6 +1485,7 @@ namespace Apps2Samsung.ViewModels
 
             DeletePreviousInstall = AppSettings.Default.DeletePreviousInstall;
             ForceSamsungLogin = AppSettings.Default.ForceSamsungLogin;
+            ShowAllJellyfinVersions = AppSettings.Default.ShowAllJellyfinVersions;
             RtlReading = AppSettings.Default.RTLReading;
             LocalIP = AppSettings.Default.LocalIp ?? string.Empty;
             TryOverwrite = AppSettings.Default.TryOverwrite;
@@ -1628,6 +1634,12 @@ namespace Apps2Samsung.ViewModels
         partial void OnForceSamsungLoginChanged(bool value)
         {
             AppSettings.Default.ForceSamsungLogin = value;
+            AppSettings.Default.Save();
+        }
+
+        partial void OnShowAllJellyfinVersionsChanged(bool value)
+        {
+            AppSettings.Default.ShowAllJellyfinVersions = value;
             AppSettings.Default.Save();
         }
 

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -530,14 +530,19 @@ namespace Apps2Samsung.ViewModels
         }
 
         [RelayCommand(CanExecute = nameof(CanOpenSettings))]
-        private void OpenSettings()
+        private async Task OpenSettings()
         {
+            var showAllBefore = AppSettings.Default.ShowAllJellyfinVersions;
             var settingsWindow = new JellyfinConfigView(_settingsViewModel);
 
             if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                settingsWindow.ShowDialog(desktop.MainWindow);
+                await settingsWindow.ShowDialog(desktop.MainWindow);
             }
+
+            // Reflect a changed version-list preference without an app restart.
+            if (AppSettings.Default.ShowAllJellyfinVersions != showAllBefore)
+                await LoadReleasesAsync();
         }
         [RelayCommand]
         private async Task ShowBuildInfoAsync()
@@ -632,13 +637,40 @@ namespace Apps2Samsung.ViewModels
                     cancellationToken.ThrowIfCancellationRequested();
                     if (string.IsNullOrWhiteSpace(provider.Url))
                         continue;
+
+                    // Multi-version providers (Jellyfin history) collapse to just
+                    // the latest release unless the user opted into the full list.
+                    var take = provider.Take;
+                    if (take > 1 && !AppSettings.Default.ShowAllJellyfinVersions)
+                        take = 1;
+
                     var release = await _addLatestRelease.GetReleasesAsync(
                         provider.Url,
                         provider.Prefix,
                         provider.DisplayName,
-                        provider.Take);
-                    if (release.Count > 0)
+                        take);
+                    if (release.Count == 0)
+                        continue;
+
+                    if (provider.ExpandAssets)
+                    {
+                        // One entry per .wgt so community apps show up as
+                        // first-class items instead of a single bundle entry.
+                        foreach (var r in release)
+                            foreach (var asset in r.Assets)
+                                list.Add(new GitHubRelease
+                                {
+                                    Name = Path.GetFileNameWithoutExtension(asset.FileName),
+                                    TagName = r.TagName,
+                                    PublishedAt = r.PublishedAt,
+                                    Url = r.Url,
+                                    Assets = new List<Asset> { asset }
+                                });
+                    }
+                    else
+                    {
                         list.AddRange(release);
+                    }
                 }
                 cancellationToken.ThrowIfCancellationRequested();
                 Releases.Clear();

--- a/Jellyfin2Samsung-CrossOS/Views/JellyfinConfigView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/JellyfinConfigView.axaml
@@ -226,6 +226,17 @@
 												  VerticalAlignment="Center"/>
 								</Grid>
 
+								<!-- Show all Jellyfin versions -->
+								<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+									<TextBlock Grid.Column="0"
+											   Text="{Binding LblShowAllJellyfinVersions}"
+											   Classes="label"
+											   VerticalAlignment="Center"/>
+									<ToggleSwitch Grid.Column="1"
+												  IsChecked="{Binding ShowAllJellyfinVersions}"
+												  VerticalAlignment="Center"/>
+								</Grid>
+
 								<!-- RTL Reading -->
 								<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
 									<TextBlock Grid.Column="0"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.4.0](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.4.0)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.5.0-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.0-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
## ✨ Stable release v2.5.0

### What's new
- **Community apps as individual entries** (#375) — every `.wgt` from the latest [tizen-community-packages](https://github.com/Apps2Samsung/tizen-community-packages) release shows directly in the Release dropdown: Moonlight, FCast, Twitch, Doom, Stremio, VLC, Flixor and more
- **"Show all Jellyfin versions" setting** (#375) — the dropdown shows just the latest Jellyfin by default; the old 5-version history is one toggle away
- Release notes are now PR-based and categorised (#372); release tags point at the built commit (#373)
- Manifest validation CI with auto-repair PRs (#371); fixed catalog manifest (#370, fixes #369)
- Website aligned with the app's color scheme (#374)

### Notes
- First stable release with the improved release-notes pipeline — labels on PRs feed the categories
- After merge, the winget cron picks this version up automatically (MSI build + manifest + Microsoft PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)