### PR TITLE
Release v2.6.0

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.5.7</CFBundleVersion>
+	<CFBundleVersion>2.6.0</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -199,5 +199,6 @@
   "catalogColDescription": "Description",
   "catalogColApplication": "Application",
   "catalogNoPreview": "No preview available",
-  "catalogNoThumbnail": "This app has no thumbnail yet."
+  "catalogNoThumbnail": "This app has no thumbnail yet.",
+  "catalogColVersion": "Version"
 }

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/nl.json
@@ -170,5 +170,6 @@
   "catalogColDescription": "Omschrijving",
   "catalogColApplication": "Applicatie",
   "catalogNoPreview": "Geen voorbeeld beschikbaar",
-  "catalogNoThumbnail": "Deze app heeft nog geen thumbnail."
+  "catalogNoThumbnail": "Deze app heeft nog geen thumbnail.",
+  "catalogColVersion": "Versie"
 }

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -52,7 +52,10 @@ namespace Apps2Samsung.Helpers
         public static AppSettings Default => _instance ??= Load();
 
         // ----- User-scoped settings -----
-        public string Language { get; set; } = "en";
+        // Empty = no choice made yet → on first run the app auto-detects the OS
+        // language (falling back to English) and then persists the result here.
+        // Existing installs already have a concrete value, so they're never changed.
+        public string Language { get; set; } = "";
         public string Certificate { get; set; } = "Jelly2Sams";
         public bool DeletePreviousInstall { get; set; } = false;
         public string UserCustomIP { get; set; } = "";

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -121,7 +121,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.5.7";
+        public string AppVersion { get; set; } = "v2.6.0";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Models/BuildVersion.cs
+++ b/Jellyfin2Samsung-CrossOS/Models/BuildVersion.cs
@@ -7,5 +7,6 @@ namespace Apps2Samsung.Models
         [ObservableProperty] private string fileName = string.Empty;
         [ObservableProperty] private string description = string.Empty;
         [ObservableProperty] private string repoUrl = string.Empty;
+        [ObservableProperty] private string version = string.Empty;
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml.Styling;
@@ -6,8 +6,12 @@ using Avalonia.Media;
 using Avalonia.Styling;
 using Apps2Samsung.Helpers;
 using Apps2Samsung.Interfaces;
+using Apps2Samsung.Extensions;
 using System;
 using System.Threading.Tasks;
