### PR TITLE
Release v2.5.7 (beta → master)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.5.4</CFBundleVersion>
+	<CFBundleVersion>2.5.7</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -1,6 +1,8 @@
 {
   "DownloadAndInstall": "Download & Install",
   "InstallationFailed": "Installation failed",
+  "connectionInterrupted": "The connection to your TV dropped during installation (\"connection reset by peer\"). This usually isn't a problem with the app — it's almost always a VPN, proxy, or \"secure DNS\" app on this computer capturing the route to your TV, or an unstable Wi-Fi link. Try this, then install again: 1) turn off any VPN / tunnel / secure-DNS app, 2) connect the TV by Ethernet or move it closer to the router, 3) make sure this computer and the TV are on the same network.",
+  "vpnDetectedWarning": "A VPN or tunnel adapter looks active ({0}). It can stop the app from finding your TV or break installs midway. If your TV isn't listed or installs fail, turn the VPN / proxy / secure-DNS app off and rescan.",
   "InstallationSuccessfulOn": "{0} has been successfully installed!",
   "DownloadFailed": "Download failed:",
   "FailedLoadingReleases": "Failed to load releases:",

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -118,7 +118,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.5.6";
+        public string AppVersion { get; set; } = "v2.5.7";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -31,6 +31,8 @@ namespace Apps2Samsung.Helpers.Core
             public const string ResignFailed = "Re-sign failed";
             public const string Failed = "failed";
             public const string NotInstalled = "failed[132]";
+            public const string TransportConnectionLost = "transport connection";
+            public const string ConnectionResetByPeer = "connection reset by peer";
         }
 
         /// <summary>
@@ -220,6 +222,8 @@ namespace Apps2Samsung.Helpers.Core
             public const string PackageAndSign = "packageAndSign";
             public const string InstallingPackage = "InstallingPackage";
             public const string InstallationFailed = "InstallationFailed";
