### PR TITLE
Gate service-strip on Tizen version (follow-up to #401)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -56,6 +56,10 @@ namespace Apps2Samsung.Helpers.Core
             public const string CertificateRequired = "7.0";
             public const string PushInstallMax = "4.0";
             public const string IntermediateVersion = "3.0";
+            // Background <tizen:service> components are only reliably installable on
+            // Samsung TVs from Tizen 4.0 onward. Below this, such a component must be
+            // stripped or the whole package is rejected with a generic install failed[118].
+            public const string ServiceComponentSupport = "4.0";
         }
 
         /// <summary>

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -255,6 +255,17 @@ namespace Apps2Samsung.Services
                     }
                 }
 
+                // Step 3b: Older TVs (below Tizen 4.0) can't install a bundled background
+                // <tizen:service> component — the whole package is rejected with a generic
+                // install failed[118] (see #400). Only on those TVs, strip the service so
+                // the main app still installs. Newer TVs keep the package untouched.
+                var serviceSupport = new Version(Constants.TizenVersions.ServiceComponentSupport);
+                if (deviceInfo.TizenVersion < serviceSupport && await FileHelper.WgtContainsService(packageUrl))
+                {
+                    if (await FileHelper.StripWgtServiceComponent(packageUrl))
+                        Trace.WriteLine($"Device Tizen {deviceInfo.TizenVersion} < {serviceSupport}: removed bundled background service so the package can install");
+                }
+
                 // Step 4: Handle certificate selection/generation
                 var certificateResult = await HandleCertificateAsync(
                     tvIpAddress,
@@ -577,11 +588,9 @@ namespace Apps2Samsung.Services
                 return InstallResult.FailureResult(certMessage);
             }
 
-            // Plain install failed[118]: a generic rejection. For a fresh install this is
-            // usually NOT an app-id conflict (those surface as 118012 / 118,-12, handled
-            // above). The common cause on older Samsung TVs is a bundled background
-            // <tizen:service> component the TV can't install — strip it and retry before
-            // anything else, so the main app still installs.
+            // Handle package ID conflict error. Note: a service-component incompatibility
+            // (the common cause on older TVs) is already handled before install in Step 3b,
+            // so reaching here generally means a genuine id/config conflict.
             if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
@@ -589,20 +598,12 @@ namespace Apps2Samsung.Services
                 if (_appSettings.TryOverwrite)
                 {
                     _appSettings.TryOverwrite = false;
-
-                    if (await FileHelper.StripWgtServiceComponent(packageUrl))
-                    {
-                        Trace.WriteLine("install failed[118]: package bundles a background service the TV can't install — removed it and retrying");
-                        return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
-                    }
-
-                    // No service to remove — fall back to the legacy app-id rewrite.
                     await FileHelper.ModifyWgtPackageId(packageUrl);
                     return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
                 }
 
                 _appSettings.TryOverwrite = false;
-                return InstallResult.FailureResult($"Installation failed: {Constants.LocalizationKeys.IncompatiblePackage.Localized()}");
+                return InstallResult.FailureResult($"Installation failed: {Constants.LocalizationKeys.ModifyConfigRequired.Localized()}");
             }
 
             // Handle generic failure


### PR DESCRIPTION
Follow-up to #401, which merged the **reactive** version of the service-strip (it stripped the bundled `<tizen:service>` whenever a plain `install failed[118]` occurred). That refactor commit landed on the branch after #401 was already merged, so it never reached beta — this PR brings it in.

**Change:** only strip the background service when the device's Tizen version is **below `Constants.TizenVersions.ServiceComponentSupport` (4.0)**, done proactively before signing/install. Newer TVs that support service apps keep the full package untouched — a generic 118 on a capable TV can no longer drop the service. The plain-118 branch is restored to its original app-id-rewrite behaviour.

`dotnet build`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)