### PR TITLE
Sort catalog tables A-Z/0-9

### DIFF
--- a/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
@@ -90,6 +90,16 @@ namespace Apps2Samsung.ViewModels
             _ = LoadAsync();
         }
 
+        private static void SortByName(ObservableCollection<BuildVersion> collection)
+        {
+            var sorted = collection
+                .OrderBy(b => b.FileName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            collection.Clear();
+            foreach (var item in sorted)
+                collection.Add(item);
+        }
+
         private void QueueRebuild()
         {
             // Start a rebuild, but only the latest one is allowed to apply results
@@ -126,6 +136,10 @@ namespace Apps2Samsung.ViewModels
                 }
 
                 ParseApplicationsTable(communityMd, CommunityApps);
+
+                // Sort both tables A-Z / 0-9, matching the release list ordering.
+                SortByName(JellyfinVersions);
+                SortByName(CommunityApps);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Follow-up to #382 (the sorting commit landed on the branch *after* #382 was already merged, so it never reached beta).

Sorts the **Jellyfin builds** and **Community applications** tables in the catalog window by name, using the same `StringComparer.OrdinalIgnoreCase` as the release dropdown — consistent ordering across the app. Preview panel unchanged.

Folds into the pending v2.5.2 (no version bump needed — beta is already at v2.5.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)