### PR TITLE
Core: extract TizenCertificateService (decoupled cert provisioning)

### DIFF
--- a/Apps2Samsung.Core/Apps2Samsung.Core.csproj
+++ b/Apps2Samsung.Core/Apps2Samsung.Core.csproj
@@ -11,4 +11,7 @@
     <RootNamespace>Apps2Samsung</RootNamespace>
     <AssemblyName>Apps2Samsung.Core</AssemblyName>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+  </ItemGroup>
 </Project>

--- a/Apps2Samsung.Core/Certificate/CertificateEndpoints.cs
+++ b/Apps2Samsung.Core/Certificate/CertificateEndpoints.cs
@@ -1,0 +1,11 @@
+namespace Apps2Samsung.Services
+{
+    /// <summary>
+    /// Samsung developer REST endpoints used when signing CSRs. Supplied by the host
+    /// (from settings) so Core carries no app-config dependency.
+    /// </summary>
+    public sealed record CertificateEndpoints(
+        string AuthorV3,
+        string DistributorsV1,
+        string DistributorsV3);
+}

--- a/Apps2Samsung.Core/Certificate/ITizenCertificateService.cs
+++ b/Apps2Samsung.Core/Certificate/ITizenCertificateService.cs
@@ -6,13 +6,13 @@ namespace Apps2Samsung.Interfaces
 {
     public interface ITizenCertificateService
     {
-        Task<(string authorP12, string distributorP12, string passwordP12)> GenerateProfileAsync(IReadOnlyCollection<string> duids, string accessToken, string userId, string userEmail, string outputPath, ProgressCallback? progress = null);
+        Task<(string authorP12, string distributorP12, string passwordP12)> GenerateProfileAsync(IReadOnlyCollection<string> duids, string accessToken, string userId, string userEmail, string outputPath, string caPath, ProgressCallback? progress = null);
 
         /// <summary>
         /// Regenerates only the distributor certificate to cover <paramref name="duids"/>, reusing
         /// the existing author keypair in <paramref name="certDir"/> so the author identity stays
         /// unchanged (keeps apps installed on other TVs overwritable). Returns the distributor .p12 path.
         /// </summary>
-        Task<string> RegenerateDistributorAsync(string certDir, IReadOnlyCollection<string> duids, string accessToken, string userId, string userEmail, ProgressCallback? progress = null);
+        Task<string> RegenerateDistributorAsync(string certDir, IReadOnlyCollection<string> duids, string accessToken, string userId, string userEmail, string caPath, ProgressCallback? progress = null);
     }
 }

--- a/Apps2Samsung.Core/Certificate/TizenCertificateService.cs
+++ b/Apps2Samsung.Core/Certificate/TizenCertificateService.cs
@@ -1,6 +1,4 @@
 using Apps2Samsung.Extensions;
-using Apps2Samsung.Helpers;
-using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Helpers.Tizen.Certificate;
 using Apps2Samsung.Interfaces;
 using Org.BouncyCastle.Asn1;
