### PR TITLE
Release v2.5.3

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.5.2</CFBundleVersion>
+	<CFBundleVersion>2.5.3</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -99,7 +99,7 @@ namespace Apps2Samsung.Helpers
 
         // ----- Application-scoped settings (readonly at runtime) -----
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
-        public string AppVersion { get; set; } = "v2.5.2";
+        public string AppVersion { get; set; } = "v2.5.3";
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -399,8 +399,10 @@ namespace Apps2Samsung.ViewModels
 
             try
             {
-                // Only load releases and devices if they haven't been loaded yet
-                if (!Releases.Any())
+                // Only load releases and devices if they haven't been loaded yet.
+                // Note: Releases always contains the "Custom WGT File" entry, so we
+                // check for *real* provider releases, not just any entry.
+                if (!HasRealReleases)
                 {
                     await LoadReleasesAsync(token);
                     token.ThrowIfCancellationRequested();
@@ -625,8 +627,30 @@ namespace Apps2Samsung.ViewModels
         }
 
 
+        // True once the release list holds something other than the always-present
+        // "Custom WGT File" entry — i.e. providers actually loaded.
+        private bool HasRealReleases =>
+            Releases.Any(r => r.Name != Constants.AppIdentifiers.CustomWgtFile);
+
+        /// <summary>
+        /// Safety net: reload the release list if it never populated (e.g. the
+        /// initial load was cancelled by the update check or a re-init race).
+        /// Runs uncancellable so a pending init cancel can't kill it again.
+        /// </summary>
+        public async Task EnsureReleasesLoadedAsync()
+        {
+            if (IsLoading || HasRealReleases)
+                return;
+
+            await LoadReleasesAsync();
+        }
+
         private async Task LoadReleasesAsync(CancellationToken cancellationToken = default)
         {
+            // Guard against concurrent loads (init vs. the recovery/refresh paths).
+            if (IsLoading)
+                return;
+
             IsLoading = true;
             try
             {

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml.cs
@@ -13,7 +13,18 @@ namespace Apps2Samsung.Views
                 if (DataContext is MainWindowViewModel vm)
                 {
                     await vm.InitializeAsync();
+                    // If init was cancelled (e.g. by the update check) the release
+                    // list can be left empty — recover once init has settled.
+                    await vm.EnsureReleasesLoadedAsync();
                 }
+            };
+
+            // Recover an empty release list when the window regains focus, so the
+            // user doesn't have to restart the app. No-op once releases are loaded.
+            this.Activated += async (_, __) =>
+            {
+                if (DataContext is MainWindowViewModel vm)
+                    await vm.EnsureReleasesLoadedAsync();
             };
         }
     }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.5.2](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.2)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.5.3-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.3-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.5.1](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.1)                                        | Recommended for most users   |
-| **Beta**   | [v2.5.2-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.2-beta)                                            | Includes new features        |
+| **Stable** | [v2.5.2](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.2)                                        | Recommended for most users   |
+| **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
## 🩹 Stable release v2.5.3

A reliability fix for the release list.

### 🐛 Fixed
* **Release list could show only "Custom WGT File" until the app was restarted.** If the startup load was interrupted (e.g. by the background update check), the list was left empty and never recovered. It now reloads automatically — after startup and whenever the window regains focus — so a restart is no longer needed (#385)

### 💡 Tip
Setting a **GitHub token** in Settings raises the API limit from 60 to 5000 requests/hour, which makes slow/again-empty loads far less likely.

### ⬆️ Updating
* **From v2.3.2+:** auto-update works
* **From v2.3.1.1 or older:** download once manually ([FAQ](https://github.com/Apps2Samsung/Apps2Samsung/discussions/365))

| Platform | Status | Notes |
|----------|--------|-------|
| 🍎 macOS (.app + dmg) | ✅ Stable | ARM64 + Intel |
| 🍎 macOS (CLI) | ✅ Stable | Per-arch tar.gz |
| 🐧 Linux | ✅ Stable | x64 + ARM64 (tar.gz / .deb) |
| 🪟 Windows | ✅ Stable | .zip / .msi (winget) |

---

### 🛡️ Security Notice
Antivirus warnings may occur and are likely **false positives**.

**Full Changelog**: https://github.com/Apps2Samsung/Apps2Samsung/compare/v2.5.2...v2.5.3
