### PR TITLE
Bump desktop app to .NET 10

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -108,7 +108,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       # ---------------- WINDOWS ----------------
       - name: Build Windows
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       # ---------------- ICON ----------------
       # ---------------- ICON ----------------

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -165,7 +165,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       # ---------------- WINDOWS ----------------
       - name: Build Windows
@@ -283,7 +283,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       # ---------------- ICON ----------------
       - name: macOS icon

--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
Prerequisite for Phase 2 (shared code with the mobile head). The tizen-sdb engine and the future `Apps2Samsung.Core`/MAUI head target net10, so the desktop app moves to net10 too.

- `Apps2Samsung.csproj` TFM `net8.0` → `net10.0`
- CI `setup-dotnet` `8.0.x` → `10.0.x` (beta-prerelease + stable-release)
- Builds clean (0 errors; only pre-existing warnings)

**Heads-up:** the next stable release cut from this is a **.NET 10** self-contained binary (was net8). Runtime is bundled so it runs anywhere the net8 one did — just a deliberate version step.