+using System.IO;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace Apps2Samsung.Services
 {
@@ -166,14 +170,110 @@ namespace Apps2Samsung.Services
         public async Task ShowErrorAsync(string message)
         {
             var window = GetMainWindow();
-            var dialog = CreateStyledDialog("Error", new TextBlock
+            Control contentControl;
+            
+            var logIndex = message.IndexOf("\n[Log written to:");
+            if (logIndex >= 0)
             {
-                Text = message,
-                TextWrapping = TextWrapping.Wrap,
-                Foreground = Brushes.Red,
-                FontSize = 14,
-                Margin = new Thickness(0, 5, 0, 0)
-            });
+                var mainMessage = message.Substring(0, logIndex).Trim();
+                var logMessage = message.Substring(logIndex).Trim();
+
+                var stackPanel = new StackPanel { Spacing = 5, Orientation = Orientation.Vertical };
+                
+                stackPanel.Children.Add(new TextBlock
+                {
+                    Text = mainMessage,
+                    TextWrapping = TextWrapping.Wrap,
+                    Foreground = Brushes.Red,
+                    FontSize = 14,
+                    Margin = new Thickness(0, 5, 0, 0)
+                });
+
+                var buttonContent = new StackPanel
+                {
+                    Orientation = Orientation.Horizontal,
+                    Spacing = 6
+                };
+                buttonContent.Children.Add(new FluentAvalonia.UI.Controls.SymbolIcon 
+                { 
+                    Symbol = FluentAvalonia.UI.Controls.Symbol.Folder, 
+                    Width = 16, 
+                    Height = 16 
+                });
+                buttonContent.Children.Add(new TextBlock 
+                { 
+                    Text = "lblOpenLogsFolder".Localized(),
+                    FontWeight = FontWeight.Bold
+                });
+
+                var openLogsButton = new Button
+                {
+                    Content = buttonContent,
+                    Background = new SolidColorBrush(Color.Parse("#2C3E50")),
+                    Foreground = Brushes.White,
+                    Cursor = new Avalonia.Input.Cursor(Avalonia.Input.StandardCursorType.Hand),
+                    CornerRadius = new CornerRadius(6),
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    Margin = new Thickness(0, 15, 0, 15),
+                    Padding = new Thickness(10, 6)
+                };
+
+                openLogsButton.Click += (_, _) =>
+                {
+                    try
+                    {
+                        var logFolder = Path.Combine(AppContext.BaseDirectory, "Logs");
+                        Directory.CreateDirectory(logFolder);
+
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            Process.Start(new ProcessStartInfo { FileName = "explorer.exe", Arguments = $"\"{logFolder}\"", UseShellExecute = true });
+                        }
+                        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        {
+                            Process.Start(new ProcessStartInfo { FileName = "open", Arguments = $"\"{logFolder}\"", UseShellExecute = false });
+                        }
+                        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        {
+                            Process.Start(new ProcessStartInfo { FileName = "xdg-open", Arguments = $"\"{logFolder}\"", UseShellExecute = false });
+                        }
+                        else
+                        {
+                            Process.Start(new ProcessStartInfo { FileName = logFolder, UseShellExecute = true });
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.WriteLine($"Failed to open Logs folder: {ex}");
+                    }
+                };
+
+                stackPanel.Children.Add(openLogsButton);
+                
+                stackPanel.Children.Add(new TextBlock
+                {
+                    Text = logMessage,
+                    TextWrapping = TextWrapping.Wrap,
+                    Foreground = Brushes.Red,
+                    FontSize = 14,
+                    Margin = new Thickness(0, 5, 0, 0)
+                });
+
+                contentControl = stackPanel;
+            }
+            else
+            {
+                contentControl = new TextBlock
+                {
+                    Text = message,
+                    TextWrapping = TextWrapping.Wrap,
+                    Foreground = Brushes.Red,
+                    FontSize = 14,
+                    Margin = new Thickness(0, 5, 0, 0)
+                };
+            }
+
+            var dialog = CreateStyledDialog("Error", contentControl);
 
             if (window != null)
                 await dialog.ShowDialog(window);

--- a/Jellyfin2Samsung-CrossOS/Services/LocalizationService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/LocalizationService.cs
@@ -61,7 +61,8 @@ namespace Apps2Samsung.Services
                 TryLoadLanguage(DefaultLanguage);
             }
 
-            var systemLang = CultureInfo.CurrentCulture.TwoLetterISOLanguageName;
+            // Prefer the OS *display* language (CurrentUICulture) for detection.
+            var systemLang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
             var configLang = AppSettings.Default.Language;
 
             var initialLang =
@@ -72,6 +73,16 @@ namespace Apps2Samsung.Services
                         : DefaultLanguage;
 
             SetLanguage(initialLang);
+
+            // First run (no stored language): commit the detected language so the
+            // settings dropdown reflects it and it stays stable across launches
+            // (detect-once, not "follow the OS forever"). Existing installs already
+            // have a value, so this never overrides an explicit choice.
+            if (string.IsNullOrWhiteSpace(configLang) && !string.IsNullOrWhiteSpace(_currentLanguage))
+            {
+                AppSettings.Default.Language = _currentLanguage;
+                AppSettings.Default.Save();
+            }
         }
 
         private void TryLoadLanguage(string lang)

--- a/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
@@ -15,6 +15,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -72,6 +73,10 @@ namespace Apps2Samsung.ViewModels
 
         private static readonly HttpClient _http = new();
         private static readonly ProviderManifestService _manifestService = new(_http);
+
+        // GitHub's API requires a User-Agent (and benefits from the auth token);
+        // the DI client has both. Fall back to the bare client if unavailable.
+        private readonly HttpClient _apiHttp = App.Services.GetService<HttpClient>() ?? _http;
         private readonly Dictionary<string, Bitmap?> _bitmapCache = new(StringComparer.OrdinalIgnoreCase);
         private ProviderManifest _manifest = new();
 
@@ -92,6 +97,7 @@ namespace Apps2Samsung.ViewModels
         public string LblColFileName => L("catalogColFileName");
         public string LblColDescription => L("catalogColDescription");
         public string LblColApplication => L("catalogColApplication");
+        public string LblColVersion => L("catalogColVersion");
         public string LblNoPreview => L("catalogNoPreview");
         public string LblNoThumbnail => L("catalogNoThumbnail");
         public string LblClose => L("btn_Close");
