### PR TITLE
Keep author certificate stable across TVs (#396, part 1)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Interfaces/ITizenCertificateService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/ITizenCertificateService.cs
@@ -6,5 +6,12 @@ namespace Apps2Samsung.Interfaces
     public interface ITizenCertificateService
     {
         Task<(string authorP12, string distributorP12, string passwordP12)> GenerateProfileAsync(string duid, string accessToken, string userId, string userEmail, string outputPath, ProgressCallback? progress = null);
+
+        /// <summary>
+        /// Regenerates only the distributor certificate for a new DUID, reusing the existing
+        /// author keypair in <paramref name="certDir"/> so the author identity stays unchanged
+        /// (keeps apps installed on other TVs overwritable). Returns the distributor .p12 path.
+        /// </summary>
+        Task<string> RegenerateDistributorAsync(string certDir, string duid, string accessToken, string userId, string userEmail, ProgressCallback? progress = null);
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/TizenCertificateService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenCertificateService.cs
@@ -84,6 +84,64 @@ namespace Apps2Samsung.Services
             return (authorp12, distributorp12, p12Plain);
         }
 
+        public async Task<string> RegenerateDistributorAsync(
+            string certDir,
+            string duid,
+            string accessToken,
+            string userId,
+            string userEmail,
+            ProgressCallback? progress = null)
+        {
+            if (string.IsNullOrEmpty(certDir))
+                throw new ArgumentException("Certificate directory cannot be empty", nameof(certDir));
+
+            var authorP12 = Path.Combine(certDir, "author.p12");
+            var passwordFile = Path.Combine(certDir, "password.txt");
+            if (!File.Exists(authorP12) || !File.Exists(passwordFile))
+                throw new FileNotFoundException(
+                    "Existing author certificate not found; cannot regenerate distributor only.", authorP12);
+
+            var password = (await File.ReadAllTextAsync(passwordFile)).Trim();
+
+            // Reuse the existing author keypair so the author identity stays byte-identical —
+            // only the device-bound distributor cert changes for the new DUID.
+            var keyPair = LoadKeyPairFromP12(authorP12, password);
+
+            progress?.Invoke("CreateDistributorCSR".Localized());
+            var distributorCsrData = GenerateDistributorCsr(keyPair, duid, userEmail);
+            await File.WriteAllBytesAsync(Path.Combine(certDir, "distributor.csr"), distributorCsrData);
+
+            progress?.Invoke("PostDistributorCSR".Localized());
+            var (profileXmlBytes, signedDistributorCsrBytes) =
+                await PostDistributorCsrAsync(accessToken, userId, distributorCsrData, duid);
+            if (profileXmlBytes != null)
+                await File.WriteAllBytesAsync(Path.Combine(certDir, "device-profile.xml"), profileXmlBytes);
+            await File.WriteAllBytesAsync(Path.Combine(certDir, "signed_distributor.cer"), signedDistributorCsrBytes);
+
+            await CheckCertificateExistenceAsync(Path.Combine(AppSettings.ProfilePath, "ca"));
+
+            progress?.Invoke("ExportPfxCertificates".Localized());
+            // author.p12 / signed_author.cer / password.txt are intentionally left untouched.
+            return await ExportPfxWithCaChainAsync(
+                signedDistributorCsrBytes, keyPair.Private, password, certDir,
+                Path.Combine(AppSettings.ProfilePath, "ca"), "distributor", "vd_tizen_dev_public2.crt");
+        }
+
+        /// <summary>Loads the keypair (public + private) from a PKCS#12 file's first key entry.</summary>
+        private static AsymmetricCipherKeyPair LoadKeyPairFromP12(string p12Path, string password)
+        {
+            using var fs = File.OpenRead(p12Path);
+            var store = new Pkcs12StoreBuilder().Build();
+            store.Load(fs, password.ToCharArray());
+
+            var alias = store.Aliases.Cast<string>().FirstOrDefault(store.IsKeyEntry)
+                ?? throw new InvalidOperationException($"No private key entry found in '{p12Path}'.");
+
+            var privateKey = store.GetKey(alias).Key;
+            var publicKey = store.GetCertificate(alias).Certificate.GetPublicKey();
+            return new AsymmetricCipherKeyPair(publicKey, privateKey);
+        }
+
         private static AsymmetricCipherKeyPair GenerateKeyPair()
         {
             var keyGen = new RsaKeyPairGenerator();

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -462,37 +463,31 @@ namespace Apps2Samsung.Services
 
             string authorp12, distributorp12, p12Password;
 
-            // Determine if Samsung login is needed
-            bool needsSamsungLogin = string.IsNullOrEmpty(selectedCertificate) ||
-                                     selectedCertificate == Constants.AppIdentifiers.Jelly2SamsDefault ||
-                                     (deviceInfo.Duid != certDuid && selectedCertificate != Constants.AppIdentifiers.JellyfinAppName) ||
-                                     _appSettings.ForceSamsungLogin;
+            var jelly2SamsDir = Path.Combine(AppSettings.CertificatePath, Constants.AppIdentifiers.Jelly2Sams);
+            bool hasAuthor = HasUsableAuthorCert(jelly2SamsDir);
 
-            if (needsSamsungLogin)
+            // A full Samsung profile (fresh keypair + new author cert) is only needed on first run,
+            // when no real cert is selected, when the author cert is missing/expired, or when forced.
+            bool needsFullProfile = string.IsNullOrEmpty(selectedCertificate) ||
+                                    selectedCertificate == Constants.AppIdentifiers.Jelly2SamsDefault ||
+                                    !hasAuthor ||
+                                    _appSettings.ForceSamsungLogin;
+
+            // Author cert exists but this TV's DUID isn't what the distributor cert was made for:
+            // regenerate ONLY the distributor (reusing the author keypair) so the author identity
+            // stays byte-identical and apps already installed on other TVs remain overwritable.
+            bool needsDistributorOnly = !needsFullProfile &&
+                                        deviceInfo.Duid != certDuid &&
+                                        selectedCertificate != Constants.AppIdentifiers.JellyfinAppName;
+
+            if (needsFullProfile || needsDistributorOnly)
             {
                 progress?.Invoke(Constants.LocalizationKeys.SamsungLogin.Localized());
                 onSamsungLoginStarted?.Invoke();
 
                 SamsungAuth auth = await SamsungLoginService.PerformSamsungLoginAsync(cancellationToken);
 
-                if (!string.IsNullOrEmpty(auth.access_token))
-                {
-                    progress?.Invoke(Constants.LocalizationKeys.CreatingCertificateProfile.Localized());
-
-                    var certificateService = new TizenCertificateService(_httpClient, _dialogService);
-                    (authorp12, distributorp12, p12Password) = await certificateService.GenerateProfileAsync(
-                        duid: deviceInfo.Duid,
-                        accessToken: auth.access_token,
-                        userId: auth.userId,
-                        userEmail: auth.inputEmailID,
-                        outputPath: Path.Combine(AppSettings.CertificatePath, Constants.AppIdentifiers.Jelly2Sams),
-                        progress);
-
-                    PackageCertificate = Constants.AppIdentifiers.Jelly2Sams;
-                    _appSettings.Certificate = PackageCertificate;
-                    _appSettings.Save();
-                }
-                else
+                if (string.IsNullOrEmpty(auth.access_token))
                 {
                     await _dialogService.ShowErrorAsync("Failed to authenticate with Samsung account.");
                     return new CertificateResult
@@ -501,6 +496,44 @@ namespace Apps2Samsung.Services
                         InstallResult = InstallResult.FailureResult("Auth failed.")
                     };
                 }
+
+                progress?.Invoke(Constants.LocalizationKeys.CreatingCertificateProfile.Localized());
+                var certificateService = new TizenCertificateService(_httpClient, _dialogService);
+
+                if (needsFullProfile)
+                {
+                    (authorp12, distributorp12, p12Password) = await certificateService.GenerateProfileAsync(
+                        duid: deviceInfo.Duid,
+                        accessToken: auth.access_token,
+                        userId: auth.userId,
+                        userEmail: auth.inputEmailID,
+                        outputPath: jelly2SamsDir,
+                        progress);
+                }
+                else
+                {
+                    // Reuse the existing author cert; only the distributor cert is regenerated.
+                    distributorp12 = await certificateService.RegenerateDistributorAsync(
+                        certDir: jelly2SamsDir,
+                        duid: deviceInfo.Duid,
+                        accessToken: auth.access_token,
+                        userId: auth.userId,
+                        userEmail: auth.inputEmailID,
+                        progress);
+                    authorp12 = Path.Combine(jelly2SamsDir, Constants.Certificate.AuthorFileName);
+                    p12Password = (await File.ReadAllTextAsync(
+                        Path.Combine(jelly2SamsDir, Constants.Certificate.PasswordFileName))).Trim();
+                }
+
+                PackageCertificate = Constants.AppIdentifiers.Jelly2Sams;
+                _appSettings.Certificate = PackageCertificate;
+                _appSettings.ChosenCertificates = new ExistingCertificates
+                {
+                    Name = Constants.AppIdentifiers.Jelly2Sams,
+                    Duid = deviceInfo.Duid,
+                    File = authorp12
+                };
+                _appSettings.Save();
             }
             else
             {
@@ -530,6 +563,28 @@ namespace Apps2Samsung.Services
                 DistributorP12 = distributorp12,
                 P12Password = p12Password
             };
+        }
+
+        // True when a generated author cert exists and is still valid — i.e. we can keep that
+        // author identity and only regenerate the distributor cert for a new TV.
+        private static bool HasUsableAuthorCert(string certDir)
+        {
+            try
+            {
+                var authorP12 = Path.Combine(certDir, Constants.Certificate.AuthorFileName);
+                var passwordFile = Path.Combine(certDir, Constants.Certificate.PasswordFileName);
+                if (!File.Exists(authorP12) || !File.Exists(passwordFile))
+                    return false;
+
+                var password = File.ReadAllText(passwordFile).Trim();
+                using var cert = new X509Certificate2(authorP12, password, X509KeyStorageFlags.Exportable);
+                return cert.NotAfter.Date >= DateTime.Today;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[Cert] Author cert check failed for '{certDir}': {ex.Message}");
+                return false;
+            }
         }
 
         #endregion

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -466,19 +466,25 @@ namespace Apps2Samsung.Services
             var jelly2SamsDir = Path.Combine(AppSettings.CertificatePath, Constants.AppIdentifiers.Jelly2Sams);
             bool hasAuthor = HasUsableAuthorCert(jelly2SamsDir);
 
