### PR TITLE
Mobile: TVApp channel injection (m3u8) + self-update check (issue #444)

### DIFF
--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -3,6 +3,7 @@ using Apps2Samsung.Services;
 using Apps2Samsung.Mobile.Catalog;
 using Apps2Samsung.Mobile.Pages;
 using Apps2Samsung.Mobile.Services;
+using Apps2Samsung.Update;
 using Microsoft.Extensions.Logging;
 using TizenSdb.SdbClient;
 
@@ -56,6 +57,9 @@ public static class MauiProgram
 
 		// App catalog (App/Version dropdowns) — reuses the shared HttpClient for GitHub calls.
 		builder.Services.AddSingleton<CatalogService>();
+
+		// Self-update check (shared Core logic) — matches the .apk asset on the latest release.
+		builder.Services.AddSingleton(sp => new GitHubUpdateChecker(sp.GetRequiredService<HttpClient>()));
 
 		// Session (holds the Samsung sign-in for the app's lifetime) + the installer page.
 		builder.Services.AddSingleton<SessionState>();

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Mobile.Catalog;
 using Apps2Samsung.Mobile.Services;
+using Apps2Samsung.Update;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Storage;
 
@@ -18,6 +19,7 @@ public partial class InstallerPage : ContentPage
 	private readonly CertificateProvisioner _certProvisioner;
 	private readonly WgtInstaller _installer;
 	private readonly CatalogService _catalog;
+	private readonly GitHubUpdateChecker _updateChecker;
 	private readonly SessionState _session;
 
 	// Parallel to TvPicker items: the IP for each listed (debug-ready) TV.
@@ -35,7 +37,7 @@ public partial class InstallerPage : ContentPage
 
 	public InstallerPage(INetworkService networkService, ISamsungLoginService loginService,
 		CertificateProvisioner certProvisioner, WgtInstaller installer, CatalogService catalog,
-		SessionState session)
+		GitHubUpdateChecker updateChecker, SessionState session)
 	{
 		InitializeComponent();
 		_networkService = networkService;
@@ -43,6 +45,7 @@ public partial class InstallerPage : ContentPage
 		_certProvisioner = certProvisioner;
 		_installer = installer;
 		_catalog = catalog;
+		_updateChecker = updateChecker;
 		_session = session;
 
 		// Shows the app version (ApplicationDisplayVersion), so it stays in sync with the build.
@@ -71,6 +74,36 @@ public partial class InstallerPage : ContentPage
 			SetStatus("No apps loaded (offline or GitHub rate-limited). Add a token in Settings, or install a custom .wgt.");
 		else if (catalog.Failed > 0)
 			SetStatus($"Ready — but {catalog.Failed} of {catalog.Total} app sources failed (likely GitHub rate limit). Add a GitHub token in Settings.");
+
+		// Quietly check for a newer build (best-effort; never blocks the UI).
+		_ = CheckForUpdatesAsync();
+	}
+
+	private async Task CheckForUpdatesAsync()
+	{
+		try
+		{
+			var current = AppInfo.Current.VersionString;
+			var result = await _updateChecker.CheckForUpdateAsync(
+				current,
+				includePrereleases: true, // mobile ships as -beta releases
+				assetMatcher: name => name.EndsWith(".apk", StringComparison.OrdinalIgnoreCase));
+
+			if (!result.IsSuccess || !result.IsUpdateAvailable)
+				return;
+
+			var download = await DisplayAlert(
+				"Update available",
+				$"{result.LatestVersion} is available (you have v{current}). Download the new APK?",
+				"Download", "Later");
+
+			if (download)
+				await Launcher.Default.OpenAsync(result.DownloadUrl ?? result.ReleasesPageUrl);
+		}
+		catch
+		{
+			// Update check is best-effort — offline / rate-limited is fine.
+		}
 	}
 
 	private async Task<CatalogService.CatalogResult?> LoadCatalogAsync()

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -94,6 +94,19 @@
 
                 <BoxView Style="{StaticResource Divider}" />
 