@@ -25,14 +23,14 @@ namespace Apps2Samsung.Services
     public class TizenCertificateService : ITizenCertificateService
     {
         private readonly HttpClient _httpClient;
-        private readonly IDialogService _dialogService;
+        private readonly CertificateEndpoints _endpoints;
 
         public TizenCertificateService(
             HttpClient httpClient,
-            IDialogService dialogService)
+            CertificateEndpoints endpoints)
         {
             _httpClient = httpClient;
-            _dialogService = dialogService;
+            _endpoints = endpoints;
         }
 
         public async Task<(string authorP12, string distributorP12, string passwordP12)> GenerateProfileAsync(
@@ -41,6 +39,7 @@ namespace Apps2Samsung.Services
             string userId,
             string userEmail,
             string outputPath,
+            string caPath,
             ProgressCallback? progress = null)
         {
             if (string.IsNullOrEmpty(outputPath))
@@ -50,37 +49,37 @@ namespace Apps2Samsung.Services
 
             Directory.CreateDirectory(outputPath);
 
-            progress?.Invoke("GenPassword".Localized());
+            progress?.Invoke("GenPassword");
             string p12Plain = cipherUtil.GenerateRandomPassword();
             string p12Encrypted = cipherUtil.GetEncryptedString(p12Plain);
             await File.WriteAllTextAsync(Path.Combine(outputPath, "password.txt"), p12Plain);
 
-            progress?.Invoke("GenKeyPair".Localized());
+            progress?.Invoke("GenKeyPair");
             var keyPair = GenerateKeyPair();
 
-            progress?.Invoke("CreateAuthorCsr".Localized());
+            progress?.Invoke("CreateAuthorCsr");
             var authorCsrData = GenerateAuthorCsr(keyPair);
             await File.WriteAllBytesAsync(Path.Combine(outputPath, "author.csr"), authorCsrData);
 
-            progress?.Invoke("CreateDistributorCSR".Localized());
+            progress?.Invoke("CreateDistributorCSR");
             var distributorCsrData = GenerateDistributorCsr(keyPair, duids, userEmail);
             await File.WriteAllBytesAsync(Path.Combine(outputPath, "distributor.csr"), distributorCsrData);
 
-            progress?.Invoke("PostAuthorCSR".Localized());
+            progress?.Invoke("PostAuthorCSR");
             var signedAuthorCsrBytes = await PostAuthorCsrAsync(authorCsrData, accessToken, userId);
             await File.WriteAllBytesAsync(Path.Combine(outputPath, "signed_author.cer"), signedAuthorCsrBytes);
 
-            progress?.Invoke("PostDistributorCSR".Localized());
+            progress?.Invoke("PostDistributorCSR");
             var (profileXmlBytes, signedDistributorCsrBytes) = await PostDistributorCsrAsync(accessToken, userId, distributorCsrData);
             if (profileXmlBytes != null)
                 await File.WriteAllBytesAsync(Path.Combine(outputPath, "device-profile.xml"), profileXmlBytes);
             await File.WriteAllBytesAsync(Path.Combine(outputPath, "signed_distributor.cer"), signedDistributorCsrBytes);
 
-            await CheckCertificateExistenceAsync(Path.Combine(AppSettings.ProfilePath, "ca"));
+            await CheckCertificateExistenceAsync(caPath);
 
-            progress?.Invoke("ExportPfxCertificates".Localized());
-            string authorp12 = await ExportPfxWithCaChainAsync(signedAuthorCsrBytes, keyPair.Private, p12Plain, outputPath, Path.Combine(AppSettings.ProfilePath, "ca"), "author", "vd_tizen_dev_author_ca.cer");
-            string distributorp12 = await ExportPfxWithCaChainAsync(signedDistributorCsrBytes, keyPair.Private, p12Plain, outputPath, Path.Combine(AppSettings.ProfilePath, "ca"), "distributor", "vd_tizen_dev_public2.crt");
+            progress?.Invoke("ExportPfxCertificates");
+            string authorp12 = await ExportPfxWithCaChainAsync(signedAuthorCsrBytes, keyPair.Private, p12Plain, outputPath, caPath, "author", "vd_tizen_dev_author_ca.cer");
+            string distributorp12 = await ExportPfxWithCaChainAsync(signedDistributorCsrBytes, keyPair.Private, p12Plain, outputPath, caPath, "distributor", "vd_tizen_dev_public2.crt");
             return (authorp12, distributorp12, p12Plain);
         }
 
@@ -90,6 +89,7 @@ namespace Apps2Samsung.Services
             string accessToken,
             string userId,
             string userEmail,