+            // Older Tizen TVs use the shipped "Jellyfin" certificate (set just above) — it's always
+            // present and never regenerated, so it bypasses all Samsung-login / regeneration logic
+            // and is just reused from disk (unless the user forces a fresh login).
+            bool isBundledJellyfin = selectedCertificate == Constants.AppIdentifiers.JellyfinAppName;
+
             // A full Samsung profile (fresh keypair + new author cert) is only needed on first run,
-            // when no real cert is selected, when the author cert is missing/expired, or when forced.
+            // when no real cert is selected, when the generated author cert is missing/expired, or
+            // when forced. The bundled "Jellyfin" cert never needs one.
             bool needsFullProfile = string.IsNullOrEmpty(selectedCertificate) ||
                                     selectedCertificate == Constants.AppIdentifiers.Jelly2SamsDefault ||
-                                    !hasAuthor ||
-                                    _appSettings.ForceSamsungLogin;
+                                    _appSettings.ForceSamsungLogin ||
+                                    (!isBundledJellyfin && !hasAuthor);
 
-            // Author cert exists but this TV's DUID isn't what the distributor cert was made for:
-            // regenerate ONLY the distributor (reusing the author keypair) so the author identity
-            // stays byte-identical and apps already installed on other TVs remain overwritable.
+            // Generated author cert exists but this TV's DUID isn't what the distributor cert was
+            // made for: regenerate ONLY the distributor (reusing the author keypair) so the author
+            // identity stays byte-identical and apps already installed on other TVs stay overwritable.
             bool needsDistributorOnly = !needsFullProfile &&
