### PR TITLE
Mobile: in-process ISdbEngine over TizenSdb.Core (NuGet)

### DIFF
--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -77,4 +77,10 @@
 		<ProjectReference Include="..\Apps2Samsung.Core\Apps2Samsung.Core.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<!-- The SDB engine, in-process. Resolves the net10.0-android asset, which carries the
+		     Android-specific cert/socket branches. Backs InProcessSdbEngine (this head's ISdbEngine). -->
+		<PackageReference Include="TizenSdb.Core" Version="1.1.0" />
+	</ItemGroup>
+
 </Project>

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -1,6 +1,8 @@
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Services;
+using Apps2Samsung.Mobile.Services;
 using Microsoft.Extensions.Logging;
+using TizenSdb.SdbClient;
 
 namespace Apps2Samsung.Mobile;
 
@@ -24,6 +26,12 @@ public static class MauiProgram
 		// name resolver yet, so NetworkService runs with those left null — detection relies only
 		// on the open debug/REST ports, so found TVs still come back (just without a friendly name).
 		builder.Services.AddSingleton<INetworkService>(_ => new NetworkService());
+
+		// The SDB engine needs a writable directory to persist its RSA auth keypair (the desktop
+		// uses the profile dir; on Android there's no ambient writable path, so point it at the
+		// app's private data dir before any connection). Set once, process-wide.
+		SdbTcpDevice.KeyDirectory = FileSystem.AppDataDirectory;
+		builder.Services.AddSingleton<ISdbEngine, InProcessSdbEngine>();
 
 		builder.Services.AddSingleton<MainPage>();
 

--- a/Apps2Samsung.Mobile/Services/InProcessSdbEngine.cs
+++ b/Apps2Samsung.Mobile/Services/InProcessSdbEngine.cs
@@ -1,0 +1,178 @@
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+using TizenSdb;
+using TizenSdb.SdbClient;
+using TizenSdb.SigningManager;
+
+namespace Apps2Samsung.Mobile.Services;
+
+/// <summary>
+/// Mobile <see cref="ISdbEngine"/>: drives <c>TizenSdb.Core</c> in-process (no exe). Each call
+/// opens a fresh <see cref="SdbTcpDevice"/> connection, runs the operation, and disposes — mirroring
+/// how the desktop CLI runs one process per command, so the <see cref="ProcessResult.Output"/> it
+/// returns matches the CLI's stdout that the shared orchestration/regex parsing expects.
+/// </summary>
+public sealed class InProcessSdbEngine : ISdbEngine
+{
+	// Commands ListApps tries in order (first useful reply wins) — ported from the CLI.
+	private static readonly string[] AppListCommands =
+	{
+		"0 vd_applist", "applist", "pkgcmd -l", "pm list packages", "ls /usr/apps", "ls /opt/usr/apps",
+	};
+
+	// Commands diagnose probes — ported from the CLI. The "0 vd_appuninstall test" line is what the
+	// desktop's diagnose parser keys on, so its exact "Testing '…': SUCCESS/FAILED" format is preserved.
+	private static readonly string[] DiagnoseCommands =
+	{
+		"0 getduid", "host:version", "host:features", "shell:uname -a", "shell:ls /usr/apps",
+		"shell:pwd", "shell:whoami", "0 vd_applist", "0 vd_appuninstall test", "pkgcmd -l",
+	};
+
+	public async Task<ProcessResult> DevicesAsync(string tvIpAddress) => await RunConnected(tvIpAddress, device =>
+	{
+		var parts = device.DeviceId.Split("::", StringSplitOptions.RemoveEmptyEntries);
+		return Task.FromResult(parts.Length >= 2 ? parts[1] : string.Empty);
+	});
+
+	public Task<ProcessResult> DisconnectAsync(string tvIpAddress)
+		// The CLI's disconnect is a no-op (each command already tears down its own connection).
+		=> Task.FromResult(Ok($"* Disconnected from {tvIpAddress}"));
+
+	public async Task<ProcessResult> CapabilityAsync(string tvIpAddress) => await RunConnected(tvIpAddress, async device =>
+	{
+		var caps = await device.CapabilityAsync();
+		var sb = new StringBuilder();
+		foreach (var cap in caps)
+			sb.AppendLine($"  {cap.Key}: {cap.Value}");
+		return sb.ToString();
+	});
+
+	public async Task<ProcessResult> DuidAsync(string tvIpAddress) => await RunConnected(tvIpAddress, async device =>
+	{
+		var duid = await device.ShellCommandAsync("0 getduid");
+		return duid.Trim();
+	});
+
+	public async Task<ProcessResult> DiagnoseAsync(string tvIpAddress) => await RunConnected(tvIpAddress, async device =>
+	{
+		var sb = new StringBuilder();
+		foreach (var cmd in DiagnoseCommands)
+		{
+			try
+			{
+				var result = await device.ShellCommandAsync(cmd);
+				sb.AppendLine($"  Testing '{cmd}': SUCCESS ({result.Length} chars)");
+			}
+			catch (Exception ex)
+			{
+				sb.AppendLine($"  Testing '{cmd}': FAILED - {ex.Message}");
+			}
+		}
+		return sb.ToString();
+	});
+
+	public async Task<ProcessResult> AppsAsync(string tvIpAddress) => await RunConnected(tvIpAddress, async device =>
+	{
+		foreach (var cmd in AppListCommands)
+		{
+			try
+			{
+				var result = await device.ShellCommandAsync(cmd);
+				if (!string.IsNullOrEmpty(result) && !result.Contains("not found") && !result.Contains("No such"))
+				{
+					var sb = new StringBuilder();
+					foreach (var line in result.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+					{
+						var trimmed = line.Trim();
+						if (trimmed.Length > 1)
+							sb.AppendLine(Regex.Replace(trimmed, @"\e\[[0-9;]*m", ""));
+					}
+					return sb.ToString();
+				}
+			}
+			catch { /* try next command */ }
+		}
+		return "Could not retrieve app list";
+	});
+
+	public async Task<ProcessResult> LaunchAsync(string tvIpAddress, string appId) => await RunConnected(tvIpAddress, async device =>
+	{
+		await device.LaunchAppAsync(appId);
+		return "App launched.";
+	});
+
+	public async Task<ProcessResult> ResignAsync(string packagePath, string authorP12, string distributorP12, string certPass)
+	{
+		// Resign is a local file operation — no device connection.
+		try
+		{
+			var output = await TizenWgtSigner.ReSignWgtWithCertsInPlace(packagePath, authorP12, distributorP12, certPass, backupPath: null);
+			return Ok($"Re-signed in place: {output}");
+		}
+		catch (Exception ex)
+		{
+			return Fail(ex);
+		}
+	}
+
+	public async Task<ProcessResult> InstallAsync(string tvIpAddress, string packagePath, string sdkToolPath) => await RunConnected(tvIpAddress, async device =>
+	{
+		var installer = new TizenInstaller(packagePath, device, sdkToolPath);
+		await installer.InstallApp();
+		return $"Install completed{(installer.PackageId is { } id ? $": {id}" : string.Empty)}";
+	});
+
+	public async Task<ProcessResult> UninstallAsync(string tvIpAddress, string packageId) => await RunConnected(tvIpAddress, async device =>
+	{
+		try
+		{
+			var result = await device.ShellCommandAsync($"0 vd_appuninstall {packageId}");
+			if (result.Contains("fail", StringComparison.OrdinalIgnoreCase) || result.Contains("error", StringComparison.OrdinalIgnoreCase))
+				throw new Exception("Uninstallation failed");
+			return result;
+		}
+		catch
+		{
+			// Fallback to pkgcmd, matching the CLI.
+			var pkgName = packageId.Split('.')[0];
+			return await device.ShellCommandAsync($"pkgcmd -u -n {pkgName} -q");
+		}
+	});
+
+	public async Task<ProcessResult> PermitInstallAsync(string tvIpAddress, string deviceXml, string sdkToolPath) => await RunConnected(tvIpAddress, async device =>
+	{
+		var installer = new TizenInstaller(deviceXml, device, sdkToolPath);
+		await installer.PermitInstallApp();
+		return "Push completed successfully";
+	});
+
+	// Opens a connection, runs <paramref name="body"/>, always disposes. Maps success to ExitCode 0
+	// (with the body's text as Output) and any failure to ExitCode 1 with the message in Error —
+	// the same shape the desktop's ExeSdbEngine surfaces from the process result.
+	private static async Task<ProcessResult> RunConnected(string ip, Func<SdbTcpDevice, Task<string>> body)
+	{
+		SdbTcpDevice? device = null;
+		try
+		{
+			device = new SdbTcpDevice(IPAddress.Parse(ip));
+			await device.ConnectAsync();
+			return Ok(await body(device));
+		}
+		catch (Exception ex)
+		{
+			return Fail(ex);
+		}
+		finally
+		{
+			if (device is not null)
+				await device.DisposeAsync();
+		}
+	}
+
+	private static ProcessResult Ok(string output) => new() { ExitCode = 0, Output = output, Error = string.Empty };
+
+	private static ProcessResult Fail(Exception ex) => new() { ExitCode = 1, Output = string.Empty, Error = ex.Message };
+}


### PR DESCRIPTION
## What

Wires the published **`TizenSdb.Core` 1.1.0** NuGet package into `Apps2Samsung.Mobile` and implements **`InProcessSdbEngine : ISdbEngine`**, which drives the engine **in-process** (no exe) — the mobile side of decision B. The abstraction is now proven end-to-end on both heads: desktop shells to `TizenSdb.exe`, mobile calls `TizenSdb.Core` directly.

## How it mirrors the CLI

Each method opens a fresh `SdbTcpDevice` connection, runs the operation, and disposes — the same one-connection-per-command model as the desktop CLI. The returned `ProcessResult.Output` mirrors the CLI's stdout so the **same orchestration/regex parsing works against either engine**:
- `capability` emits `  platform_version: …` / `  sdk_toolpath: …`
- `diagnose` keeps the exact `Testing '0 vd_appuninstall test': …` line the desktop parser keys on

Ported from the CLI handlers: `devices`/`duid`/`capability`/`diagnose`/`apps`/`launch`/`uninstall` (with the `pkgcmd` fallback) via `SdbTcpDevice`; `install`/`permit-install` via `TizenInstaller`; `resign` via `TizenWgtSigner` (local file op, no connection). Failures map to `ExitCode 1` + `Error`, same shape as the desktop process result.

## Android specifics

- `SdbTcpDevice.KeyDirectory` is set to `FileSystem.AppDataDirectory` in `MauiProgram` so the engine persists its RSA auth keypair (no ambient writable path on Android).
- The `net10.0-android` package asset resolves, so the Android cert/socket branches are used.

Registered `ISdbEngine → InProcessSdbEngine` in DI. Builds clean (0 errors).

## Not yet

This provides the engine; it isn't driven by UI yet. Next: Samsung OAuth (WebView + loopback), the cert-provisioning flow, and the install-orchestration UI that consumes this engine. On-device verification of the in-process connect/install path also pending (the Probe already proved the raw flow works).