### PR TITLE
Clean up auto-generated release notes (beta + stable)

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -69,10 +69,22 @@ jobs:
           fi
 
       - name: Prepare release notes
+        shell: bash
         run: |
           DATE=$(date +'%Y-%m-%d')
+
+          # Tidy GitHub's generated notes: drop the HTML comment + the redundant
+          # "What's Changed" heading, and shorten each
+          # "* <title> by @user in <url>/pull/N" line to "- <title> (#N)".
+          sed -E \
+            -e '/^<!--/d' \
+            -e "/^## What's Changed[[:space:]]*$/d" \
+            -e 's~^\* (.*) by @[^ ]+ in https?://github.com/[^ ]+/pull/([0-9]+)[[:space:]]*$~- \1 (#\2)~' \
+            CHANGELOG.md | cat -s > CHANGELOG.clean.md
+          mv CHANGELOG.clean.md CHANGELOG.md
+
           {
-            echo "## 📦 [${VERSION_TAG}] – ${DATE}"
+            echo "## 📦 ${VERSION_TAG} — ${DATE}"
             echo ""
             cat CHANGELOG.md
             echo ""

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -133,8 +133,19 @@ jobs:
         shell: bash
         run: |
           DATE=$(date +'%Y-%m-%d')
+
+          # Tidy GitHub's generated notes: drop the HTML comment + the redundant
+          # "What's Changed" heading, and shorten each
+          # "* <title> by @user in <url>/pull/N" line to "- <title> (#N)".
+          sed -E \
+            -e '/^<!--/d' \
+            -e "/^## What's Changed[[:space:]]*$/d" \
+            -e 's~^\* (.*) by @[^ ]+ in https?://github.com/[^ ]+/pull/([0-9]+)[[:space:]]*$~- \1 (#\2)~' \
+            CHANGELOG.md | cat -s > CHANGELOG.clean.md
+          mv CHANGELOG.clean.md CHANGELOG.md
+
           {
-            echo "## 📦 [${VERSION_TAG}] – ${DATE}"
+            echo "## 📦 ${VERSION_TAG} — ${DATE}"
             echo ""
             cat CHANGELOG.md
             echo ""


### PR DESCRIPTION
Stops the release notes from looking like a raw GitHub "What's Changed" dump — every release is now tidy automatically, no manual editing.

### Before
```
## 📦 [v2.5.4-beta] – 2026-06-11
<!-- Release notes generated using configuration in .github/release.yml ... -->
## What's Changed
### 🔀 Other changes
* Fix app-scoped settings ... by @PatrickSt1991 in https://github.com/.../pull/387
...
```

### After
```
## 📦 v2.5.4-beta — 2026-06-11
### 🔀 Other changes
- Fix app-scoped settings being frozen by preserved settings.json (#387)
- Add optional oblong (16:9) TVApp launcher icon for Tizen 5.5 TVs (#389)
- Update TVApp oblong icon, add Litefin oblong icon, bump v2.5.4 (#394)

**Full Changelog**: ...
| Platform | Status | Notes | ...
```

### What changed (both `beta-prerelease.yml` and `stable-release.yml`)
Post-process the `generate-notes` output in the "Prepare release notes" step:
- strip the `<!-- generated using ... -->` comment
- drop the redundant `## What's Changed` heading (it sat under the version header)
- shorten `* <title> by @user in <full-url>/pull/N` → `- <title> (#N)`
- tidy the header to `## 📦 <tag> — <date>`

Pure text transform on the generated changelog — the build/publish/upload steps and the `release.yml` categories are untouched.

### Note on categories
The `### 🚀 New features` / `### 🐛 Bug fixes` split in `.github/release.yml` only kicks in when PRs are **labelled** (feature/enhancement, bug/fix, …). Unlabelled PRs land under "Other changes" (now clean). If you want auto-split without manual labelling, a small PR-title auto-labeler can be added as a follow-up.
