### PR TITLE
Fix docker-build.sh after Jellyfin2Samsung → Apps2Samsung rename (#417)

docker-build.sh still targets the pre-rename project, so it fails on
current master:

    MSBUILD : error MSB1009: Project file does not exist.
    Switch: Jellyfin2Samsung-CrossOS/Jellyfin2Samsung.csproj

#361 renamed the csproj/assembly to Apps2Samsung but did not update the
build
script. Fix - point the two hardcoded paths (and the header comment) at
the new name:

- PROJECT → Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
- BIN     → .../publish/Apps2Samsung

Verified: ran ./docker-build.sh on current master (v2.5.7) in the
sdk:8.0
container - publish succeeds and produces the Apps2Samsung binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@
 
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
-| **Stable** | [v2.5.6](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.6)                                        | Recommended for most users   |
-| **Beta**   | [v2.5.7-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.7-beta)                                            | Includes new features        |
+| **Stable** | [v2.5.7](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.7)                                        | Recommended for most users   |
+| **Beta**   | [N/A](#)                                            | Includes new features        |
 
 <!-- versions:end -->
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build Jellyfin2Samsung from source inside the .NET 8 SDK container.
+# Build Apps2Samsung from source inside the .NET 8 SDK container.
 # No host dotnet install needed. Output is owned by the current user.
 #
 # Usage:
@@ -10,8 +10,8 @@
 set -euo pipefail
 
 IMAGE="mcr.microsoft.com/dotnet/sdk:8.0"
-PROJECT="Jellyfin2Samsung-CrossOS/Jellyfin2Samsung.csproj"
-BIN="Jellyfin2Samsung-CrossOS/bin/Release/net8.0/linux-x64/publish/Jellyfin2Samsung"
+PROJECT="Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj"
+BIN="Jellyfin2Samsung-CrossOS/bin/Release/net8.0/linux-x64/publish/Apps2Samsung"
 
 # Repo root = dir this script lives in.
 cd "$(dirname "$(readlink -f "$0")")"


### PR DESCRIPTION
# Pull Request Template

## Branch
- [ ] I branched off beta (not master) to develop this feature/fix

## Description

Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.

Fixes # (issue number, if applicable)

---

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [ ] My code follows the existing project structure and style  
- [ ] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [ ] I have verified that the installer still works with the underlying CLI  

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