+            public const string ConnectionInterrupted = "connectionInterrupted";
+            public const string VpnDetected = "vpnDetectedWarning";
             public const string InstallationSuccessful = "InstallationSuccessful";
             public const string InsufficientSpace = "insufficientSpace";
             public const string AuthorMismatch = "AuthorMismatch";

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/GitHubAuthHandler.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,8 +24,26 @@ namespace Apps2Samsung.Helpers.Core
         {
             var handler = new HttpClientHandler();
 
+            // Explicitly offer modern TLS. Legacy stacks — notably Windows 7 — default to
+            // TLS 1.0/1.1, which GitHub and Samsung now refuse at the handshake, surfacing as
+            // "The SSL connection could not be established". Requesting 1.2/1.3 lets those TVs
+            // negotiate TLS 1.2 (the highest Windows 7 SChannel supports when it's enabled).
+            try
+            {
+                handler.SslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13;
+            }
+            catch
+            {
+                try { handler.SslProtocols = SslProtocols.Tls12; } catch { /* fall back to OS default */ }
+            }
 
-            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS())
+            // Accept chain/name validation issues for the specific hosts we talk to on platforms
+            // whose trust store / TLS stack is unreliable: Linux (no unified store integration for
+            // these) and legacy Windows (7/8 — stale root certificates). Scoped to our known hosts,
+            // and only where the OS is already outside the supported set. Modern Windows/macOS keep
+            // full validation.
+            var legacyWindows = OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10);
+            if ((!OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS()) || legacyWindows)
             {
                 handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
                 {
@@ -34,9 +53,11 @@ namespace Apps2Samsung.Helpers.Core
                     var host = message.RequestUri?.Host ?? string.Empty;
                     if (host.EndsWith("samsung.com", StringComparison.OrdinalIgnoreCase) ||
                         host.EndsWith("samsungqbe.com", StringComparison.OrdinalIgnoreCase) ||
-                        host.EndsWith("tizen.org", StringComparison.OrdinalIgnoreCase))
+                        host.EndsWith("tizen.org", StringComparison.OrdinalIgnoreCase) ||
+                        host.EndsWith("github.com", StringComparison.OrdinalIgnoreCase) ||
+                        host.EndsWith("githubusercontent.com", StringComparison.OrdinalIgnoreCase))
                     {
-                        Trace.TraceWarning($"[SSL] Accepting Samsung cert with validation issue on Linux: {host} ({errors})");
+                        Trace.TraceWarning($"[SSL] Accepting cert with validation issue for {host} ({errors})");
                         return true;
                     }
 

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/PackageHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/PackageHelper.cs
@@ -28,7 +28,7 @@ namespace Apps2Samsung.Helpers.Core
 
             try
             {
-                string downloadPath = await _tizenInstaller.DownloadPackageAsync(selectedAsset.DownloadUrl);
+                string downloadPath = await _tizenInstaller.DownloadPackageAsync(selectedAsset.DownloadUrl, validateWgt: true);
                 progress?.Invoke("DownloadCompleted".Localized());
                 return downloadPath;
             }

--- a/Jellyfin2Samsung-CrossOS/Interfaces/INetworkService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/INetworkService.cs
@@ -17,5 +17,6 @@ namespace Apps2Samsung.Interfaces
         Task<string?> GetManufacturerFromIp(string ipAddress);
         bool IsDifferentSubnet(string ip1, string ip2);
         Task<IReadOnlyList<NetworkInterfaceOption>> GetNetworkInterfaceOptionsAsync();
+        string? GetActiveVpnAdapterName();
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
@@ -10,7 +10,7 @@ namespace Apps2Samsung.Interfaces
     {
         Task<string> GetTvNameAsync(string tvIpAddress);
         Task<string> EnsureTizenSdbAvailable();
-        Task<string> DownloadPackageAsync(string downloadUrl);
+        Task<string> DownloadPackageAsync(string downloadUrl, bool validateWgt = false);
         Task<InstallResult> InstallPackageAsync(string packageUrl, string tvIpAddress, CancellationToken cancellationToken, ProgressCallback? progress = null, Action? onSamsungLoginStarted = null);
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/NetworkService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/NetworkService.cs
@@ -199,6 +199,7 @@ namespace Apps2Samsung.Services
                 .SelectMany(ni => ni.GetIPProperties().UnicastAddresses)
                 .Where(ua => ua.Address.AddressFamily == AddressFamily.InterNetwork)
                 .Where(ua => !IPAddress.IsLoopback(ua.Address))
+                .Where(ua => IsScannableAddress(ua.Address))
                 .Where(ua => ua.IPv4Mask != null && !ua.IPv4Mask.Equals(IPAddress.Any))
                 .Select(ua => (Address: ua.Address, Mask: ua.IPv4Mask))
                 .ToList();
@@ -258,6 +259,110 @@ namespace Apps2Samsung.Services
 
             for (uint i = netInt + 1; i < broadInt; i++)
                 yield return UIntToIp(i);
+        }
+
+        // Ranges that can appear as a local interface but are never a real home LAN the TV
+        // lives on. Scanning them (typically a VPN / tunnel / "secure DNS" adapter sitting on
+        // 198.18.0.0/15 or CGNAT) wastes minutes probing phantom hosts and can divert the
+        // install route onto the tunnel, causing "connection reset by peer" mid-push.
+        // NOTE: the user-supplied custom IP bypasses this (added after the filter), so a
+        // deliberate TV address in an unusual range is still scanned.
+        private static readonly (uint Network, uint Mask)[] NonScannableRanges = BuildNonScannableRanges();
+
+        private static (uint, uint)[] BuildNonScannableRanges()
+        {
+            (uint, uint) R(string net, string mask) =>
+                (IpToUInt(IPAddress.Parse(net)), IpToUInt(IPAddress.Parse(mask)));
+
+            return new[]
+            {
+                R("169.254.0.0",  "255.255.0.0"),   // link-local / APIPA
+                R("100.64.0.0",   "255.192.0.0"),   // CGNAT (Tailscale, Cloudflare WARP, some ISPs)
+                R("198.18.0.0",   "255.254.0.0"),   // RFC 2544 benchmarking (VPN/proxy adapters)
+                R("192.0.2.0",    "255.255.255.0"), // TEST-NET-1
+                R("198.51.100.0", "255.255.255.0"), // TEST-NET-2
+                R("203.0.113.0",  "255.255.255.0"), // TEST-NET-3
+            };
+        }
+
+        private static bool IsScannableAddress(IPAddress ip)
+        {
+            uint addr = IpToUInt(ip);
+            foreach (var (network, mask) in NonScannableRanges)
+            {
+                if ((addr & mask) == (network & mask))
+                    return false;
+            }
+            return true;
+        }
+
+        // IPv4 ranges only an overlay/VPN hands out, used to spot an active tunnel adapter.
+        private static readonly (uint Network, uint Mask)[] VpnRanges =
+        {
+            (IpToUInt(IPAddress.Parse("100.64.0.0")), IpToUInt(IPAddress.Parse("255.192.0.0"))),   // CGNAT (Tailscale, WARP)
+            (IpToUInt(IPAddress.Parse("198.18.0.0")), IpToUInt(IPAddress.Parse("255.254.0.0"))),   // RFC 2544 (VPN/proxy)
+            (IpToUInt(IPAddress.Parse("25.0.0.0")),   IpToUInt(IPAddress.Parse("255.0.0.0"))),     // Hamachi
+        };
+
+        // Adapter name/description fragments that identify a known VPN / tunnel product.
+        private static readonly string[] VpnNameTokens =
+        {
+            "vpn", "wireguard", "wintun", "tap-windows", "openvpn", "tailscale", "zerotier",
+            "hamachi", "nordlynx", "mullvad", "proton", "expressvpn", "surfshark", "cloudflare warp",
+        };
+
+        private static bool IsVpnRange(IPAddress ip)
+        {
+            uint addr = IpToUInt(ip);
+            foreach (var (network, mask) in VpnRanges)
+            {
+                if ((addr & mask) == (network & mask))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Best-effort detection of an active VPN / tunnel adapter, so the UI can warn the user
+        /// before they blame the app for a TV that "won't be found". Returns the adapter's
+        /// description (or name) when one looks like a VPN, otherwise null. Heuristic only.
+        /// </summary>
+        public string? GetActiveVpnAdapterName()
+        {
+            try
+            {
+                foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+                {
+                    if (ni.OperationalStatus != OperationalStatus.Up ||
+                        ni.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+                        continue;
+
+                    static string Describe(NetworkInterface n) =>
+                        string.IsNullOrWhiteSpace(n.Description) ? n.Name : n.Description;
+
+                    // 1) Adapter type that is inherently a tunnel / dial-up VPN.
+                    if (ni.NetworkInterfaceType == NetworkInterfaceType.Tunnel ||
+                        ni.NetworkInterfaceType == NetworkInterfaceType.Ppp)
+                        return Describe(ni);
+
+                    // 2) Name/description matches a known VPN / tunnel product.
+                    var text = $"{ni.Name} {ni.Description}";
+                    if (VpnNameTokens.Any(t => text.Contains(t, StringComparison.OrdinalIgnoreCase)))
+                        return Describe(ni);
+
+                    // 3) An IPv4 in a range only a VPN/overlay hands out.
+                    if (ni.GetIPProperties().UnicastAddresses
+                        .Where(ua => ua.Address.AddressFamily == AddressFamily.InterNetwork)
+                        .Any(ua => IsVpnRange(ua.Address)))
+                        return Describe(ni);
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[VPN] detection failed: {ex.Message}");
+            }
+
+            return null;
         }
 
         private static uint IpToUInt(IPAddress ip)

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -189,19 +189,90 @@ namespace Apps2Samsung.Services
             var fileName = UrlHelper.GetFileNameFromUrl(downloadUrl);
             var localPath = Path.Combine(AppSettings.DownloadPath, fileName);
 
+            // Reuse a cached copy only if it's actually a valid archive. A previous download
+            // that was interrupted (network drop, VPN reset, app quit) can leave a truncated
+            // .wgt here; returning it blindly makes the patcher fail later with "End of Central
+            // Directory record could not be found". If the cached file is corrupt, drop it and
+            // re-download.
             if (File.Exists(localPath))
-                return localPath;
+            {
+                if (IsValidZipArchive(localPath))
+                    return localPath;
+
+                Trace.WriteLine($"[Download] Cached package is corrupt, re-downloading: {localPath}");
+                TryDelete(localPath);
+            }
 
             Directory.CreateDirectory(AppSettings.DownloadPath);
 
-            using var response = await _httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead);
-            response.EnsureSuccessStatusCode();
+            // Download to a temp file and only promote it to the final path once the transfer
+            // completes and validates, so an interrupted download never poisons the cache.
+            var tempPath = localPath + ".part";
+            TryDelete(tempPath);
 
-            await using var contentStream = await response.Content.ReadAsStreamAsync();
-            await using var fileStream = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
-            await contentStream.CopyToAsync(fileStream);
+            try
+            {
+                using var response = await _httpClient.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead);
+                response.EnsureSuccessStatusCode();
 
-            return localPath;
+                await using (var contentStream = await response.Content.ReadAsStreamAsync())
+                await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    await contentStream.CopyToAsync(fileStream);
+                }
+
+                // If the server advertised a size, make sure we got all of it.
+                var expected = response.Content.Headers.ContentLength;
+                var actual = new FileInfo(tempPath).Length;
+                if (expected.HasValue && actual != expected.Value)
+                    throw new IOException($"Download incomplete: received {actual} of {expected.Value} bytes.");
+
+                // .wgt is a zip — if the trailer isn't there, the file is truncated/corrupt.
+                if (!IsValidZipArchive(tempPath))
+                    throw new InvalidDataException("Downloaded package is not a valid .wgt archive (corrupt or incomplete).");
+
+                File.Move(tempPath, localPath, overwrite: true);
+                return localPath;
+            }
+            catch
+            {
+                TryDelete(tempPath);
+                throw;
+            }
+        }
+
+        // A .wgt is a zip archive. Opening it and reading the entry table forces the zip
+        // reader to locate the End-of-Central-Directory record, so a truncated/empty file
+        // fails here instead of deep inside the patcher.
+        private static bool IsValidZipArchive(string path)
+        {
+            try
+            {
+                // 22 bytes is the minimum size of an empty zip (the EOCD record alone),
+                // so anything smaller can't be a real package.
+                if (new FileInfo(path).Length < 22)
+                    return false;
+
+                using var archive = System.IO.Compression.ZipFile.OpenRead(path);
+                return archive.Entries.Count > 0;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[Download] Could not delete '{path}': {ex.Message}");
+            }
         }
 
         #endregion
@@ -692,6 +763,20 @@ namespace Apps2Samsung.Services
             Action? onSamsungLoginStarted)
         {
             var installResults = await InstallPackageOnDeviceAsync(tvIpAddress, packageUrl, sdkToolPath);
+
+            // Transport / connection failure (e.g. "Unable to read data from the transport
+            // connection: Connection reset by peer"). Environmental — a VPN/proxy/firewall on
+            // the host capturing the route to the TV, or an unstable Wi-Fi link — not a packaging
+            // problem, so retrying or overwriting can't help. Fail fast with an actionable hint
+            // instead of looping a re-sign+re-push over the same broken route.
+            if (installResults.Output.Contains(Constants.TizenErrorCodes.TransportConnectionLost, StringComparison.OrdinalIgnoreCase) ||
+                installResults.Output.Contains(Constants.TizenErrorCodes.ConnectionResetByPeer, StringComparison.OrdinalIgnoreCase))
+            {
+                _appSettings.TryOverwrite = false;
+                progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
+                Trace.WriteLine($"[Install] Transport connection lost to {tvIpAddress}: {installResults.Output}");
+                return InstallResult.FailureResult(Constants.LocalizationKeys.ConnectionInterrupted.Localized());
+            }
 
             // Handle insufficient space error
             if (installResults.Output.Contains(Constants.TizenErrorCodes.DownloadFailed116))

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -184,19 +184,20 @@ namespace Apps2Samsung.Services
             }
         }
 