+            string caPath,
             ProgressCallback? progress = null)
         {
             if (string.IsNullOrEmpty(certDir))
@@ -107,24 +107,24 @@ namespace Apps2Samsung.Services
             // only the device-bound distributor cert changes for the new DUID.
             var keyPair = LoadKeyPairFromP12(authorP12, password);
 
-            progress?.Invoke("CreateDistributorCSR".Localized());
+            progress?.Invoke("CreateDistributorCSR");
             var distributorCsrData = GenerateDistributorCsr(keyPair, duids, userEmail);
             await File.WriteAllBytesAsync(Path.Combine(certDir, "distributor.csr"), distributorCsrData);
 
-            progress?.Invoke("PostDistributorCSR".Localized());
+            progress?.Invoke("PostDistributorCSR");
             var (profileXmlBytes, signedDistributorCsrBytes) =
                 await PostDistributorCsrAsync(accessToken, userId, distributorCsrData);
             if (profileXmlBytes != null)
                 await File.WriteAllBytesAsync(Path.Combine(certDir, "device-profile.xml"), profileXmlBytes);
             await File.WriteAllBytesAsync(Path.Combine(certDir, "signed_distributor.cer"), signedDistributorCsrBytes);
 
-            await CheckCertificateExistenceAsync(Path.Combine(AppSettings.ProfilePath, "ca"));
+            await CheckCertificateExistenceAsync(caPath);
 
-            progress?.Invoke("ExportPfxCertificates".Localized());
+            progress?.Invoke("ExportPfxCertificates");
             // author.p12 / signed_author.cer / password.txt are intentionally left untouched.
             return await ExportPfxWithCaChainAsync(
                 signedDistributorCsrBytes, keyPair.Private, password, certDir,
-                Path.Combine(AppSettings.ProfilePath, "ca"), "distributor", "vd_tizen_dev_public2.crt");
+                caPath, "distributor", "vd_tizen_dev_public2.crt");
         }
 
         /// <summary>Loads the keypair (public + private) from a PKCS#12 file's first key entry.</summary>
@@ -199,7 +199,7 @@ namespace Apps2Samsung.Services
 
         }
 
-        private async Task CheckCertificateExistenceAsync(string caPath)
+        private static Task CheckCertificateExistenceAsync(string caPath)
         {
             string[] requiredFiles = { "vd_tizen_dev_author_ca.cer", "vd_tizen_dev_public2.crt" };
 
@@ -207,14 +207,16 @@ namespace Apps2Samsung.Services
             {
                 string target = Path.Combine(caPath, file);
                 if (!File.Exists(target))
-                    await _dialogService.ShowErrorAsync($"Missing CA file: {file}");
+                    // Core can't show UI; surface it so the host head reports it.
+                    throw new FileNotFoundException($"Missing CA file: {file}", target);
             }
+            return Task.CompletedTask;
         }
 
         // Simplified Http Post for Author CSR
         private async Task<byte[]> PostAuthorCsrAsync(byte[] csrData, string accessToken, string userId)
         {
-            var request = new HttpRequestMessage(HttpMethod.Post, AppSettings.Default.AuthorEndpoint_V3);
+            var request = new HttpRequestMessage(HttpMethod.Post, _endpoints.AuthorV3);
             var content = new MultipartFormDataContent
             {
                 { new StringContent(accessToken), "access_token" },
@@ -242,7 +244,7 @@ namespace Apps2Samsung.Services
                 { new ByteArrayContent(csrBytes), "csr", "distributor.csr" }
             };
 
-            var v1Request = new HttpRequestMessage(HttpMethod.Post, AppSettings.Default.DistributorsEndpoint_V1);
+            var v1Request = new HttpRequestMessage(HttpMethod.Post, _endpoints.DistributorsV1);
             v1Request.Content = v1Content;
             var v1Response = await _httpClient.SendAsync(v1Request);
 
@@ -264,7 +266,7 @@ namespace Apps2Samsung.Services
                 { new ByteArrayContent(csrBytes), "csr", "distributor.csr" }
             };
 
-            var v3Request = new HttpRequestMessage(HttpMethod.Post, AppSettings.Default.DistributorsEndpoint_V3);
+            var v3Request = new HttpRequestMessage(HttpMethod.Post, _endpoints.DistributorsV3);
             v3Request.Content = v3Content;
             var v3Response = await _httpClient.SendAsync(v3Request);
 
@@ -359,7 +361,7 @@ namespace Apps2Samsung.Services
             }
 
             // --- Optional sanity check ---
-            if (PlatformService.IsWindows)
+            if (OperatingSystem.IsWindows())
             {
                 try
                 {
@@ -384,10 +386,6 @@ namespace Apps2Samsung.Services
             }
 
             return target;
-        }
-        private static X509KeyStorageFlags GetX509KeyStorageFlags()
-        {
-            return PlatformService.GetX509KeyStorageFlags();
         }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/App.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/App.axaml.cs