@@ -106,6 +112,7 @@ namespace Apps2Samsung.ViewModels
             OnPropertyChanged(nameof(LblColFileName));
             OnPropertyChanged(nameof(LblColDescription));
             OnPropertyChanged(nameof(LblColApplication));
+            OnPropertyChanged(nameof(LblColVersion));
             OnPropertyChanged(nameof(LblNoPreview));
             OnPropertyChanged(nameof(LblNoThumbnail));
             OnPropertyChanged(nameof(LblClose));
@@ -161,7 +168,15 @@ namespace Apps2Samsung.ViewModels
                 JellyfinVersions.Clear();
                 CommunityApps.Clear();
 
+                // Core Jellyfin builds come from one upstream release; tag their rows
+                // with that provider's URL so they all get its release version.
+                var coreUrl = _manifest.Providers
+                    .FirstOrDefault(p => p.Url?.Contains("jellyfin-tizen-builds", StringComparison.OrdinalIgnoreCase) == true)
+                    ?.Url ?? string.Empty;
+
                 ParseVersionsTable(jellyfinMd, JellyfinVersions);
+                foreach (var v in JellyfinVersions)
+                    v.RepoUrl = coreUrl;
 
                 foreach (var provider in _manifest.Providers)
                 {
@@ -171,7 +186,8 @@ namespace Apps2Samsung.ViewModels
                     JellyfinVersions.Add(new BuildVersion
                     {
                         FileName = provider.BuildInfo.Name,
-                        Description = provider.BuildInfo.Description
+                        Description = provider.BuildInfo.Description,
+                        RepoUrl = provider.Url ?? string.Empty
                     });
                 }
 
@@ -189,6 +205,10 @@ namespace Apps2Samsung.ViewModels
             {
                 _isLoading = false;
             }
+
+            // Community versions come from the README; Jellyfin + forks are fetched
+            // from their GitHub release (the same source the installer uses).
+            await ApplyProviderVersionsAsync();
 
             // Do a single authoritative rebuild after load finishes
             var version = Interlocked.Increment(ref _rebuildVersion);
@@ -286,6 +306,53 @@ namespace Apps2Samsung.ViewModels
             });
         }
 
+        // Fetch each distinct provider URL's latest release tag once and apply it
+        // to every row from that provider (core builds share one release tag).
+        private async Task ApplyProviderVersionsAsync()
+        {
+            var urls = JellyfinVersions
+                .Select(v => v.RepoUrl)
+                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            foreach (var url in urls)
+            {
+                var tag = await GetLatestReleaseTagAsync(url);
+                if (string.IsNullOrWhiteSpace(tag))
+                    continue;
+
+                foreach (var v in JellyfinVersions)
+                    if (string.Equals(v.RepoUrl, url, StringComparison.OrdinalIgnoreCase))
+                        v.Version = tag;
+            }
+        }
+
+        private async Task<string> GetLatestReleaseTagAsync(string url)
+        {
+            try
+            {
+                var json = (await _apiHttp.GetStringAsync(url)).TrimStart();
+
+                // A releases endpoint returns an array; a pinned .../releases/tags/<tag>
+                // endpoint returns a single object.
+                if (json.StartsWith("["))
+                {
+                    var list = JsonSerializer.Deserialize<List<GitHubRelease>>(json, JsonSerializerOptionsProvider.Default);
+                    var first = list?.FirstOrDefault();
+                    return first?.TagName ?? first?.Name ?? string.Empty;
+                }
+
+                var single = JsonSerializer.Deserialize<GitHubRelease>(json, JsonSerializerOptionsProvider.Default);
+                return single?.TagName ?? single?.Name ?? string.Empty;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"Failed to fetch release tag from {url}: {ex.Message}");
+                return string.Empty;
+            }
+        }
+
         private async Task<Bitmap?> LoadBitmapAsync(string url)
         {
             if (_bitmapCache.TryGetValue(url, out var cached))
@@ -348,38 +415,73 @@ namespace Apps2Samsung.ViewModels
             }
         }
 
