### PR TITLE
Release v2.5.2

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.5.1</CFBundleVersion>
+	<CFBundleVersion>2.5.2</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -167,5 +167,15 @@
   "lblChannelUrl": "m3u8 URL",
   "lblAddChannel": "Add channel",
   "lblNoChannels": "No channels yet. Click \"Add channel\" to create one.",
-  "lblTvAppOnlyNotice": "These settings apply ONLY to TVApp — they are written into the package before installation."
+  "lblTvAppOnlyNotice": "These settings apply ONLY to TVApp — they are written into the package before installation.",
+  "catalogTitle": "App Catalog",
+  "catalogSubtitle": "Everything you can install on your Samsung device",
+  "catalogJellyfinBuilds": "Jellyfin builds",
+  "catalogCommunityApps": "Community applications",
+  "catalogAppPreview": "App preview",
+  "catalogColFileName": "File name",
+  "catalogColDescription": "Description",
+  "catalogColApplication": "Application",
+  "catalogNoPreview": "No preview available",
+  "catalogNoThumbnail": "This app has no thumbnail yet."
 }

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
@@ -160,5 +160,15 @@
   "IncompatiblePackageDetailed": "Pakketversie {0} niet compatibel met Tizen OS {1}",
   "lblMdnsWarning": "Waarschuwing: Je gebruikt een mDNS-hostnaam (.local). Samsung TV's kunnen .local-adressen niet betrouwbaar omzetten, waardoor de server als \"undefined\" op je TV kan verschijnen — vooral na netwerkonderbrekingen. Gebruik in plaats daarvan een direct IP-adres (bijv. 192.168.1.100) voor een stabiele verbinding.",
   "lblOpenLogsFolder": "Open Logs Folder",
-  "lblJellyfinOnlyNotice": "These settings apply ONLY to the official Jellyfin client — they are not supported for Jellyfin forks or other apps."
+  "lblJellyfinOnlyNotice": "These settings apply ONLY to the official Jellyfin client — they are not supported for Jellyfin forks or other apps.",
+  "catalogTitle": "App-catalogus",
+  "catalogSubtitle": "Alles wat je op je Samsung-apparaat kunt installeren",
+  "catalogJellyfinBuilds": "Jellyfin-builds",
+  "catalogCommunityApps": "Community-applicaties",
+  "catalogAppPreview": "App-voorbeeld",
+  "catalogColFileName": "Bestandsnaam",
+  "catalogColDescription": "Omschrijving",
+  "catalogColApplication": "Applicatie",
+  "catalogNoPreview": "Geen voorbeeld beschikbaar",
+  "catalogNoThumbnail": "Deze app heeft nog geen thumbnail."
 }

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -99,7 +99,7 @@ namespace Apps2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.5.1";
+        public string AppVersion { get; set; } = "v2.5.2";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";

--- a/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
@@ -90,6 +90,16 @@ namespace Apps2Samsung.ViewModels
             _ = LoadAsync();
         }
 