+                <!-- TVApp channels (m3u8) -->
+                <Label Text="TVApp channels" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Name + stream URL (m3u8) pairs, written into the TVApp package's channel list when you install it. Order is the play order." />
+                <VerticalStackLayout x:Name="ChannelsContainer" Spacing="8" />
+                <Button Text="➕ Add channel" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                        Padding="14,8" Clicked="OnAddChannel" />
+
+                <BoxView Style="{StaticResource Divider}" />
+
                 <!-- Certificate note (mobile provisions automatically) -->
                 <Label Text="Certificate" FontAttributes="Bold" FontSize="14" />
                 <Label Style="{StaticResource Hint}"

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using Apps2Samsung.Mobile.Services;
 
 namespace Apps2Samsung.Mobile.Pages;
@@ -5,6 +8,9 @@ namespace Apps2Samsung.Mobile.Pages;
 public partial class SettingsPage : ContentPage
 {
 	private bool _loaded;
+	private readonly List<ChannelRow> _channelRows = new();
+
+	private sealed record ChannelRow(View Container, Entry Name, Entry Url);
 
 	public SettingsPage()
 	{
@@ -23,6 +29,12 @@ public partial class SettingsPage : ContentPage
 		OpenAfterSwitch.IsToggled = MobileSettings.OpenAfterInstall;
 		KeepWgtSwitch.IsToggled = MobileSettings.KeepWgtFile;
 		ShowAllJfSwitch.IsToggled = MobileSettings.ShowAllJellyfinVersions;
+
+		ChannelsContainer.Children.Clear();
+		_channelRows.Clear();
+		foreach (var channel in MobileSettings.GetTvAppChannels())
+			AddChannelRow(channel.Name, channel.Url);
+
 		_loaded = true;
 	}
 
@@ -55,5 +67,70 @@ public partial class SettingsPage : ContentPage
 		MobileSettings.OpenAfterInstall = OpenAfterSwitch.IsToggled;
 		MobileSettings.KeepWgtFile = KeepWgtSwitch.IsToggled;
 		MobileSettings.ShowAllJellyfinVersions = ShowAllJfSwitch.IsToggled;
+	}
+
+	private void OnAddChannel(object? sender, EventArgs e) => AddChannelRow(string.Empty, string.Empty);
+
+	private void AddChannelRow(string name, string url)
+	{
+		var nameEntry = new Entry { Text = name, Placeholder = "Name", BackgroundColor = Colors.Transparent };
+		var urlEntry = new Entry { Text = url, Placeholder = "https://…/stream.m3u8", BackgroundColor = Colors.Transparent };
+		var removeBtn = new Button
+		{
+			Text = "✕",
+			FontSize = 14,
+			Padding = 0,
+			WidthRequest = 40,
+			HeightRequest = 40,
+			CornerRadius = 6,
+			BackgroundColor = Colors.Transparent,
+			BorderWidth = 1,
+			BorderColor = Color.FromArgb("#CDD3D8"),
+			TextColor = Color.FromArgb("#B00020"),
+		};
+
+		var grid = new Grid
+		{
+			ColumnSpacing = 8,
+			ColumnDefinitions =
+			{
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(new GridLength(40)),
+			},
+		};
+		Grid.SetColumn(nameEntry, 0);
+		Grid.SetColumn(urlEntry, 1);
+		Grid.SetColumn(removeBtn, 2);
+		grid.Children.Add(nameEntry);
+		grid.Children.Add(urlEntry);
+		grid.Children.Add(removeBtn);
+
+		var row = new ChannelRow(grid, nameEntry, urlEntry);
+		nameEntry.Unfocused += (_, _) => SaveChannels();
+		urlEntry.Unfocused += (_, _) => SaveChannels();
+		removeBtn.Clicked += (_, _) =>
+		{
+			ChannelsContainer.Children.Remove(grid);
+			_channelRows.Remove(row);
+			SaveChannels();
+		};
+
+		_channelRows.Add(row);
+		ChannelsContainer.Children.Add(grid);
+	}
+
+	private void SaveChannels()
+	{
+		if (!_loaded)
+			return;
+
+		// Persist as the {name,url} JSON shape the Core injector expects; skip blank rows.
+		var channels = _channelRows
+			.Select(r => new { name = r.Name.Text ?? string.Empty, url = r.Url.Text ?? string.Empty })
+			.Where(c => !string.IsNullOrWhiteSpace(c.name) || !string.IsNullOrWhiteSpace(c.url))
+			.ToList();
+
+		MobileSettings.TvAppChannelsJson = JsonSerializer.Serialize(channels);
 	}
 }

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -1,3 +1,4 @@
+using Apps2Samsung.Packaging;
 using Microsoft.Maui.Storage;
 
 namespace Apps2Samsung.Mobile.Services;
