### PR TITLE
Mobile: .wgt download + install orchestration

### DIFF
--- a/Apps2Samsung.Core/Certificate/TizenCertificateService.cs
+++ b/Apps2Samsung.Core/Certificate/TizenCertificateService.cs
@@ -338,7 +338,14 @@ namespace Apps2Samsung.Services
             var caBcCert = parser.ReadCertificate(candidateDot.RawData);
 
             // --- Build PKCS#12 deterministically with BC (alias + order) ---
-            var store = new Pkcs12StoreBuilder().Build();
+            // Encrypt BOTH the key and the certificate bags with 3DES. BouncyCastle's default
+            // cert-bag cipher is legacy 40-bit RC2, which Windows reads but Android/MonoVM (and
+            // OpenSSL-3 hosts) reject — surfacing as a misleading "certificate cannot be read with
+            // the provided password" when the resigner loads the .p12. 3DES is read everywhere.
+            var store = new Pkcs12StoreBuilder()
+                .SetKeyAlgorithm(PkcsObjectIdentifiers.PbeWithShaAnd3KeyTripleDesCbc)
+                .SetCertAlgorithm(PkcsObjectIdentifiers.PbeWithShaAnd3KeyTripleDesCbc)
+                .Build();
 
             var keyEntry = new AsymmetricKeyEntry(privateKey);
             var leafEntry = new X509CertificateEntry(leafBc);

--- a/Apps2Samsung.Mobile/MainPage.xaml
+++ b/Apps2Samsung.Mobile/MainPage.xaml
@@ -36,6 +36,18 @@
                 Clicked="OnProvisionClicked"
                 HorizontalOptions="Fill" />
 
+            <Entry
+                x:Name="WgtUrlEntry"
+                Text="https://github.com/jeppevinkel/jellyfin-tizen-builds/releases/latest/download/Jellyfin.wgt"
+                Placeholder=".wgt URL"
+                Keyboard="Url" />
+
+            <Button
+                x:Name="InstallBtn"
+                Text="Download &amp; install"
+                Clicked="OnInstallClicked"
+                HorizontalOptions="Fill" />
+
             <ActivityIndicator
                 x:Name="Busy"
                 IsRunning="False"

--- a/Apps2Samsung.Mobile/MainPage.xaml.cs
+++ b/Apps2Samsung.Mobile/MainPage.xaml.cs
@@ -11,17 +11,20 @@ public partial class MainPage : ContentPage
 	private readonly INetworkService _networkService;
 	private readonly ISamsungLoginService _loginService;
 	private readonly CertificateProvisioner _certProvisioner;
+	private readonly WgtInstaller _installer;
 
-	// Held between the smoke steps: sign in, scan (pick first debug-ready TV), then provision.
+	// Held between the smoke steps: sign in, scan (pick first debug-ready TV), provision, then install.
 	private SamsungAuth? _auth;
 	private string? _readyTvIp;
+	private CertificateProvisioner.Result? _cert;
 
-	public MainPage(INetworkService networkService, ISamsungLoginService loginService, CertificateProvisioner certProvisioner)
+	public MainPage(INetworkService networkService, ISamsungLoginService loginService, CertificateProvisioner certProvisioner, WgtInstaller installer)
 	{
 		InitializeComponent();
 		_networkService = networkService;
 		_loginService = loginService;
 		_certProvisioner = certProvisioner;
+		_installer = installer;
 	}
 
 	private async void OnScanClicked(object? sender, EventArgs e)
@@ -111,6 +114,7 @@ public partial class MainPage : ContentPage
 				_auth,
 				step => MainThread.BeginInvokeOnMainThread(() => ResultsLabel.Text = $"Provisioning: {step}"));
 
+			_cert = result;
 			ResultsLabel.Text =
 				$"Certificate ready for {_readyTvIp}\nDUID: {result.Duid}\n" +
 				$"Author: {Path.GetFileName(result.AuthorP12)}\nDistributor: {Path.GetFileName(result.DistributorP12)}\n" +
