### PR TITLE
Auto-detect OS language on first run (#421)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -52,7 +52,10 @@ namespace Apps2Samsung.Helpers
         public static AppSettings Default => _instance ??= Load();
 
         // ----- User-scoped settings -----
-        public string Language { get; set; } = "en";
+        // Empty = no choice made yet → on first run the app auto-detects the OS
+        // language (falling back to English) and then persists the result here.
+        // Existing installs already have a concrete value, so they're never changed.
+        public string Language { get; set; } = "";
         public string Certificate { get; set; } = "Jelly2Sams";
         public bool DeletePreviousInstall { get; set; } = false;
         public string UserCustomIP { get; set; } = "";

--- a/Jellyfin2Samsung-CrossOS/Services/LocalizationService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/LocalizationService.cs
@@ -61,7 +61,8 @@ namespace Apps2Samsung.Services
                 TryLoadLanguage(DefaultLanguage);
             }
 
-            var systemLang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+            // Prefer the OS *display* language (CurrentUICulture) for detection.
+            var systemLang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
             var configLang = AppSettings.Default.Language;
 
             var initialLang =
@@ -72,6 +73,16 @@ namespace Apps2Samsung.Services
                         : DefaultLanguage;
 
             SetLanguage(initialLang);
+
+            // First run (no stored language): commit the detected language so the
+            // settings dropdown reflects it and it stays stable across launches
+            // (detect-once, not "follow the OS forever"). Existing installs already
+            // have a value, so this never overrides an explicit choice.
+            if (string.IsNullOrWhiteSpace(configLang) && !string.IsNullOrWhiteSpace(_currentLanguage))
+            {
+                AppSettings.Default.Language = _currentLanguage;
+                AppSettings.Default.Save();
+            }
         }
 
         private void TryLoadLanguage(string lang)


### PR DESCRIPTION
Closes #421.

**Cause:** `AppSettings.Language` defaulted to `"en"`, so it was never empty — and the OS-language detection already present in `LocalizationService` (which only kicks in when no language is configured) never ran. The app always opened in English.

**Fix (one-line default + persist):**
- `AppSettings.Language` now defaults to `""` = "no choice yet".
- On first run, the existing logic resolves the OS **display** language (`CurrentUICulture`), uses it when a matching translation exists, else English, and now **persists** the resolved value so it's stable and the settings dropdown reflects it (detect-once, not follow-the-OS-forever).

**Migration / scope (per decision):** new installs only.
| Case | Result |
|---|---|
| Fresh install, supported OS lang | that language |
| Fresh install, unsupported OS lang | English |
| Existing install (has a stored language) | unchanged — never silently flipped |

Existing users (incl. the PT requester) keep their stored language and change it once manually if wanted — this deliberately avoids force-switching the many users who run English UIs on a localized OS.

`dotnet build`: 0 errors.