### PR TITLE
Core: extract package-modification primitives + TVApp channel injector

### DIFF
--- a/Apps2Samsung.Core/Models/InstallResult.cs
+++ b/Apps2Samsung.Core/Models/InstallResult.cs
@@ -1,9 +1,9 @@
-﻿namespace Apps2Samsung.Models
+namespace Apps2Samsung.Models
 {
     public class InstallResult
     {
         public bool Success { get; init; }
-        public string ErrorMessage { get; init; }
+        public string ErrorMessage { get; init; } = string.Empty;
 
         public static InstallResult SuccessResult() => new() { Success = true };
         public static InstallResult FailureResult(string error) => new()

--- a/Apps2Samsung.Core/Packaging/IPackagePatcher.cs
+++ b/Apps2Samsung.Core/Packaging/IPackagePatcher.cs
@@ -1,5 +1,4 @@
 using Apps2Samsung.Models;
-using System.Threading.Tasks;
 
 namespace Apps2Samsung.Interfaces
 {

--- a/Apps2Samsung.Core/Packaging/PackageWorkspace.cs
+++ b/Apps2Samsung.Core/Packaging/PackageWorkspace.cs
@@ -1,9 +1,12 @@
-﻿using System;
-using System.IO;
 using System.IO.Compression;
 
 namespace Apps2Samsung.Helpers.Core
 {
+    /// <summary>
+    /// Extract-edit-repack helper for a <c>.wgt</c> package (a zip). Extracts to a temp dir next
+    /// to the package, lets callers edit files under <see cref="Root"/>, then repacks in place.
+    /// Portable (System.IO.Compression only) — shared by the desktop and mobile heads.
+    /// </summary>
     public sealed class PackageWorkspace : IDisposable
     {
         public string Root { get; }

--- a/Apps2Samsung.Core/Packaging/TvAppChannelInjector.cs
+++ b/Apps2Samsung.Core/Packaging/TvAppChannelInjector.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Apps2Samsung.Helpers.Core;
+
+namespace Apps2Samsung.Packaging
+{
+    /// <summary>One TVApp channel entry — a display name and an m3u8 (or other) stream URL.</summary>
+    public sealed record TvChannel(string Name, string Url);
+
+    /// <summary>
+    /// Injects a user's TVApp channel list into a TVApp <c>.wgt</c> by rewriting the placeholder
+    /// <c>var channels = [...]</c> array in <c>js/main.js</c>. Settings-agnostic (channels are passed
+    /// in), so both the desktop and mobile heads reuse it — the desktop reads them from its
+    /// <c>AppSettings</c>, mobile from its own settings.
+    /// </summary>
+    public static class TvAppChannelInjector
+    {
+        private const string MainJsRelativePath = "js/main.js";
+
+        // Matches `var channels = [ ... ];` (smallest span, across newlines).
+        private static readonly Regex ChannelsArrayRegex =
+            new(@"var\s+channels\s*=\s*\[.*?\];", RegexOptions.Singleline | RegexOptions.Compiled);
+
+        private static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
+
+        /// <summary>True if the package is a TVApp build (matched by wgt filename).</summary>
+        public static bool AppliesTo(string packagePath)
+            => Path.GetFileName(packagePath).Contains("tvapp", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>Parses a persisted JSON array of <c>{ name, url }</c> into channels (empty on error).</summary>
+        public static IReadOnlyList<TvChannel> ParseChannelsJson(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return Array.Empty<TvChannel>();
+
+            try
+            {
+                var raw = JsonSerializer.Deserialize<List<ChannelDto>>(json, ReadOptions);
+                if (raw is null)
+                    return Array.Empty<TvChannel>();
+
+                return raw.ConvertAll(c => new TvChannel(c.Name ?? string.Empty, c.Url ?? string.Empty));
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[TvApp] Failed to parse configured channels: {ex.Message}");
+                return Array.Empty<TvChannel>();
+            }
+        }
+
+        /// <summary>
+        /// Rewrites the channels array inside the package's <c>js/main.js</c>. No-op (leaves the
+        /// package untouched) if there are no channels, the file is missing, or the placeholder
+        /// array isn't found.
+        /// </summary>
+        public static async Task InjectChannelsAsync(string packagePath, IReadOnlyList<TvChannel> channels)
+        {
+            if (channels.Count == 0)
+            {
+                Trace.WriteLine("[TvApp] No channels configured; leaving package unchanged.");
+                return;
+            }
+
+            using var ws = PackageWorkspace.Extract(packagePath);
+
+            var mainJsPath = Path.Combine(ws.Root, "js", "main.js");
+            if (!File.Exists(mainJsPath))
+            {
+                Trace.WriteLine($"[TvApp] {MainJsRelativePath} not found in package; skipping channels.");
+                return;
+            }
+
+            var js = await File.ReadAllTextAsync(mainJsPath);
+            if (!ChannelsArrayRegex.IsMatch(js))
+            {
+                Trace.WriteLine("[TvApp] channels array not found in main.js; skipping channels.");
+                return;
+            }
+
+            // JSON is valid JS; serialize with lowercase keys to match TVApp's { name, url } shape.
+            var payload = JsonSerializer.Serialize(
+                channels.Select(c => new { name = c.Name ?? string.Empty, url = c.Url ?? string.Empty }));
+
+            js = ChannelsArrayRegex.Replace(js, $"var channels = {payload};", 1);
+
+            await File.WriteAllTextAsync(mainJsPath, js);
+            ws.Repack();
+            Trace.WriteLine($"[TvApp] Injected {channels.Count} channel(s) into {MainJsRelativePath}.");
+        }
+
+        private sealed class ChannelDto
+        {
+            public string? Name { get; set; }
+            public string? Url { get; set; }
+        }
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/Helpers/TvApp/TvAppPackagePatcher.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/TvApp/TvAppPackagePatcher.cs
@@ -1,94 +1,27 @@
-using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Text.Json;
-using System.Text.RegularExpressions;
+using Apps2Samsung.Packaging;
 using System.Threading.Tasks;
 
 namespace Apps2Samsung.Helpers.TvApp
 {
     /// <summary>
     /// Applies the user's TVApp (KaashDev/TVapp) configuration to the package before install:
-    /// rewrites the placeholder <c>var channels = [...]</c> array in <c>js/main.js</c>.
+    /// rewrites the placeholder <c>var channels = [...]</c> array in <c>js/main.js</c>. The actual
+    /// wgt-editing lives in the shared <see cref="TvAppChannelInjector"/> (Apps2Samsung.Core); this
+    /// desktop patcher just feeds it the channels persisted in <see cref="AppSettings"/>.
     /// (The launcher icon — including the 16:9 "oblong" tile — is handled by
     /// <see cref="CustomIconPackagePatcher"/>.)
     /// </summary>
     public class TvAppPackagePatcher : IPackagePatcher
     {
-        private const string MainJsRelativePath = "js/main.js";
-
-        // Matches `var channels = [ ... ];` (smallest span, across newlines).
-        private static readonly Regex ChannelsArrayRegex =
-            new(@"var\s+channels\s*=\s*\[.*?\];", RegexOptions.Singleline | RegexOptions.Compiled);
-
-        private static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
-
-        public bool CanHandle(string packagePath)
-            => Path.GetFileName(packagePath).Contains("tvapp", StringComparison.OrdinalIgnoreCase);
+        public bool CanHandle(string packagePath) => TvAppChannelInjector.AppliesTo(packagePath);
 
         public async Task<InstallResult> ApplyAsync(string packagePath)
         {
-            var channels = LoadConfiguredChannels();
-
-            if (channels.Count == 0)
-            {
-                Trace.WriteLine("[TvApp] No channels configured; leaving package unchanged.");
-                return InstallResult.SuccessResult();
-            }
-
-            using var ws = PackageWorkspace.Extract(packagePath);
-            await PatchChannelsAsync(ws, channels);
-            ws.Repack();
-
+            var channels = TvAppChannelInjector.ParseChannelsJson(AppSettings.Default.TvAppChannelsJson);
+            await TvAppChannelInjector.InjectChannelsAsync(packagePath, channels);
             return InstallResult.SuccessResult();
-        }
-
-        private static async Task PatchChannelsAsync(PackageWorkspace ws, List<TvAppChannel> channels)
-        {
-            var mainJsPath = Path.Combine(ws.Root, "js", "main.js");
-            if (!File.Exists(mainJsPath))
-            {
-                Trace.WriteLine($"[TvApp] {MainJsRelativePath} not found in package; skipping channels.");
-                return;
-            }
-
-            var js = await File.ReadAllTextAsync(mainJsPath);
-
-            if (!ChannelsArrayRegex.IsMatch(js))
-            {
-                Trace.WriteLine("[TvApp] channels array not found in main.js; skipping channels.");
-                return;
-            }
-
-            // JSON is valid JS; serialize with lowercase keys to match TVApp's { name, url } shape.
-            var payload = JsonSerializer.Serialize(
-                channels.ConvertAll(c => new { name = c.Name ?? string.Empty, url = c.Url ?? string.Empty }));
-
-            js = ChannelsArrayRegex.Replace(js, $"var channels = {payload};", 1);
-
-            await File.WriteAllTextAsync(mainJsPath, js);
-            Trace.WriteLine($"[TvApp] Injected {channels.Count} channel(s) into {MainJsRelativePath}.");
-        }
-
-        private static List<TvAppChannel> LoadConfiguredChannels()
-        {
-            var json = AppSettings.Default.TvAppChannelsJson;
-            if (string.IsNullOrWhiteSpace(json))
-                return new List<TvAppChannel>();
-
-            try
-            {
-                return JsonSerializer.Deserialize<List<TvAppChannel>>(json, ReadOptions) ?? new List<TvAppChannel>();
-            }
-            catch (Exception ex)
-            {
-                Trace.WriteLine($"[TvApp] Failed to parse configured channels: {ex.Message}");
-                return new List<TvAppChannel>();
-            }
         }
     }
 }


### PR DESCRIPTION
## What

Foundational refactor for issue #444 (mobile custom WGT + package modification). Moves the desktop's portable package-editing logic into `Apps2Samsung.Core` so the mobile head can reuse it. **No user-facing change.**

Moved into Core (kept in their existing namespaces, so the desktop needs no `using` changes):
- `PackageWorkspace` — extract/edit/repack a `.wgt`
- `IPackagePatcher` + `InstallResult`

Added to Core:
- `TvAppChannelInjector` — **settings-agnostic**: parses a `{name,url}` JSON list and rewrites the `var channels = [...]` array in a TVApp wgt's `js/main.js`. Channels are passed in, so the desktop feeds it `AppSettings.TvAppChannelsJson` and mobile will feed its own settings.

Desktop `TvAppPackagePatcher` now delegates to the Core injector (behavior unchanged).

## Verified
- Desktop (`Apps2Samsung.csproj`) builds clean.
- Mobile (`net10.0-android`) builds clean.

## Next (follow-up PRs)
- Extract the self-update *check* logic into Core (the download/apply stays platform-specific).
- Wire the mobile features: custom-WGT file picker, TVApp channel settings/UI, update check.