@@ -124,6 +128,48 @@ public partial class MainPage : ContentPage
 		{
 			Busy.IsRunning = Busy.IsVisible = false;
 			ProvisionBtn.IsEnabled = true;
+		}
+	}
+
+	private async void OnInstallClicked(object? sender, EventArgs e)
+	{
+		if (_cert is null)
+		{
+			ResultsLabel.Text = "Provision a certificate first.";
+			return;
+		}
+		if (string.IsNullOrEmpty(_readyTvIp))
+		{
+			ResultsLabel.Text = "Scan first and make sure a debug-ready TV was found.";
+			return;
+		}
+		var url = WgtUrlEntry.Text?.Trim();
+		if (string.IsNullOrEmpty(url))
+		{
+			ResultsLabel.Text = "Enter a .wgt URL to install.";
+			return;
+		}
+
+		InstallBtn.IsEnabled = false;
+		Busy.IsRunning = Busy.IsVisible = true;
+
+		try
+		{
+			void Report(string step) => MainThread.BeginInvokeOnMainThread(() => ResultsLabel.Text = step);
+
+			var wgtPath = await _installer.DownloadAsync(url, Report);
+			var output = await _installer.InstallAsync(_readyTvIp, wgtPath, _cert, Report);
+
+			ResultsLabel.Text = $"Installed {Path.GetFileName(wgtPath)} on {_readyTvIp} ✓\n\n{output.Trim()}";
+		}
+		catch (Exception ex)
+		{
+			ResultsLabel.Text = $"Install failed: {ex.Message}";
+		}
+		finally
+		{
+			Busy.IsRunning = Busy.IsVisible = false;
+			InstallBtn.IsEnabled = true;
 		}
 	}
 }

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -51,6 +51,9 @@ public static class MauiProgram
 			new TizenCertificateService(sp.GetRequiredService<HttpClient>(), CertificateEndpoints.Default));
 		builder.Services.AddSingleton<CertificateProvisioner>();
 