+        // Header-driven so the README's column order/count can change (e.g. adding a
+        // Version column) without breaking parsing. Columns are located by header text.
         private void ParseApplicationsTable(string md, ObservableCollection<BuildVersion> target)
         {
-            var match = RegexPatterns.BuildInfo.ApplicationsTable.Match(md);
-            if (!match.Success) return;
+            var lines = md.Replace("\r\n", "\n").Split('\n');
 
-            var table = match.Groups["table"].Value;
-            var rows = RegexPatterns.BuildInfo.TableRow3Columns.Matches(table);
-
-            bool headerSkipped = false;
-
-            foreach (System.Text.RegularExpressions.Match row in rows)
+            int headerIdx = -1;
+            for (int i = 0; i < lines.Length; i++)
             {
-                var col1 = row.Groups[1].Value.Trim();
-                var col2 = row.Groups[2].Value.Trim();
-                var col3 = row.Groups[3].Value.Trim();
-
-                if (!headerSkipped && col1.Contains("Application", StringComparison.OrdinalIgnoreCase))
+                var l = lines[i].TrimStart();
+                if (l.StartsWith("|")
+                    && l.Contains("Application", StringComparison.OrdinalIgnoreCase)
+                    && l.Contains("Description", StringComparison.OrdinalIgnoreCase))
                 {
-                    headerSkipped = true;
-                    continue;
+                    headerIdx = i;
+                    break;
                 }
+            }
+            if (headerIdx < 0) return;
 
-                if (col1.StartsWith("-"))
-                    continue;
+            var headers = SplitTableRow(lines[headerIdx]);
+            int nameCol = FindColumn(headers, "Application");
+            int descCol = FindColumn(headers, "Description");
+            int verCol = FindColumn(headers, "Version");
+            if (nameCol < 0 || descCol < 0) return;
+
+            for (int i = headerIdx + 1; i < lines.Length; i++)
+            {
+                if (!lines[i].TrimStart().StartsWith("|"))
+                    break; // table ended
+
+                var cells = SplitTableRow(lines[i]);
+                if (cells.Count == 0) continue;
+
+                // Skip the |---|---| separator row.
+                if (cells.All(c => c.Trim().Trim('-', ':', ' ').Length == 0)) continue;
+
+                var name = nameCol < cells.Count ? CleanText(cells[nameCol]) : string.Empty;
+                if (string.IsNullOrWhiteSpace(name)) continue;
 
                 target.Add(new BuildVersion
                 {
-                    FileName = CleanText(col1),
-                    Description = CleanText(col2)
+                    FileName = name,
+                    Description = descCol < cells.Count ? CleanText(cells[descCol]) : string.Empty,
+                    Version = verCol >= 0 && verCol < cells.Count ? CleanVersion(cells[verCol]) : string.Empty
                 });
             }
         }
+
+        private static List<string> SplitTableRow(string row)
+        {
+            row = row.Trim();
+            if (row.StartsWith("|")) row = row[1..];
+            if (row.EndsWith("|")) row = row[..^1];
+            return row.Split('|').ToList();
+        }
+
+        private static int FindColumn(List<string> headers, string name)
+        {
+            for (int i = 0; i < headers.Count; i++)
+                if (headers[i].Contains(name, StringComparison.OrdinalIgnoreCase))
+                    return i;
+            return -1;
+        }
+
+        // README version cells are wrapped in `backticks`; strip those (plus bold/emoji).
+        private static string CleanVersion(string cell) => CleanText(cell).Trim('`', ' ');
 
         [RelayCommand]
         private void Close()

--- a/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/BuildInfoViewModel.cs
@@ -30,6 +30,46 @@ namespace Apps2Samsung.ViewModels
         [ObservableProperty]
         private ProviderOption? selectedProviderOption;
 
+        // Selected row in each table — selecting one drives the preview panel
+        // (so the user no longer has to use the dropdown above the preview).
+        [ObservableProperty]
+        private BuildVersion? selectedJellyfinVersion;
+
+        [ObservableProperty]
+        private BuildVersion? selectedCommunityApp;
+
+        partial void OnSelectedJellyfinVersionChanged(BuildVersion? value)
+        {
+            if (value is null) return;
+            SelectedCommunityApp = null;   // one active selection across both tables
+            SelectPreviewFor(value.FileName);
+        }
+
+        partial void OnSelectedCommunityAppChanged(BuildVersion? value)
+        {
+            if (value is null) return;
+            SelectedJellyfinVersion = null;
+            SelectPreviewFor(value.FileName);
+        }
+
+        // Point the preview at the ProviderOption matching the picked row.
+        // ProviderOptions.DisplayName is built from the same names shown in the
+        // tables, so an exact match works; fall back to a contains match.
+        private void SelectPreviewFor(string name)
+        {
+            name = (name ?? string.Empty).Trim();
+            if (name.Length == 0) return;
+
+            var match = ProviderOptions.FirstOrDefault(o =>
+                            string.Equals(o.DisplayName, name, StringComparison.OrdinalIgnoreCase))
+                     ?? ProviderOptions.FirstOrDefault(o =>
+                            name.Contains(o.DisplayName, StringComparison.OrdinalIgnoreCase)
+                            || o.DisplayName.Contains(name, StringComparison.OrdinalIgnoreCase));
+
+            if (match is not null)
+                SelectedProviderOption = match;
+        }
+
         private static readonly HttpClient _http = new();
         private static readonly ProviderManifestService _manifestService = new(_http);
         private readonly Dictionary<string, Bitmap?> _bitmapCache = new(StringComparer.OrdinalIgnoreCase);

