### PR TITLE
Fix: release list left empty when init is cancelled

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.5.2</CFBundleVersion>
+	<CFBundleVersion>2.5.3</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -99,7 +99,7 @@ namespace Apps2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.5.2";
+        public string AppVersion { get; set; } = "v2.5.3";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -399,8 +399,10 @@ namespace Apps2Samsung.ViewModels
 
             try
             {
-                // Only load releases and devices if they haven't been loaded yet
-                if (!Releases.Any())
+                // Only load releases and devices if they haven't been loaded yet.
+                // Note: Releases always contains the "Custom WGT File" entry, so we
+                // check for *real* provider releases, not just any entry.
+                if (!HasRealReleases)
                 {
                     await LoadReleasesAsync(token);
                     token.ThrowIfCancellationRequested();
@@ -625,8 +627,30 @@ namespace Apps2Samsung.ViewModels
         }
 
 
+        // True once the release list holds something other than the always-present
+        // "Custom WGT File" entry — i.e. providers actually loaded.
+        private bool HasRealReleases =>
+            Releases.Any(r => r.Name != Constants.AppIdentifiers.CustomWgtFile);
+
+        /// <summary>
+        /// Safety net: reload the release list if it never populated (e.g. the
+        /// initial load was cancelled by the update check or a re-init race).
+        /// Runs uncancellable so a pending init cancel can't kill it again.
+        /// </summary>
+        public async Task EnsureReleasesLoadedAsync()
+        {
+            if (IsLoading || HasRealReleases)
+                return;
+
+            await LoadReleasesAsync();
+        }
+
         private async Task LoadReleasesAsync(CancellationToken cancellationToken = default)
         {
+            // Guard against concurrent loads (init vs. the recovery/refresh paths).
+            if (IsLoading)
+                return;
+
             IsLoading = true;
             try
             {

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml.cs
@@ -13,7 +13,18 @@ namespace Apps2Samsung.Views
                 if (DataContext is MainWindowViewModel vm)
                 {
                     await vm.InitializeAsync();
+                    // If init was cancelled (e.g. by the update check) the release
+                    // list can be left empty — recover once init has settled.
+                    await vm.EnsureReleasesLoadedAsync();
                 }
+            };
+
+            // Recover an empty release list when the window regains focus, so the
+            // user doesn't have to restart the app. No-op once releases are loaded.
+            this.Activated += async (_, __) =>
+            {
+                if (DataContext is MainWindowViewModel vm)
+                    await vm.EnsureReleasesLoadedAsync();
             };
         }
     }


### PR DESCRIPTION
**Symptom:** sometimes the Release dropdown shows only "Custom WGT File"; reopening the app fixes it.

**Root cause (two coupled bugs):**
1. `LoadReleasesAsync` runs under the shared `_initializationCts`. The background update check cancels that token (`CheckForUpdatesAsync` → `_initializationCts.Cancel()`), and a re-init can too — aborting the release load mid-flight. The `finally` still adds "Custom WGT File", so the list isn't empty, just missing the real entries. (Confirmed in a user trace: `Initialization cancelled` right after startup.)
2. The recovery path `ResumeInitializationAsync` guarded on `if (!Releases.Any())` — but `Releases` always has the Custom WGT entry, so the guard was never true and **recovery never ran**. Only a full restart reloaded.

**Fix:**
- `HasRealReleases` helper ignores the always-present Custom WGT entry
- `ResumeInitializationAsync` now reloads when there are no *real* releases
- `EnsureReleasesLoadedAsync()` — an uncancellable, reentrancy-guarded safety-net reload
- `MainWindow` runs it after `InitializeAsync` **and on `Activated`**, so simply refocusing the window recovers an empty list (no restart needed) — matches the reported workaround
- Added a concurrent-load guard to `LoadReleasesAsync`

Also a good idea (separate): setting a GitHub token in Settings raises the API limit from 60→5000/hr, making the unauthenticated path far less likely to stall. Not required for this fix.

`dotnet build`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)