+		// Install: download a .wgt and push it to the TV (resign -> [permit] -> install).
+		builder.Services.AddSingleton<WgtInstaller>();
+
 		builder.Services.AddSingleton<MainPage>();
 
 #if DEBUG

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -1,0 +1,94 @@
+using System.Linq;
+using Apps2Samsung.Interfaces;
+using Microsoft.Maui.Storage;
+
+namespace Apps2Samsung.Mobile.Services;
+
+/// <summary>
+/// Downloads a .wgt and installs it on the TV via the in-process <see cref="ISdbEngine"/>, using
+/// the certificates from <see cref="CertificateProvisioner"/>. Mirrors the desktop install sequence:
+/// read capability (sdk tool path + platform version) → (older TVs only) push the device profile →
+/// re-sign the package with the author/distributor certs → install.
+/// </summary>
+public sealed class WgtInstaller
+{
+	// Fallback install staging path when the TV's capability report doesn't include one.
+	private const string DefaultSdkToolPath = "/opt/usr/apps/tmp";
+	// Below this Tizen version the device profile must be pushed first (permit-install).
+	private static readonly Version PushInstallMax = new(4, 0);
+	private static readonly Version IntermediateVersion = new(3, 0);
+	private const string HomeDeveloperPath = "/home/developer";
+
+	private readonly ISdbEngine _sdb;
+	private readonly HttpClient _http;
+
+	public WgtInstaller(ISdbEngine sdb, HttpClient http)
+	{
+		_sdb = sdb;
+		_http = http;
+	}
+
+	public async Task<string> DownloadAsync(string url, Action<string>? progress = null)
+	{
+		progress?.Invoke("Downloading package…");
+
+		var name = url.Split('/').LastOrDefault()?.Split('?')[0];
+		if (string.IsNullOrWhiteSpace(name) || !name.EndsWith(".wgt", StringComparison.OrdinalIgnoreCase))
+			name = "package.wgt";
+		var dest = Path.Combine(FileSystem.CacheDirectory, name);
+
+		using var resp = await _http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+		resp.EnsureSuccessStatusCode();
+		await using (var src = await resp.Content.ReadAsStreamAsync())
+		await using (var dst = File.Create(dest))
+			await src.CopyToAsync(dst);
+
+		return dest;
+	}
+
+	public async Task<string> InstallAsync(string tvIp, string wgtPath, CertificateProvisioner.Result cert, Action<string>? progress = null)
+	{
+		progress?.Invoke("Reading TV capabilities…");
+		var cap = await _sdb.CapabilityAsync(tvIp);
+		var sdkToolPath = ParseCapability(cap.Output, "sdk_toolpath") ?? DefaultSdkToolPath;
+		Version.TryParse(ParseCapability(cap.Output, "platform_version"), out var version);
+
+		// Older TVs (<= 4.0) need the distributor device profile pushed before install; newer TVs
+		// carry the authorization in the re-signed package itself.
+		if (version is not null && version <= PushInstallMax)
+		{
+			progress?.Invoke("Authorizing device…");
+			var profileXml = Path.Combine(cert.ProfileDir, "device-profile.xml");
+			var target = version < IntermediateVersion ? HomeDeveloperPath : sdkToolPath;
+			await _sdb.PermitInstallAsync(tvIp, profileXml, target);
+		}
+
+		progress?.Invoke("Re-signing package…");
+		var resign = await _sdb.ResignAsync(wgtPath, cert.AuthorP12, cert.DistributorP12, cert.Password);
+		if (resign.ExitCode != 0 || resign.Output.Contains("Re-sign failed", StringComparison.OrdinalIgnoreCase))
+			throw new InvalidOperationException($"Re-sign failed: {Detail(resign.Error, resign.Output)}");
+
+		progress?.Invoke("Installing on TV…");
+		var install = await _sdb.InstallAsync(tvIp, wgtPath, sdkToolPath);
+		if (install.ExitCode != 0)
+			throw new InvalidOperationException($"Install failed: {Detail(install.Error, install.Output)}");
+
+		return install.Output;
+	}
+
+	// Pulls a "  key: value" line out of the capability report.
+	private static string? ParseCapability(string output, string key)
+	{
+		foreach (var line in output.Split('\n'))
+		{
+			var marker = key + ":";
+			var i = line.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
+			if (i >= 0)
+				return line[(i + marker.Length)..].Trim();
+		}
+		return null;
+	}
+
+	private static string Detail(string error, string output) =>
+		!string.IsNullOrWhiteSpace(error) ? error : output.Trim();
+}


### PR DESCRIPTION
## What

Completes the mobile install path. **`WgtInstaller`** downloads a `.wgt` and pushes it to the TV via the in-process `ISdbEngine`, using the certs from `CertificateProvisioner`. Mirrors the desktop sequence:

1. Read **capability** → sdk tool path + platform version
2. *(TVs ≤ Tizen 4.0 only)* push the device profile — **permit-install**
3. **re-sign** the package with the author/distributor certs
4. **install**

## Wiring

- Minimal URL downloader to the app cache (no catalog yet — a URL field defaults to the latest Jellyfin Tizen `.wgt`).
- DI: `WgtInstaller` (ISdbEngine + HttpClient).
- **MainPage**: holds the provisioned cert result + a `.wgt` URL entry and a **Download & install** button that runs the full chain against the ready TV.

Builds clean (0 errors).

## Note

On-device **install** (push + `pkgcmd` via `TizenInstaller`) runs for the first time here — it was *not* one of the proven Probe gates (which covered connect/auth, capability, re-sign, certs, OAuth). This PR's on-device smoke is its first real test; may need follow-up fixes like the scan PR did.