### PR TITLE
CI: fix [skip ci] silently suppressing stable releases

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -3,6 +3,8 @@ name: Beta Pre-Release
 on:
   push:
     branches: [beta]
+    paths-ignore:
+      - 'README.md'
 
 permissions:
   contents: write

--- a/.github/workflows/update-version-table.yml
+++ b/.github/workflows/update-version-table.yml
@@ -94,6 +94,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update version table in README [skip ci]"
+            git commit -m "chore: update version table in README"
             git push
           fi


### PR DESCRIPTION
**Why v2.5.0 didn't auto-release when #377 was merged:** after every version bump, the version-table bot pushes `chore: update version table in README [skip ci]` — which becomes `beta`'s HEAD. GitHub [suppresses](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs) `pull_request`-triggered workflows when the PR's HEAD commit message contains `[skip ci]`, so the `closed`-type trigger of the Stable Release workflow never fired. (#368/v2.4.0 only worked because no version-table change happened between the bump and the merge.)

**Fix:**
- The bot commits **without** `[skip ci]`
- `beta-prerelease` gets `paths-ignore: README.md`, which is what the `[skip ci]` was actually protecting against (a pointless rebuild loop — the bot only ever touches README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)