### PR TITLE
Fix #400: LiteFin install fails on old Tizen TVs (bundled background service)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -208,5 +208,84 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
 
             return match.Success ? match.Groups["version"].Value : null;
         }
+
+        /// <summary>
+        /// True when the package bundles a background <c>&lt;tizen:service&gt;</c> component.
+        /// Older Samsung TVs (Tizen 2.x/3.x) can't install such multi-component widgets and
+        /// reject them with a generic "install failed[118]".
+        /// </summary>
+        public static async Task<bool> WgtContainsService(string wgtPath)
+        {
+            if (!File.Exists(wgtPath))
+                return false;
+
+            using var memoryStream = new MemoryStream();
+            using (var originalStream = File.OpenRead(wgtPath))
+                await originalStream.CopyToAsync(memoryStream);
+
+            memoryStream.Position = 0;
+
+            using var archive = new ZipArchive(memoryStream, ZipArchiveMode.Read, true);
+            var configEntry = archive.GetEntry("config.xml");
+            if (configEntry == null)
+                return false;
+
+            string configContent;
+            using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
+                configContent = await reader.ReadToEndAsync();
+
+            return Regex.IsMatch(configContent, @"<tizen:service\b", RegexOptions.IgnoreCase);
+        }
+
+        /// <summary>
+        /// Removes every <c>&lt;tizen:service&gt;…&lt;/tizen:service&gt;</c> element from the
+        /// package's config.xml so the main UI app can install on older TVs that don't support
+        /// background-service components. Returns true if anything was removed (the wgt must be
+        /// re-signed afterwards — the caller re-enters the install flow which re-signs).
+        /// </summary>
+        public static async Task<bool> StripWgtServiceComponent(string wgtPath)
+        {
+            if (!File.Exists(wgtPath))
+                return false;
+
+            using var memoryStream = new MemoryStream();
+            using (var originalStream = File.OpenRead(wgtPath))
+                await originalStream.CopyToAsync(memoryStream);
+
+            memoryStream.Position = 0;
+
+            bool changed = false;
+            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Update, true))
+            {
+                var configEntry = archive.GetEntry("config.xml");
+                if (configEntry == null)
+                    return false;
+
+                string configContent;
+                using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
+                    configContent = await reader.ReadToEndAsync();
+
+                // Drop full <tizen:service>...</tizen:service> blocks and any self-closing form.
+                var newConfig = Regex.Replace(
+                    configContent,
+                    @"[ \t]*<tizen:service\b[\s\S]*?</tizen:service>\s*|[ \t]*<tizen:service\b[^>]*/>\s*",
+                    string.Empty,
+                    RegexOptions.IgnoreCase);
+
+                if (newConfig == configContent)
+                    return false;
+
+                changed = true;
+                configEntry.Delete();
+                var newEntry = archive.CreateEntry("config.xml");
+                using var writer = new StreamWriter(newEntry.Open(), Encoding.UTF8);
+                await writer.WriteAsync(newConfig);
+            }
+
+            if (changed)
+                await File.WriteAllBytesAsync(wgtPath, memoryStream.ToArray());
+
+            return changed;
+        }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -577,7 +577,11 @@ namespace Apps2Samsung.Services
                 return InstallResult.FailureResult(certMessage);
             }
 
-            // Handle package ID conflict error
+            // Plain install failed[118]: a generic rejection. For a fresh install this is
+            // usually NOT an app-id conflict (those surface as 118012 / 118,-12, handled
+            // above). The common cause on older Samsung TVs is a bundled background
+            // <tizen:service> component the TV can't install — strip it and retry before
+            // anything else, so the main app still installs.
             if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
@@ -585,12 +589,20 @@ namespace Apps2Samsung.Services
                 if (_appSettings.TryOverwrite)
                 {
                     _appSettings.TryOverwrite = false;
+
+                    if (await FileHelper.StripWgtServiceComponent(packageUrl))
+                    {
+                        Trace.WriteLine("install failed[118]: package bundles a background service the TV can't install — removed it and retrying");
+                        return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
+                    }
+
+                    // No service to remove — fall back to the legacy app-id rewrite.
                     await FileHelper.ModifyWgtPackageId(packageUrl);
                     return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
                 }
 
                 _appSettings.TryOverwrite = false;
-                return InstallResult.FailureResult($"Installation failed: {Constants.LocalizationKeys.ModifyConfigRequired.Localized()}");
+                return InstallResult.FailureResult($"Installation failed: {Constants.LocalizationKeys.IncompatiblePackage.Localized()}");
             }
 
             // Handle generic failure


### PR DESCRIPTION
Fixes #400.

## Diagnosis (from the reporter's logs + package inspection)
- TV: Samsung UE50KU6079, **Tizen 2.4** (2016), heavily locked down (most `sdb`/`pkgcmd` commands fail).
- Install log: `app_id[LitefinApp.Litefin] install failed[118]`; uninstall log: `uninstall failed[132]` → **the app was never installed**, so plain 118 is *not* an id/cert conflict.
- Comparing packages: **LiteFin bundles a `<tizen:service id="LitefinApp.ytresolver">` background-service component**; Moonfin & AVPlay (which install fine on the same TV) have none. Old Samsung TVs can't install multi-component widgets with a background service → generic 118.
- The installer misread 118 as an app-id conflict, rewrote the id, retried, and showed the misleading **"Jellyfin app needs a new app id!"**.

## Fix
- `FileHelper.WgtContainsService` / `StripWgtServiceComponent` — detect & remove `<tizen:service>` blocks from `config.xml` (same zip-rewrite approach as `ModifyWgtPackageId`; re-entering the install flow re-signs the package).
- On plain `install failed[118]`: **strip the service component and retry** so the main app installs. The background service (YouTube resolver) is only dropped when the TV actually rejected the package; falls back to the legacy app-id rewrite when there's no service.
- Replaced the misleading Jellyfin-branded failure text with the accurate, already-localized **IncompatiblePackage** message.

## Verification
- Strip regex tested on the real LiteFin `ultra-legacy` config.xml → service removed, main app/content retained, **well-formed XML**.
- `dotnet build`: 0 errors.

## Note
On these legacy TVs LiteFin's in-app YouTube-trailer resolver (the stripped service) won't function, but the app itself installs and runs — a working install beats a hard failure. Worth a line in the FAQ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)