--- a/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
@@ -99,6 +99,7 @@
 								ClipToBounds="True"
 								Height="220">
 							<DataGrid ItemsSource="{Binding JellyfinVersions}"
+										  SelectedItem="{Binding SelectedJellyfinVersion, Mode=TwoWay}"
 									  AutoGenerateColumns="False"
 									  HeadersVisibility="Column"
 									  IsReadOnly="True"
@@ -130,6 +131,7 @@
 								ClipToBounds="True"
 								Height="280">
 							<DataGrid ItemsSource="{Binding CommunityApps}"
+										  SelectedItem="{Binding SelectedCommunityApp, Mode=TwoWay}"
 									  AutoGenerateColumns="False"
 									  HeadersVisibility="Column"
 									  IsReadOnly="True"

--- a/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/BuildInfoWindow.axaml
@@ -105,8 +105,10 @@
 									  IsReadOnly="True"
 									  ColumnWidth="*">
 								<DataGrid.Columns>
-									<DataGridTextColumn Header="{Binding LblColFileName}" Width="200"
+									<DataGridTextColumn Header="{Binding LblColFileName}" Width="180"
 														Binding="{Binding FileName}" />
+									<DataGridTextColumn Header="{Binding LblColVersion}" Width="130"
+														Binding="{Binding Version}" />
 									<DataGridTemplateColumn Header="{Binding LblColDescription}" Width="*">
 										<DataGridTemplateColumn.CellTemplate>
 											<DataTemplate>
@@ -137,8 +139,10 @@
 									  IsReadOnly="True"
 									  ColumnWidth="*">
 								<DataGrid.Columns>
-									<DataGridTextColumn Header="{Binding LblColApplication}" Width="200"
+									<DataGridTextColumn Header="{Binding LblColApplication}" Width="180"
 														Binding="{Binding FileName}" />
+									<DataGridTextColumn Header="{Binding LblColVersion}" Width="130"
+														Binding="{Binding Version}" />
 									<DataGridTemplateColumn Header="{Binding LblColDescription}" Width="*">
 										<DataGridTemplateColumn.CellTemplate>
 											<DataTemplate>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.5.7](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.5.7)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.6.0-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.6.0-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
## 🚀 Stable release v2.6.0

New features for the App Catalog and first-run experience.

### ✨ New
* 🌍 **Auto-detect language on first run** — fresh installs open in the OS display language when a translation exists, otherwise English. Existing installs keep their chosen language. (#421)
* 🖼️ **Catalog: click a row to preview** — selecting an app in the Jellyfin builds or Community applications table shows its preview directly, no need for the dropdown. (#420)
* 🔢 **Catalog: version column** — shows the version that will be installed. Community apps read it from the community README; Jellyfin builds and the forks (Moonfin/Litefin/AVPlay) show their latest GitHub release tag. (#420)

### ⬆️ Updating
* **From v2.3.2+:** auto-update works
* **From v2.3.1.1 or older:** download once manually ([FAQ](https://github.com/Apps2Samsung/Apps2Samsung/discussions/365))

| Platform | Status | Notes |
|----------|--------|-------|
| 🍎 macOS (.app + dmg) | ✅ Stable | ARM64 + Intel |
| 🍎 macOS (CLI) | ✅ Stable | Per-arch tar.gz |
| 🐧 Linux | ✅ Stable | x64 + ARM64 (tar.gz / .deb) |
| 🪟 Windows | ✅ Stable | .zip / .msi (winget) |

---

### 🛡️ Security Notice
Antivirus warnings may occur and are likely **false positives**.

**Full Changelog**: https://github.com/Apps2Samsung/Apps2Samsung/compare/v2.5.7...v2.6.0
