### PR TITLE
Fix app-scoped settings being frozen by preserved settings.json

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -98,11 +98,21 @@ namespace Apps2Samsung.Helpers
         public DateTime? LastUpdateCheck { get; set; } = null;
 
         // ----- Application-scoped settings (readonly at runtime) -----
+        // [JsonIgnore] so these always reflect the shipped code defaults. If they were
+        // serialized, a preserved settings.json would freeze them at the value first
+        // written — e.g. an upgraded user would keep seeing their old AppVersion and
+        // stale endpoint URLs after an update.
+        [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
+        [JsonIgnore]
         public string AppVersion { get; set; } = "v2.5.3";
+        [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
+        [JsonIgnore]
         public string JellyfinAvReleaseFork { get; set; } = "https://api.github.com/repos/asamahy/tizen-jellyfin-avplay/releases";
+        [JsonIgnore]
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";
+        [JsonIgnore]
         public string CommunityInfo { get; set; } = "https://raw.githubusercontent.com/PatrickSt1991/tizen-community-packages/refs/heads/main/README.md";
         public AppSettings() { }
 


### PR DESCRIPTION
AppVersion and the other "readonly at runtime" fields (AuthorEndpoint, TizenSdb, JellyfinAvReleaseFork, ReleaseInfo, CommunityInfo) were serialized to settings.json. On upgrade, Load() deserialized the user's existing file and overwrote the new code defaults, so existing users kept seeing their old AppVersion and stale endpoint URLs after updating — made more certain by the new per-user-dir settings migration.

Mark the app-scoped block [JsonIgnore] so these always reflect the shipped code values and are no longer persisted. Nothing writes to them at runtime, so this is safe; leftover keys in an existing settings.json are ignored on load.

# Pull Request Template

## Branch
- [ ] I branched off beta (not master) to develop this feature/fix

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes # (issue number, if applicable)

---

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [ ] My code follows the existing project structure and style  
- [ ] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [ ] I have verified that the installer still works with the underlying CLI  

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