@@ -15,6 +16,7 @@ public static class MobileSettings
 	private const string KeyKeepWgt = "keep_wgt_file";
 	private const string KeyShowAllJf = "show_all_jellyfin_versions";
 	private const string KeyManualDuids = "manual_duids";
+	private const string KeyTvAppChannels = "tvapp_channels_json";
 	private const string KeyGitHubToken = "github_token"; // SecureStorage
 
 	/// <summary>Uninstall the previous version before installing (desktop: "Remove old version").</summary>
@@ -77,6 +79,17 @@ public static class MobileSettings
 		}
 		catch { /* secure storage unavailable — keep the in-memory value for this run */ }
 	}
+
+	/// <summary>Persisted TVApp channels as a JSON array of {name,url} (empty when unset).</summary>
+	public static string TvAppChannelsJson
+	{
+		get => Preferences.Get(KeyTvAppChannels, string.Empty);
+		set => Preferences.Set(KeyTvAppChannels, value ?? string.Empty);
+	}
+
+	/// <summary>The configured TVApp channels, injected into a TVApp wgt at install time.</summary>
+	public static IReadOnlyList<TvChannel> GetTvAppChannels() =>
+		TvAppChannelInjector.ParseChannelsJson(TvAppChannelsJson);
 
 	/// <summary>Splits <see cref="ManualDuids"/> into individual DUIDs.</summary>
 	public static string[] ParseDuids() =>

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Xml.Linq;
 using Apps2Samsung.Interfaces;
+using Apps2Samsung.Packaging;
 using Microsoft.Maui.Storage;
 
 namespace Apps2Samsung.Mobile.Services;
@@ -80,6 +81,18 @@ public sealed class WgtInstaller
 			var profileXml = Path.Combine(cert.ProfileDir, "device-profile.xml");
 			var target = version < IntermediateVersion ? HomeDeveloperPath : sdkToolPath;
 			await _sdb.PermitInstallAsync(tvIp, profileXml, target);
+		}
+
+		// Apply per-app modifications before signing — e.g. inject the user's TVApp channels
+		// (m3u8 URLs) into a TVApp package's js/main.js. Shared logic lives in Core.
+		if (TvAppChannelInjector.AppliesTo(wgtPath))
+		{
+			var channels = MobileSettings.GetTvAppChannels();
+			if (channels.Count > 0)
+			{
+				progress?.Invoke("Applying TVApp channels…");
+				await TvAppChannelInjector.InjectChannelsAsync(wgtPath, channels);
+			}
 		}
 
 		progress?.Invoke("Re-signing package…");


### PR DESCRIPTION
## What

Completes #444 on mobile, on top of the shared Core logic (#445, #446).

### TVApp channels (m3u8)
- Settings gains a **'TVApp channels'** editor — add/remove *name + stream-URL* rows, saved as `{name,url}` JSON in Preferences.
- `WgtInstaller` runs the Core **`TvAppChannelInjector`** on a TVApp package **before re-signing**, rewriting its `js/main.js` channel list with the configured channels.

### Self-update check
- On launch, `InstallerPage` calls the Core **`GitHubUpdateChecker`** (`includePrereleases: true`, `.apk` asset matcher). If a newer release exists, it prompts to **download the APK** (opens the asset URL, or the releases page as fallback). Best-effort — silent when offline/rate-limited.

## Verified
Builds clean (`net10.0-android`). On-device test pending (phone off adb) — a test APK will be built from this branch.

## Notes
Custom-WGT (the first half of #444) already merged in #447; this branch is based on it, so a build here carries all three features.