### PR TITLE
Mobile: fix on-device scan + OAuth callback (validated on S22)

### DIFF
--- a/Apps2Samsung.Core/Network/NetworkService.cs
+++ b/Apps2Samsung.Core/Network/NetworkService.cs
@@ -190,16 +190,14 @@ namespace Apps2Samsung.Services
             try
             {
                 using var client = new TcpClient();
-                var connectTask = client.ConnectAsync(ip, port, ct);
-                var timeoutTask = Task.Delay(Timeout.Infinite, ct);
-
-                var completedTask = await Task.WhenAny(connectTask.AsTask(), timeoutTask);
-                if (completedTask == connectTask.AsTask())
-                {
-                    await connectTask; // Ensure connection succeeded
-                    return true;
-                }
-                return false;
+                // ConnectAsync honours the caller's cancellation token (a linked timeout CTS), so a
+                // closed/filtered port cancels to false. It returns a ValueTask — await it EXACTLY
+                // once. The previous code called .AsTask() on the ValueTask twice (plus a trailing
+                // await), which on Android/MonoVM faults ("a ValueTask may be consumed only once")
+                // and made every probe return false — so no TV was ever detected despite the
+                // connects actually happening. Desktop's runtime tolerated the double-consumption.
+                await client.ConnectAsync(ip, port, ct);
+                return true;
             }
             catch
             {

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -1,3 +1,5 @@
+using System.Net;
+using System.Net.Sockets;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Services;
 using Apps2Samsung.Mobile.Services;
@@ -25,7 +27,11 @@ public static class MauiProgram
 		// The TV scan is fully portable. This head has no arp vendor lookup and no SDB-backed
 		// name resolver yet, so NetworkService runs with those left null — detection relies only
 		// on the open debug/REST ports, so found TVs still come back (just without a friendly name).
-		builder.Services.AddSingleton<INetworkService>(_ => new NetworkService());
+		// On Android, NetworkInterface doesn't reliably classify the Wi-Fi adapter as
+		// Ethernet/Wireless80211 and IPv4Mask is unavailable, so the Core scan's interface
+		// enumeration yields nothing. Feed the device's own IPv4 as the custom scan IP: the
+		// scanner then covers its /24 (the mask fallback), which finds TVs on the same LAN.
+		builder.Services.AddSingleton<INetworkService>(_ => new NetworkService(customIpProvider: GetDeviceIPv4));
 
 		// The SDB engine needs a writable directory to persist its RSA auth keypair (the desktop
 		// uses the profile dir; on Android there's no ambient writable path, so point it at the
@@ -52,5 +58,22 @@ public static class MauiProgram
 #endif
 
 		return builder.Build();
+	}
+
+	// The device's own LAN IPv4, via the route the OS picks for an outbound socket (no packets are
+	// sent — Connect on a UDP socket just resolves the local endpoint). Works on Android where
+	// interface enumeration/masks don't; null if offline.
+	private static string? GetDeviceIPv4()
+	{
+		try
+		{
+			using var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0);
+			socket.Connect("8.8.8.8", 65530);
+			return (socket.LocalEndPoint as IPEndPoint)?.Address.ToString();
+		}
+		catch
+		{
+			return null;
+		}
 	}
 }

--- a/Apps2Samsung.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/Apps2Samsung.Mobile/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:networkSecurityConfig="@xml/network_security_config"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/Apps2Samsung.Mobile/Platforms/Android/Resources/xml/network_security_config.xml
+++ b/Apps2Samsung.Mobile/Platforms/Android/Resources/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Android blocks cleartext HTTP by default (API 28+). The Samsung SignInGate redirects the
+     captured token by POSTing to the in-app loopback listener over http://localhost:4794, so
+     cleartext must be permitted — but ONLY to loopback. Everything else (Samsung = HTTPS; the
+     SDB scan/protocol = raw TCP, not HTTP-policy-gated) stays under the secure default. -->
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## What

Three fixes found during the **first on-device smoke** (Samsung S22 / Android 16). After these, **scan → Samsung sign-in → certificate provisioning all work end-to-end on the phone** — author + distributor `.p12` minted on-device (DUID read in-process, BouncyCastle/CSR/PKCS12 confirmed on MonoVM).

## Fixes

1. **The scan bug (Core)** — `NetworkService.IsPortOpenAsync` awaits the `ConnectAsync` **`ValueTask`** exactly once now. It was calling `.AsTask()` twice (plus a trailing `await`); a `ValueTask` may be consumed only once, and MonoVM faults on the second consumption, so **every port probe returned false** — no TV ever detected, even though the TCP connects happened (they populated the phone's ARP table). Desktop's runtime happened to tolerate the double-consume. The simplified single-await form is correct on both.
2. **Android subnet (mobile)** — feed the device's own IPv4 as the scan's custom IP. Android's `NetworkInterface` doesn't classify `wlan0` as `Wireless80211`/`Ethernet` and doesn't expose `IPv4Mask`, so Core interface enumeration returned no networks to scan; the own-IP `/24` gives the scanner a range.
3. **Cleartext callback (mobile)** — a network-security-config permitting cleartext **only to localhost**, so SignInGate's token POST to the loopback listener (`http://localhost:4794`) isn't blocked by Android (`ERR_CLEARTEXT_NOT_PERMITTED`). Samsung stays HTTPS; the SDB scan/protocol is raw TCP (unaffected).

Desktop build unaffected (0 errors).

## Significance

This de-risks the whole mobile port: the cert-provisioning path — the biggest unknown — is proven on hardware. Next: the install orchestration (resign the `.wgt` with these certs → permit-install → install).