+        private static void SortByName(ObservableCollection<BuildVersion> collection)
+        {
+            var sorted = collection
+                .OrderBy(b => b.FileName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            collection.Clear();
+            foreach (var item in sorted)
+                collection.Add(item);
+        }
+
         private void QueueRebuild()
         {
             // Start a rebuild, but only the latest one is allowed to apply results
@@ -126,6 +136,10 @@ namespace Apps2Samsung.ViewModels
                 }
 
                 ParseApplicationsTable(communityMd, CommunityApps);
+
+                // Sort both tables A-Z / 0-9, matching the release list ordering.
+                SortByName(JellyfinVersions);
+                SortByName(CommunityApps);
             }
             catch (Exception ex)
             {

--- a/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
@@ -4,8 +4,10 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Apps2Samsung.Helpers;
 using Apps2Samsung.Helpers.Core;
+using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using Apps2Samsung.Services;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -36,8 +38,43 @@ namespace Apps2Samsung.ViewModels
         private bool _isLoading;
         private int _rebuildVersion;
 
+        private readonly ILocalizationService _localizationService =
+            App.Services.GetRequiredService<ILocalizationService>();
+
+        private string L(string key) => _localizationService.GetString(key);
+
+        // Localized labels for the catalog window.
+        public string LblCatalogTitle => L("catalogTitle");
+        public string LblCatalogSubtitle => L("catalogSubtitle");
+        public string LblJellyfinBuilds => L("catalogJellyfinBuilds");
+        public string LblCommunityApps => L("catalogCommunityApps");
+        public string LblAppPreview => L("catalogAppPreview");
+        public string LblColFileName => L("catalogColFileName");
+        public string LblColDescription => L("catalogColDescription");
+        public string LblColApplication => L("catalogColApplication");
+        public string LblNoPreview => L("catalogNoPreview");
+        public string LblNoThumbnail => L("catalogNoThumbnail");
+        public string LblClose => L("btn_Close");
+
+        private void RefreshLocalizedLabels()
+        {
+            OnPropertyChanged(nameof(LblCatalogTitle));
+            OnPropertyChanged(nameof(LblCatalogSubtitle));
+            OnPropertyChanged(nameof(LblJellyfinBuilds));
+            OnPropertyChanged(nameof(LblCommunityApps));
+            OnPropertyChanged(nameof(LblAppPreview));
+            OnPropertyChanged(nameof(LblColFileName));
+            OnPropertyChanged(nameof(LblColDescription));
+            OnPropertyChanged(nameof(LblColApplication));
+            OnPropertyChanged(nameof(LblNoPreview));
+            OnPropertyChanged(nameof(LblNoThumbnail));
+            OnPropertyChanged(nameof(LblClose));
+        }
+
         public BuildInfoViewModel()
         {
+            _localizationService.LanguageChanged += (_, __) => RefreshLocalizedLabels();
+
             CommunityApps.CollectionChanged += (_, __) =>
             {
                 if (_isLoading) return;

--- a/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
@@ -1,18 +1,39 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:fa="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
         x:Class="Apps2Samsung.Views.BuildInfoWindow"
         xmlns:viewModels="clr-namespace:Apps2Samsung.ViewModels"
         x:DataType="viewModels:BuildInfoViewModel"
         SizeToContent="WidthAndHeight"
         MinWidth="900"
         MaxWidth="1200"
-        MinHeight="520"
+        MinHeight="540"
         WindowStartupLocation="CenterOwner"
-        Title="Jellyfin Tizen Versions">
+        Title="App Catalog">
 
 	<Window.Styles>
 		<StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.xaml"/>
 		<StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
+		<StyleInclude Source="avares://Apps2Samsung/Styles/Buttons.axaml"/>
+		<StyleInclude Source="avares://Apps2Samsung/Styles/TextBlocks.axaml"/>
+
+		<!-- Softer, modern tables to match the rest of the app -->
+		<Style Selector="DataGrid">
+			<Setter Property="GridLinesVisibility" Value="Horizontal"/>
+			<Setter Property="BorderThickness" Value="0"/>
+			<Setter Property="RowHeight" Value="34"/>
+			<Setter Property="FontSize" Value="13"/>
+		</Style>
+		<Style Selector="DataGridColumnHeader">
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="Foreground" Value="{DynamicResource SystemControlForegroundBaseMediumBrush}"/>
+			<Setter Property="FontWeight" Value="SemiBold"/>
+			<Setter Property="FontSize" Value="12"/>
+			<Setter Property="Padding" Value="10,8"/>
+		</Style>
+		<Style Selector="DataGridRow:pointerover /template/ Rectangle#BackgroundRectangle">
+			<Setter Property="Opacity" Value="0.04"/>
+		</Style>
 	</Window.Styles>
 
 	<Border Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
@@ -30,133 +51,146 @@
 							  Opacity="0.15"/>
 		</Border.Effect>
 
-		<StackPanel Spacing="16">
+		<DockPanel>
 
-			<!-- Header -->
-			<Border Background="#2C3E50"
-					Padding="14,10"
-					CornerRadius="6">
-				<TextBlock Text="Jellyfin Tizen Build Versions"
-						   Foreground="White"
-						   FontWeight="SemiBold"
-						   FontSize="18"
-						   HorizontalAlignment="Center"/>
+			<!-- Header (matches the Settings window) -->
+			<Border DockPanel.Dock="Top"
+					Background="#2C3E50"
+					CornerRadius="8"
+					Padding="24,16"
+					Margin="0,0,0,16">
+				<StackPanel Spacing="2" HorizontalAlignment="Center">
+					<TextBlock Text="App Catalog"
+							   Foreground="White"
+							   FontWeight="SemiBold"
+							   FontSize="18"
+							   HorizontalAlignment="Center"/>
+					<TextBlock Text="Everything you can install on your Samsung device"
+							   Foreground="#B9C9DA"
+							   FontSize="12"
+							   HorizontalAlignment="Center"/>
+				</StackPanel>
 			</Border>
 
+			<!-- Footer -->
+			<StackPanel DockPanel.Dock="Bottom"
+						Orientation="Horizontal"
+						HorizontalAlignment="Right"
+						Margin="0,16,0,0">
+				<Button Content="Close"
+						Classes="primary"
+						Width="110"
+						Command="{Binding CloseCommand}"/>
+			</StackPanel>
+
 			<!-- Two-column layout -->
-			<Grid ColumnDefinitions="*,340"
+			<Grid ColumnDefinitions="*,360"
 				  ColumnSpacing="18">
 
 				<!-- ================= LEFT COLUMN ================= -->
-				<StackPanel Grid.Column="0" Spacing="16">
+				<StackPanel Grid.Column="0" Spacing="18">
 
-					<Border Background="#34495E"
-							Padding="10"
-							CornerRadius="6">
-						<TextBlock Text="Jellyfin Builds"
-								   Foreground="White"
-								   FontWeight="Medium"
-								   FontSize="15"/>
-					</Border>
+					<StackPanel Spacing="8">
+						<TextBlock Text="Jellyfin builds" Classes="subtitle"/>
+						<Border Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+								BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+								BorderThickness="1"
+								CornerRadius="8"
+								ClipToBounds="True"
+								Height="220">
+							<DataGrid ItemsSource="{Binding JellyfinVersions}"
+									  AutoGenerateColumns="False"
+									  HeadersVisibility="Column"
+									  IsReadOnly="True"
+									  ColumnWidth="*">
+								<DataGrid.Columns>
+									<DataGridTextColumn Header="File name" Width="200"
+														Binding="{Binding FileName}" />
+									<DataGridTemplateColumn Header="Description" Width="*">
+										<DataGridTemplateColumn.CellTemplate>
+											<DataTemplate>
+												<TextBlock Text="{Binding Description}"
+														   TextWrapping="Wrap"
+														   Padding="10,6"
+														   VerticalAlignment="Center"/>
+											</DataTemplate>
+										</DataGridTemplateColumn.CellTemplate>
+									</DataGridTemplateColumn>
+								</DataGrid.Columns>
+							</DataGrid>
+						</Border>
+					</StackPanel>
 
-					<Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-							BorderThickness="1"
-							CornerRadius="4"
-							Height="220">
-						<DataGrid ItemsSource="{Binding JellyfinVersions}"
-								  AutoGenerateColumns="False"
-								  HeadersVisibility="Column"
-								  GridLinesVisibility="All"
-								  IsReadOnly="True"
-								  ColumnWidth="*">
-							<DataGrid.Columns>
-								<DataGridTextColumn Header="File name" Width="180"
-													Binding="{Binding FileName}" />
-								<DataGridTemplateColumn Header="Description" Width="*">
-									<DataGridTemplateColumn.CellTemplate>
-										<DataTemplate>
-											<TextBlock Text="{Binding Description}"
-													   TextWrapping="Wrap"
-													   Padding="4"
-													   VerticalAlignment="Center"/>
-										</DataTemplate>
-									</DataGridTemplateColumn.CellTemplate>
-								</DataGridTemplateColumn>
-							</DataGrid.Columns>
-						</DataGrid>
-					</Border>
-
-					<Border Background="#34495E"
-							Padding="10"
-							CornerRadius="6"
-							Margin="0,6,0,0">
-						<TextBlock Text="Community Applications"
-								   Foreground="White"
-								   FontWeight="Medium"
-								   FontSize="15"/>
-					</Border>
-
-					<Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-							BorderThickness="1"
-							CornerRadius="4"
-							Height="280">
-						<DataGrid ItemsSource="{Binding CommunityApps}"
-								  AutoGenerateColumns="False"
-								  HeadersVisibility="Column"
-								  GridLinesVisibility="All"
-								  RowHeight="32"
-								  IsReadOnly="True"
-								  ColumnWidth="*">
-							<DataGrid.Columns>
-								<DataGridTextColumn Header="Application" Width="180"
-													Binding="{Binding FileName}" />
-								<DataGridTextColumn Header="Description" Width="*"
-													Binding="{Binding Description}" />
-							</DataGrid.Columns>
-						</DataGrid>
-					</Border>
+					<StackPanel Spacing="8">
+						<TextBlock Text="Community applications" Classes="subtitle"/>
+						<Border Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+								BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+								BorderThickness="1"
+								CornerRadius="8"
+								ClipToBounds="True"
+								Height="280">
+							<DataGrid ItemsSource="{Binding CommunityApps}"
+									  AutoGenerateColumns="False"
+									  HeadersVisibility="Column"
+									  IsReadOnly="True"
+									  ColumnWidth="*">
+								<DataGrid.Columns>
+									<DataGridTextColumn Header="Application" Width="200"
+														Binding="{Binding FileName}" />
+									<DataGridTemplateColumn Header="Description" Width="*">
+										<DataGridTemplateColumn.CellTemplate>
+											<DataTemplate>
+												<TextBlock Text="{Binding Description}"
+														   TextWrapping="Wrap"
+														   Padding="10,6"
+														   VerticalAlignment="Center"/>
+											</DataTemplate>
+										</DataGridTemplateColumn.CellTemplate>
+									</DataGridTemplateColumn>
+								</DataGrid.Columns>
+							</DataGrid>
+						</Border>
+					</StackPanel>
 
 				</StackPanel>
 
 				<!-- ================= RIGHT COLUMN ================= -->
 				<!-- CompileBindings off so you can iterate on option types freely -->
 				<StackPanel Grid.Column="1"
-							Spacing="10"
+							Spacing="8"
 							x:CompileBindings="False">
 
-					<Border Background="#34495E"
-							Padding="10"
-							CornerRadius="6">
-						<TextBlock Text="App Preview"
-								   Foreground="White"
-								   FontWeight="Medium"
-								   FontSize="15"/>
-					</Border>
+					<TextBlock Text="App preview" Classes="subtitle"/>
 
-					<!-- Dropdown: TEXT ONLY (no preview image here) -->
 					<ComboBox ItemsSource="{Binding ProviderOptions}"
 							  SelectedItem="{Binding SelectedProviderOption, Mode=TwoWay}"
-							  MinWidth="320"
 							  HorizontalAlignment="Stretch"
 							  DisplayMemberBinding="{Binding DisplayName}"/>
 
 					<!-- Preview card: image shows ONLY here -->
-					<Border Height="320"
+					<Border Height="360"
 							CornerRadius="12"
 							ClipToBounds="True"
-							Background="#22000000">
+							Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+							BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+							BorderThickness="1">
 						<Grid>
-							<!-- fallback text behind -->
+							<!-- fallback empty state behind -->
 							<StackPanel VerticalAlignment="Center"
 										HorizontalAlignment="Center"
-										Spacing="6"
-										Margin="12">
+										Spacing="10"
+										Margin="16">
+								<fa:SymbolIcon Symbol="Image"
+											   FontSize="40"
+											   Opacity="0.35"
+											   HorizontalAlignment="Center"/>
 								<TextBlock Text="No preview available"
 										   FontWeight="SemiBold"
 										   FontSize="14"
+										   Opacity="0.8"
 										   HorizontalAlignment="Center"/>
-								<TextBlock Text="This app has no thumbnail."
-										   Opacity="0.7"
+								<TextBlock Text="This app has no thumbnail yet."
+										   Opacity="0.55"
 										   FontSize="12"
 										   HorizontalAlignment="Center"/>
 							</StackPanel>
@@ -166,24 +200,15 @@
 								   Stretch="Uniform"
 								   StretchDirection="DownOnly"
 								   HorizontalAlignment="Center"
-								   VerticalAlignment="Center"/>
+								   VerticalAlignment="Center"
+								   Margin="8"/>
 						</Grid>
 					</Border>
-
 
 				</StackPanel>
 
 			</Grid>
 
-			<!-- Footer -->
-			<StackPanel Orientation="Horizontal"
-						HorizontalAlignment="Right"
-						Margin="0,6,0,0">
-				<Button Content="Close"
-						Width="100"
-						Command="{Binding CloseCommand}"/>
-			</StackPanel>
-
-		</StackPanel>
+		</DockPanel>
 	</Border>
 </Window>

--- a/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
@@ -60,12 +60,12 @@
 					Padding="24,16"
 					Margin="0,0,0,16">
 				<StackPanel Spacing="2" HorizontalAlignment="Center">
-					<TextBlock Text="App Catalog"
+					<TextBlock Text="{Binding LblCatalogTitle}"
 							   Foreground="White"
 							   FontWeight="SemiBold"
 							   FontSize="18"
 							   HorizontalAlignment="Center"/>
-					<TextBlock Text="Everything you can install on your Samsung device"
+					<TextBlock Text="{Binding LblCatalogSubtitle}"
 							   Foreground="#B9C9DA"
 							   FontSize="12"
 							   HorizontalAlignment="Center"/>
@@ -77,7 +77,7 @@
 						Orientation="Horizontal"
 						HorizontalAlignment="Right"
 						Margin="0,16,0,0">
-				<Button Content="Close"
+				<Button Content="{Binding LblClose}"
 						Classes="primary"
 						Width="110"
 						Command="{Binding CloseCommand}"/>
@@ -91,7 +91,7 @@
 				<StackPanel Grid.Column="0" Spacing="18">
 
 					<StackPanel Spacing="8">
-						<TextBlock Text="Jellyfin builds" Classes="subtitle"/>
+						<TextBlock Text="{Binding LblJellyfinBuilds}" Classes="subtitle"/>
 						<Border Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
 								BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
 								BorderThickness="1"
@@ -104,9 +104,9 @@
 									  IsReadOnly="True"
 									  ColumnWidth="*">
 								<DataGrid.Columns>
-									<DataGridTextColumn Header="File name" Width="200"
+									<DataGridTextColumn Header="{Binding LblColFileName}" Width="200"
 														Binding="{Binding FileName}" />
-									<DataGridTemplateColumn Header="Description" Width="*">
+									<DataGridTemplateColumn Header="{Binding LblColDescription}" Width="*">
 										<DataGridTemplateColumn.CellTemplate>
 											<DataTemplate>
 												<TextBlock Text="{Binding Description}"
@@ -122,7 +122,7 @@
 					</StackPanel>
 
 					<StackPanel Spacing="8">
-						<TextBlock Text="Community applications" Classes="subtitle"/>
+						<TextBlock Text="{Binding LblCommunityApps}" Classes="subtitle"/>
 						<Border Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
 								BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
 								BorderThickness="1"
@@ -135,9 +135,9 @@
 									  IsReadOnly="True"
 									  ColumnWidth="*">
 								<DataGrid.Columns>
-									<DataGridTextColumn Header="Application" Width="200"
+									<DataGridTextColumn Header="{Binding LblColApplication}" Width="200"
 														Binding="{Binding FileName}" />
-									<DataGridTemplateColumn Header="Description" Width="*">
+									<DataGridTemplateColumn Header="{Binding LblColDescription}" Width="*">
 										<DataGridTemplateColumn.CellTemplate>
 											<DataTemplate>
 												<TextBlock Text="{Binding Description}"
@@ -160,7 +160,7 @@
 							Spacing="8"
 							x:CompileBindings="False">
 
-					<TextBlock Text="App preview" Classes="subtitle"/>
+					<TextBlock Text="{Binding LblAppPreview}" Classes="subtitle"/>
 
 					<ComboBox ItemsSource="{Binding ProviderOptions}"
 							  SelectedItem="{Binding SelectedProviderOption, Mode=TwoWay}"
@@ -184,12 +184,12 @@
 											   FontSize="40"
 											   Opacity="0.35"
 											   HorizontalAlignment="Center"/>
-								<TextBlock Text="No preview available"
+								<TextBlock Text="{Binding LblNoPreview}"
 										   FontWeight="SemiBold"
 										   FontSize="14"
 										   Opacity="0.8"
 										   HorizontalAlignment="Center"/>
-								<TextBlock Text="This app has no thumbnail yet."
+								<TextBlock Text="{Binding LblNoThumbnail}"
 										   Opacity="0.55"
 										   FontSize="12"
 										   HorizontalAlignment="Center"/>

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.5.0](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.0)                                        | Recommended for most users   |
-| **Beta**   | [v2.5.1-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.1-beta)                                            | Includes new features        |
+| **Stable** | [v2.5.1](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.1)                                        | Recommended for most users   |
+| **Beta**   | [v2.5.2-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.2-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
## 🚀 Stable release v2.5.2

Bundles the catalog-window refresh with the v2.5.1 settings improvements (both shipped in quick succession).

### ✨ New in v2.5.2
* 🎨 **Redesigned App Catalog window** (the **?** next to Version) — modernised to match the rest of the app: new header, themed cards, softer tables, nicer preview panel, full dark-mode support (#382)
* 🌍 **Fully localized** — catalog titles, section/column headers and empty-state are now translatable (English + Dutch; others fall back to English) (#382)
* 🔤 **Sorted catalog** — Jellyfin builds and community apps listed A–Z / 0–9, matching the release dropdown (#383)

### ⚙️ Also included from v2.5.1
* **Settings overhaul for multiple apps** — the settings view now supports per-app configuration
* **Settings survive app updates** — moved to the per-user OS data dir (`%APPDATA%\Apps2Samsung` / `~/.config/Apps2Samsung`) with a one-time migration of existing `settings.json`
* **Preserve m3u8 URLs** + release sorting fixes

### ⬆️ Updating
* **From v2.3.2+:** auto-update works
* **From v2.3.1.1 or older:** download once manually ([FAQ](https://github.com/Apps2Samsung/Apps2Samsung/discussions/365))

| Platform | Status | Notes |
|----------|--------|-------|
| 🍎 macOS (.app + dmg) | ✅ Stable | ARM64 + Intel |
| 🍎 macOS (CLI) | ✅ Stable | Per-arch tar.gz |
| 🐧 Linux | ✅ Stable | x64 + ARM64 (tar.gz / .deb) |
| 🪟 Windows | ✅ Stable | .zip / .msi (winget) |

---

### 🛡️ Security Notice
Antivirus warnings may occur and are likely **false positives**.

**Full Changelog**: https://github.com/Apps2Samsung/Apps2Samsung/compare/v2.5.0...v2.5.2