-        public async Task<string> DownloadPackageAsync(string downloadUrl)
+        // <paramref name="validateWgt"/>: the download is a .wgt (a zip) and should be verified
+        // as a valid archive. Off for non-archive downloads like the raw Tizen SDB binary.
+        public async Task<string> DownloadPackageAsync(string downloadUrl, bool validateWgt = false)
         {
             var fileName = UrlHelper.GetFileNameFromUrl(downloadUrl);
             var localPath = Path.Combine(AppSettings.DownloadPath, fileName);
 
-            // Reuse a cached copy only if it's actually a valid archive. A previous download
-            // that was interrupted (network drop, VPN reset, app quit) can leave a truncated
-            // .wgt here; returning it blindly makes the patcher fail later with "End of Central
-            // Directory record could not be found". If the cached file is corrupt, drop it and
-            // re-download.
+            // Reuse a cached copy. For a .wgt, only if it's actually a valid archive: a previous
+            // download that was interrupted (network drop, VPN reset, app quit) can leave a
+            // truncated file here, and returning it blindly makes the patcher fail later with
+            // "End of Central Directory record could not be found". If corrupt, drop and re-download.
             if (File.Exists(localPath))
             {
-                if (IsValidZipArchive(localPath))
+                if (!validateWgt || IsValidZipArchive(localPath))
                     return localPath;
 
                 Trace.WriteLine($"[Download] Cached package is corrupt, re-downloading: {localPath}");
@@ -228,7 +229,7 @@ namespace Apps2Samsung.Services
                     throw new IOException($"Download incomplete: received {actual} of {expected.Value} bytes.");
 
                 // .wgt is a zip — if the trailer isn't there, the file is truncated/corrupt.
-                if (!IsValidZipArchive(tempPath))
+                if (validateWgt && !IsValidZipArchive(tempPath))
                     throw new InvalidDataException("Downloaded package is not a valid .wgt archive (corrupt or incomplete).");
 
                 File.Move(tempPath, localPath, overwrite: true);

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -324,7 +324,15 @@ namespace Apps2Samsung.Services
             {
                 progress?.Invoke($"Installation error: {ex}");
                 _appSettings.TryOverwrite = false;
-                return InstallResult.FailureResult(ex.Message);
+
+                // Surface the innermost cause too — outer messages like "The SSL connection could
+                // not be established, see inner exception" are useless on their own (e.g. an old
+                // Windows 7 TLS stack rejecting GitHub's certificate chain).
+                var baseEx = ex.GetBaseException();
+                var detail = baseEx.Message != ex.Message
+                    ? $"{ex.Message} ({baseEx.Message})"
+                    : ex.Message;
+                return InstallResult.FailureResult(detail);
             }
             finally
             {

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -77,6 +77,21 @@ namespace Apps2Samsung.ViewModels
         [ObservableProperty]
         private bool darkMode;
 
+        [ObservableProperty]
+        private string vpnWarning = string.Empty;
+
+        public bool HasVpnWarning => !string.IsNullOrEmpty(VpnWarning);
+
+        partial void OnVpnWarningChanged(string value) => OnPropertyChanged(nameof(HasVpnWarning));
+
+        private void RefreshVpnWarning()
+        {
+            var adapter = _networkService.GetActiveVpnAdapterName();
+            VpnWarning = string.IsNullOrEmpty(adapter)
+                ? string.Empty
+                : string.Format(L("vpnDetectedWarning"), adapter);
+        }
+
         private string _currentStatusKey = string.Empty;
 
         private string? _downloadedPackagePath;
@@ -136,6 +151,7 @@ namespace Apps2Samsung.ViewModels
         private void OnLanguageChanged(object? sender, EventArgs e)
         {
             RefreshLocalizedProperties();
+            RefreshVpnWarning();
 
             if (!string.IsNullOrEmpty(_currentStatusKey))
                 StatusBar = L(_currentStatusKey);
@@ -758,6 +774,7 @@ namespace Apps2Samsung.ViewModels
         {
             IsLoadingDevices = true;
             AvailableDevices.Clear();
+            RefreshVpnWarning();
 
             try
             {

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -278,7 +278,7 @@ namespace Apps2Samsung.ViewModels
                 token.ThrowIfCancellationRequested();
 
                 SetStatus("ScanningNetwork");
-                //await LoadDevicesAsync(token);
+                await LoadDevicesAsync(token);
                 CustomWgtPath = AppSettings.Default.CustomWgtPath ?? "";
             }
             catch (OperationCanceledException)
@@ -434,7 +434,7 @@ namespace Apps2Samsung.ViewModels
                 if (!AvailableDevices.Any(d => d.IpAddress != L("lblOther")))
                 {
                     SetStatus("ScanningNetwork");
-                    //await LoadDevicesAsync(token);
+                    await LoadDevicesAsync(token);
                 }
 
                 CustomWgtPath = AppSettings.Default.CustomWgtPath ?? "";

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -258,6 +258,10 @@ namespace Apps2Samsung.ViewModels
                 // Check for updates first (non-blocking, runs in background)
                 _ = CheckForUpdatesAsync();
 
+                // Evaluate the VPN/tunnel warning up front, independent of the (slow) network
+                // scan, so the banner appears immediately on startup.
+                RefreshVpnWarning();
+
                 SetStatus("CheckingTizenSdb");
 
                 string tizenSdb = await _tizenInstaller.EnsureTizenSdbAvailable();
@@ -274,7 +278,7 @@ namespace Apps2Samsung.ViewModels
                 token.ThrowIfCancellationRequested();
 
                 SetStatus("ScanningNetwork");
-                await LoadDevicesAsync(token);
+                //await LoadDevicesAsync(token);
                 CustomWgtPath = AppSettings.Default.CustomWgtPath ?? "";
             }
             catch (OperationCanceledException)
@@ -430,7 +434,7 @@ namespace Apps2Samsung.ViewModels
                 if (!AvailableDevices.Any(d => d.IpAddress != L("lblOther")))
                 {
                     SetStatus("ScanningNetwork");
-                    await LoadDevicesAsync(token);
+                    //await LoadDevicesAsync(token);
                 }
 
                 CustomWgtPath = AppSettings.Default.CustomWgtPath ?? "";

--- a/Jellyfin2Samsung-CrossOS/Views/AppIconsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/AppIconsView.axaml
@@ -9,7 +9,7 @@
              x:Class="Apps2Samsung.Views.AppIconsView"
              x:DataType="viewModels:AppIconsViewModel">
 
-	<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,0">
+	<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,16">
 		<StackPanel Spacing="12">
 
 			<TextBlock Text="{Binding LblAppIcons}"
@@ -56,6 +56,8 @@
 				</StackPanel>
 			</Grid>
 
+		<!-- bottom slack: ScrollViewer under-measures wrapping content, so guarantee the last row clears the fold -->
+			<Border Height="40"/>
 		</StackPanel>
 	</ScrollViewer>
 </UserControl>

--- a/Jellyfin2Samsung-CrossOS/Views/AppSettingsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/AppSettingsView.axaml
@@ -8,7 +8,7 @@
              x:Class="Apps2Samsung.Views.AppSettingsView"
              x:DataType="viewModels:AppSettingsViewModel">
 
-	<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,0">
+	<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,16">
 		<StackPanel Spacing="16">
 
 			<!-- Application Settings Section -->
@@ -233,6 +233,8 @@
 				</Grid>
 			</StackPanel>
 
+		<!-- bottom slack: ScrollViewer under-measures wrapping content, so guarantee the last row clears the fold -->
+			<Border Height="40"/>
 		</StackPanel>
 	</ScrollViewer>
 </UserControl>

--- a/Jellyfin2Samsung-CrossOS/Views/JellyfinSettingsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/JellyfinSettingsView.axaml
@@ -12,7 +12,7 @@
 
 		<!-- TAB: Server & Auto-Login -->
 		<TabItem Header="{Binding LblTabServer}">
-			<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,0">
+			<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,16">
 				<StackPanel Spacing="16">
 
 					<!-- Jellyfin-only notice -->

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -6,7 +6,7 @@
 		xmlns:helpers="clr-namespace:Apps2Samsung.Helpers.Converters"
 		xmlns:fa="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
         Width="580"
-        Height="410"
+        SizeToContent="Height"
         WindowStartupLocation="CenterScreen"
         Title="Apps2Samsung">
 	<Window.Resources>
@@ -51,10 +51,10 @@
 			<Border Background="#FFF3CD" CornerRadius="6" Padding="12,10"
 			        BorderBrush="#FFE69C" BorderThickness="1"
 			        IsVisible="{Binding HasVpnWarning}">
-				<StackPanel Orientation="Horizontal" Spacing="10">
-					<fa:SymbolIcon Symbol="Important" Width="18" Height="18" Foreground="#856404" VerticalAlignment="Top"/>
-					<TextBlock Text="{Binding VpnWarning}" Foreground="#856404" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"/>
-				</StackPanel>
+				<Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+					<fa:SymbolIcon Grid.Column="0" Symbol="Important" Width="18" Height="18" Foreground="#856404" VerticalAlignment="Top"/>
+					<TextBlock Grid.Column="1" Text="{Binding VpnWarning}" Foreground="#856404" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"/>
+				</Grid>
 			</Border>
 
 			<!-- Form fields - side by side layout -->

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -47,6 +47,16 @@
 				</StackPanel>
 			</Border>
 
+			<!-- VPN / tunnel adapter warning -->
+			<Border Background="#FFF3CD" CornerRadius="6" Padding="12,10"
+			        BorderBrush="#FFE69C" BorderThickness="1"
+			        IsVisible="{Binding HasVpnWarning}">
+				<StackPanel Orientation="Horizontal" Spacing="10">
+					<fa:SymbolIcon Symbol="Important" Width="18" Height="18" Foreground="#856404" VerticalAlignment="Top"/>
+					<TextBlock Text="{Binding VpnWarning}" Foreground="#856404" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"/>
+				</StackPanel>
+			</Border>
+
 			<!-- Form fields - side by side layout -->
 			<StackPanel Spacing="18">
 

--- a/Jellyfin2Samsung-CrossOS/Views/SettingsWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/SettingsWindow.axaml
@@ -9,7 +9,9 @@
         x:DataType="viewModels:SettingsWindowViewModel"
         Title="Settings"
         Width="880"
-        Height="850">
+        Height="680"
+        MinHeight="420"
+        WindowStartupLocation="CenterScreen">
 
 	<Window.Styles>
 		<StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.xaml"/>
@@ -17,6 +19,17 @@
 		<StyleInclude Source="avares://Apps2Samsung/Styles/Buttons.axaml"/>
 		<StyleInclude Source="avares://Apps2Samsung/Styles/TextBlocks.axaml"/>
 		<StyleInclude Source="avares://Apps2Samsung/Styles/ComboBoxes.axaml"/>
+
+		<!-- Keep section scrollbars visible (the Fluent default fades to a near-invisible
+		     overlay, making long settings lists look unscrollable / the last row "clipped"). -->
+		<Style Selector="ScrollViewer">
+			<Setter Property="AllowAutoHide" Value="False"/>
+			<Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
+			<!-- Horizontal disabled so content is measured at the real (wrapped) width; with
+			     horizontal scroll enabled the ScrollViewer under-measures the vertical extent and
+			     the last row becomes unreachable. -->
+			<Setter Property="HorizontalScrollBarVisibility" Value="Disabled"/>
+		</Style>
 	</Window.Styles>
 
 	<Border Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
@@ -95,7 +108,9 @@
 				</ListBox>
 
 				<ContentControl Grid.Column="1"
-								Content="{Binding SelectedSection.Content}"/>
+								Content="{Binding SelectedSection.Content}"
+								HorizontalContentAlignment="Stretch"
+								VerticalContentAlignment="Stretch"/>
 
 			</Grid>
 		</Grid>

--- a/Jellyfin2Samsung-CrossOS/Views/TvAppSettingsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/TvAppSettingsView.axaml
@@ -9,7 +9,7 @@
              x:Class="Apps2Samsung.Views.TvAppSettingsView"
              x:DataType="viewModels:TvAppSettingsViewModel">
 
-	<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,0">
+	<ScrollViewer VerticalScrollBarVisibility="Auto" Padding="0,12,20,16">
 		<StackPanel Spacing="16">
 
 			<!-- TVApp-only notice -->
@@ -102,6 +102,8 @@
 				</StackPanel>
 			</Button>
 
+		<!-- bottom slack: ScrollViewer under-measures wrapping content, so guarantee the last row clears the fold -->
+			<Border Height="40"/>
 		</StackPanel>
 	</ScrollViewer>
 </UserControl>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.5.6](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.6)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.5.7-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.7-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
Promotes **beta → master** to publish **v2.5.7** stable.

### ✨ New since 2.5.6
- **VPN / tunnel warning** — the main screen warns when a VPN, proxy, or "secure DNS" adapter is active (a common cause of the app not finding or installing to a TV).
- **Smarter network scan** — skips VPN/tunnel and reserved IP ranges, so scans are faster and no longer chase phantom hosts or route installs through a tunnel.

### 🛠️ Fixes
- **Windows 7 downloads (#415)** — request modern TLS (1.2/1.3) and tolerate older certificate stores so downloads work on legacy Windows (best-effort; TLS 1.2 must be enabled in the OS).
- **Clearer install errors** — a dropped connection ("connection reset by peer") shows an actionable hint instead of silently retrying, and failures surface the real underlying cause.
- **Corrupt download recovery** — validate the downloaded package and re-download if a previous attempt left it incomplete (fixes "End of Central Directory record could not be found").
- **Settings window** — the Application list no longer clips its bottom row; scrollbars stay visible.
- **Main window** — resizes correctly so nothing gets cut off.
- **Release list** — the version dropdown scrollbar is now visible and usable.

**Full Changelog**: https://github.com/Apps2Samsung/Apps2Samsung/compare/v2.5.6...beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