@@ -69,7 +69,12 @@ namespace Apps2Samsung
             services.AddSingleton<IDialogService, DialogService>();
             services.AddSingleton<ILocalizationService, LocalizationService>();
             services.AddSingleton<INetworkService, NetworkService>();
-            services.AddSingleton<ITizenCertificateService, TizenCertificateService>();
+            services.AddSingleton<ITizenCertificateService>(sp => new TizenCertificateService(
+                sp.GetRequiredService<HttpClient>(),
+                new CertificateEndpoints(
+                    AppSettings.Default.AuthorEndpoint_V3,
+                    AppSettings.Default.DistributorsEndpoint_V1,
+                    AppSettings.Default.DistributorsEndpoint_V3)));
             services.AddSingleton<ITizenInstallerService, TizenInstallerService>();
             services.AddSingleton<IThemeService, ThemeService>();
             services.AddSingleton<IUpdaterService, UpdaterService>();

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -597,7 +597,15 @@ namespace Apps2Samsung.Services
                 }
 
                 progress?.Invoke(Constants.LocalizationKeys.CreatingCertificateProfile.Localized());
-                var certificateService = new TizenCertificateService(_httpClient, _dialogService);
+                var certificateService = new TizenCertificateService(
+                    _httpClient,
+                    new CertificateEndpoints(
+                        _appSettings.AuthorEndpoint_V3,
+                        _appSettings.DistributorsEndpoint_V1,
+                        _appSettings.DistributorsEndpoint_V3));
+                var caPath = Path.Combine(AppSettings.ProfilePath, "ca");
+                // Core emits progress as localization keys; localize them here at the boundary.
+                ProgressCallback? certProgress = progress is null ? null : new ProgressCallback(k => progress(k.Localized()));
 
                 // Union of DUIDs the (re)generated distributor cert should cover: this TV first,
                 // then manual entries, then already-covered ones — capped at Samsung's per-cert limit.
@@ -611,7 +619,8 @@ namespace Apps2Samsung.Services
                         userId: auth.userId,
                         userEmail: auth.inputEmailID,
                         outputPath: jelly2SamsDir,
-                        progress);
+                        caPath: caPath,
+                        certProgress);
                 }
                 else
                 {
@@ -622,7 +631,8 @@ namespace Apps2Samsung.Services
                         accessToken: auth.access_token,
                         userId: auth.userId,
                         userEmail: auth.inputEmailID,
-                        progress);
+                        caPath: caPath,
+                        certProgress);
                     authorp12 = Path.Combine(jelly2SamsDir, Constants.Certificate.AuthorFileName);
                     p12Password = (await File.ReadAllTextAsync(
                         Path.Combine(jelly2SamsDir, Constants.Certificate.PasswordFileName))).Trim();


### PR DESCRIPTION
Phase 2, step 4 — the real one. `TizenCertificateService` + `ITizenCertificateService` move into `Apps2Samsung.Core`, fully decoupled from the desktop UI so the mobile head can reuse it.

## Decoupling
- **`IDialogService` dropped** → CA-missing throws `FileNotFoundException` (host head reports it).
- **Endpoints injected** via a `CertificateEndpoints` record (host builds it from `AppSettings`) instead of reading `AppSettings.Default`.
- **`caPath` parameter** replaces `AppSettings.ProfilePath` (Core makes no app-data assumptions).
- **Progress → keys**: Core emits localization keys; the desktop localizes them at the boundary (`TizenInstallerService` wraps the callback with `.Localized()`).
- **`PlatformService.IsWindows` → `OperatingSystem.IsWindows()`**; dropped the dead `GetX509KeyStorageFlags` helper.
- BouncyCastle added to Core (proven on MonoVM by the tizen-sdb probe).

## Rewired (desktop)
- DI registration builds `CertificateEndpoints` from `AppSettings`.
- `TizenInstallerService` passes `caPath` + a localizing progress wrapper.

Core + desktop **build clean (0 errors)**.

## ⚠ Verify before shipping
This touches the critical cert path and I can only compile-verify. **Smoke-test a real cert generation on desktop** (Samsung login → generate profile → install) and confirm it's identical to the pre-PR baseline you validated earlier. Provisioning logic is byte-unchanged — only where paths/endpoints/progress come from moved.