-                                        deviceInfo.Duid != certDuid &&
-                                        selectedCertificate != Constants.AppIdentifiers.JellyfinAppName;
+                                        !isBundledJellyfin &&
+                                        deviceInfo.Duid != certDuid;
 
             if (needsFullProfile || needsDistributorOnly)
             {


### PR DESCRIPTION
First of two PRs for #396.

### Problem
Installing to a **second TV** regenerated the entire signing profile — `HandleCertificateAsync` set `needsSamsungLogin` on a different-TV DUID, and `GenerateProfileAsync` then built a **new keypair → new author cert**. That broke overwrite/update of apps already installed on the **first** TV (`install failed[118,-12] … same id, different certificate`).

The Tizen **author** cert is account-bound; only the **distributor** cert is device-bound (DUID in its SAN). So a new TV only needs a new *distributor* cert — the author identity should stay put.

### Change
A new-TV install now regenerates **only the distributor cert**, reusing the existing author keypair so the author cert stays **byte-identical**:
- **`TizenCertificateService.RegenerateDistributorAsync`** — loads the keypair from the existing `author.p12` (`LoadKeyPairFromP12`, BouncyCastle `Pkcs12Store`) and rebuilds only `distributor.csr` / `signed_distributor.cer` / `device-profile.xml` / `distributor.p12`. `author.p12` / `signed_author.cer` / `password.txt` are **never touched**.
- **`HandleCertificateAsync`** now branches three ways:
  - **Full profile** (fresh keypair) — first run, no/`default` cert, missing/expired author cert, or `ForceSamsungLogin`.
  - **Distributor-only** — author cert exists & this TV's DUID differs (and not the shipped "Jellyfin" cert).
  - **Reuse from disk** — DUID already matches (no Samsung login), unchanged.

### Verification
- Release build: **0 errors**.
- Offline: loaded the bundled `Assets/Certificate/Jellyfin/author.p12` with its password and confirmed the private key matches the cert (same RSA modulus) — the `LoadKeyPairFromP12` premise holds on a real Tizen p12.
- **Needs a real TV + Samsung account** (couldn't run from CI): install to TV A → record `author.p12` SHA‑256 → install to TV B (Samsung login, distributor regenerated) → **author.p12 hash unchanged** → re-install/update an app on TV A → still overwrites. Please validate before merge.

### Scope / follow-up
Author-reuse only. **Multi-DUID distributor certs + manual DUID entry** (so one cert covers several TVs and you re-login less) remain in #396 as a follow-up — they depend on Samsung's endpoint signing a multi-`deviceid` CSR, which needs live testing.

No version bump.
