### PR TITLE
Fix #399: advance rolling beta tag so notes include all merged PRs

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -54,6 +54,15 @@ jobs:
         run: |
           LAST_TAG=$(git tag --sort=-creatordate | grep beta | grep -vx "$VERSION_TAG" | head -n 1)
 
+          # The rolling beta tag is reused across pushes, but action-gh-release
+          # won't re-point an existing tag — so it stays pinned at the commit it
+          # was first created on, and generate-notes computes the PR range against
+          # that stale point (notes lag behind merged PRs, see #399). Force-move the
+          # tag to the current commit first so the notes reflect everything merged
+          # since the previous beta tag.
+          git tag -f "$VERSION_TAG" "$GITHUB_SHA"
+          git push -f origin "refs/tags/$VERSION_TAG"
+
           ARGS=(-f tag_name="$VERSION_TAG" -f target_commitish="$GITHUB_SHA")
           if [ -n "$LAST_TAG" ]; then
             ARGS+=(-f previous_tag_name="$LAST_TAG")


### PR DESCRIPTION
Fixes #399.

**Root cause:** the `vX.Y.Z-beta` tag is reused on every push, but `softprops/action-gh-release` does not re-point an existing tag. So the tag ref stayed pinned at the commit it was first created on; `generate-notes` (called with `tag_name=vX.Y.Z-beta`) computed the PR range against that stale commit, and PRs merged afterwards never appeared until a version bump.

**Fix (issue's option 1):** in the *Generate changelog* step, force-move the tag to the current commit before calling `generate-notes`:
```
git tag -f "$VERSION_TAG" "$GITHUB_SHA"
git push -f origin "refs/tags/$VERSION_TAG"
```
Notes now reflect everything merged since the previous beta tag — no manual editing.

**Stable:** unaffected — it cuts a fresh version tag each release (tag never pre-exists, so `target_commitish` is honoured). No change needed there.

**Verification:** YAML validates; the checkout already uses `fetch-depth: 0` (all tags) and the workflow has `contents: write`, so the tag force-push works with the default token. Real proof comes on the next beta push — notes should list all PRs since the prior beta.