### PR TITLE
Mobile: '?' app catalog view (app previews + versions)

### DIFF
--- a/Apps2Samsung.Mobile/Catalog/CatalogService.cs
+++ b/Apps2Samsung.Mobile/Catalog/CatalogService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
+using Apps2Samsung.Catalog;
 using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Models;
 using Apps2Samsung.Mobile.Services;
@@ -23,12 +24,21 @@ public sealed class CatalogService
 
 	private readonly HttpClient _http;
 	private readonly AddLatestRelease _releases;
+	private readonly BuildInfoService _buildInfo;
 
 	public CatalogService(HttpClient http)
 	{
 		_http = http;
 		// Mobile has no auth handler on its HttpClient, so supply the PAT here.
 		_releases = new AddLatestRelease(http, () => MobileSettings.GitHubToken);
+		_buildInfo = new BuildInfoService(http, () => MobileSettings.GitHubToken);
+	}
+
+	/// <summary>Loads the "app preview + versions" catalog for the info view (the "?" button).</summary>
+	public async Task<BuildInfoResult> LoadBuildInfoAsync()
+	{
+		var manifest = await GetManifestAsync();
+		return await _buildInfo.LoadAsync(manifest);
 	}
 
 	/// <summary>The catalog plus how many providers failed to load (e.g. GitHub rate limit).</summary>

--- a/Apps2Samsung.Mobile/Pages/BuildInfoPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/BuildInfoPage.xaml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Apps2Samsung.Mobile.Pages.BuildInfoPage"
+             Title="App catalog"
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#141414}">
+
+    <ContentPage.Resources>
+        <!-- One app card: preview thumbnail + name/version/description. -->
+        <DataTemplate x:Key="RowTemplate">
+            <Border Padding="10" Margin="0,0,0,8" StrokeThickness="1"
+                    StrokeShape="RoundRectangle 6"
+                    Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
+                    BackgroundColor="{AppThemeBinding Light=White, Dark=#242424}">
+                <Grid ColumnDefinitions="84,*" ColumnSpacing="10">
+                    <Border Grid.Column="0" BackgroundColor="{AppThemeBinding Light=#F2F4F6, Dark=#1A1A1A}"
+                            StrokeThickness="0" StrokeShape="RoundRectangle 4" HeightRequest="60">
+                        <Image Source="{Binding Preview}" Aspect="AspectFit" />
+                    </Border>
+                    <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
+                        <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="15" />
+                        <Label Text="{Binding Version}" FontSize="12" TextColor="#2C3E50"
+                               IsVisible="{Binding HasVersion}" />
+                        <Label Text="{Binding Description}" FontSize="12" Opacity="0.7" LineBreakMode="WordWrap" />
+                    </VerticalStackLayout>
+                </Grid>
+            </Border>
+        </DataTemplate>
+    </ContentPage.Resources>
+
+    <ScrollView>
+        <Border Margin="12" Padding="16" StrokeThickness="1"
+                StrokeShape="RoundRectangle 8"
+                Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
+                BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
+            <VerticalStackLayout Spacing="14">
+
+                <!-- Header banner with a back affordance -->
+                <Border BackgroundColor="#2C3E50" Padding="12,18" StrokeThickness="0" StrokeShape="RoundRectangle 8">
+                    <Grid ColumnDefinitions="44,*,44" VerticalOptions="Center">
+                        <Button Grid.Column="0" Text="‹" FontSize="26" TextColor="White"
+                                BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                                WidthRequest="44" HeightRequest="44" Clicked="OnBackClicked" />
+                        <Label Grid.Column="1" Text="App catalog" TextColor="White" FontAttributes="Bold"
+                               VerticalOptions="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                    </Grid>
+                </Border>
+
+                <Label x:Name="StatusLabel" Text="Loading…" HorizontalOptions="Center" Opacity="0.7" />
+                <ActivityIndicator x:Name="Busy" IsRunning="True" HorizontalOptions="Center" Color="#2C3E50" />
+
+                <!-- Jellyfin builds -->
+                <Label x:Name="JellyfinHeader" Text="Jellyfin builds" FontAttributes="Bold" FontSize="14" IsVisible="False" />
+                <VerticalStackLayout x:Name="JellyfinList" Spacing="0"
+                                     BindableLayout.ItemTemplate="{StaticResource RowTemplate}" />
+
+                <!-- Community apps -->
+                <Label x:Name="CommunityHeader" Text="Community apps" FontAttributes="Bold" FontSize="14" IsVisible="False" />
+                <VerticalStackLayout x:Name="CommunityList" Spacing="0"
+                                     BindableLayout.ItemTemplate="{StaticResource RowTemplate}" />
+
+            </VerticalStackLayout>
+        </Border>
+    </ScrollView>
+
+</ContentPage>

--- a/Apps2Samsung.Mobile/Pages/BuildInfoPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/BuildInfoPage.xaml.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using Apps2Samsung.Catalog;
+using Apps2Samsung.Mobile.Catalog;
+using Microsoft.Maui.Controls;
+
+namespace Apps2Samsung.Mobile.Pages;
+
+public partial class BuildInfoPage : ContentPage
+{
+	private readonly CatalogService _catalog;
+	private bool _loaded;
+
+	public BuildInfoPage(CatalogService catalog)
+	{
+		InitializeComponent();
+		_catalog = catalog;
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		if (_loaded)
+			return;
+		_loaded = true;
+
+		try
+		{
+			var result = await _catalog.LoadBuildInfoAsync();
+			var jellyfin = result.JellyfinBuilds.Select(Row.From).ToList();
+			var community = result.CommunityApps.Select(Row.From).ToList();
+
+			BindableLayout.SetItemsSource(JellyfinList, jellyfin);
+			BindableLayout.SetItemsSource(CommunityList, community);
+			JellyfinHeader.IsVisible = jellyfin.Count > 0;
+			CommunityHeader.IsVisible = community.Count > 0;
+
+			Busy.IsRunning = false;
+			Busy.IsVisible = false;
+			StatusLabel.IsVisible = jellyfin.Count == 0 && community.Count == 0;
+			StatusLabel.Text = "Couldn't load the catalog (offline or GitHub rate-limited).";
+		}
+		catch (Exception ex)
+		{
+			Busy.IsRunning = false;
+			Busy.IsVisible = false;
+			StatusLabel.Text = $"Couldn't load the catalog: {ex.Message}";
+		}
+	}
+
+	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
+
+	// View-row adapter over the Core BuildInfoItem (turns the preview URL into an ImageSource).
+	private sealed class Row
+	{
+		public string Name { get; init; } = string.Empty;
+		public string Version { get; init; } = string.Empty;
+		public string Description { get; init; } = string.Empty;
+		public bool HasVersion => !string.IsNullOrWhiteSpace(Version);
+		public ImageSource? Preview { get; init; }
+
+		public static Row From(BuildInfoItem item) => new()
+		{
+			Name = item.Name,
+			Version = item.Version,
+			Description = item.Description,
+			Preview = string.IsNullOrWhiteSpace(item.PreviewImageUrl)
+				? null
+				: ImageSource.FromUri(new Uri(item.PreviewImageUrl!)),
+		};
+	}
+}

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
@@ -42,14 +42,20 @@
                     </Border>
                 </Grid>
 
-                <!-- Version -->
-                <Grid ColumnDefinitions="80,*" ColumnSpacing="10" VerticalOptions="Center">
+                <!-- Version + catalog ("?") -->
+                <Grid ColumnDefinitions="80,*,44" ColumnSpacing="8" VerticalOptions="Center">
                     <Label Grid.Column="0" Text="Version" VerticalOptions="Center" FontSize="14" FontAttributes="Bold" />
                     <Border Grid.Column="1" Padding="8,0" StrokeThickness="1" StrokeShape="RoundRectangle 6"
                             Stroke="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
                             BackgroundColor="{AppThemeBinding Light=White, Dark=#2A2A2A}">
                         <Picker x:Name="VersionPicker" BackgroundColor="Transparent" />
                     </Border>
+                    <Button Grid.Column="2" Text="?" FontSize="18" FontAttributes="Bold"
+                            BackgroundColor="Transparent" BorderWidth="1"
+                            BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                            Padding="0" WidthRequest="44" HeightRequest="44" CornerRadius="22"
+                            Clicked="OnCatalogClicked" />
                 </Grid>
 
                 <!-- TV selection + refresh -->

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -203,6 +203,9 @@ public partial class InstallerPage : ContentPage
 	private async void OnSettingsClicked(object? sender, EventArgs e) =>
 		await Navigation.PushAsync(new SettingsPage());
 
+	private async void OnCatalogClicked(object? sender, EventArgs e) =>
+		await Navigation.PushAsync(new BuildInfoPage(_catalog));
+
 	private async Task ScanAsync()
 	{
 		RefreshBtn.IsEnabled = false;


### PR DESCRIPTION
## What

Adds the mobile equivalent of the desktop's **'?'** catalog window, using the shared Core `BuildInfoService` (from #449).

- A **'?' button** next to the Version dropdown opens a **`BuildInfoPage`** showing app **previews + versions + descriptions**, grouped into **Jellyfin builds** and **Community apps**.
- Data comes from `CatalogService.LoadBuildInfoAsync` → Core `BuildInfoService.LoadAsync` (manifest + README parsing + latest-release tags). Preview images load from their URLs.

## Verified
Builds clean (`net10.0-android`). On-device test pending (phone off adb) — a test APK will be built from this branch.

## Wraps up #444 + the catalog work
custom WGT (#447), TVApp channels + update check (#448), Core consolidation + version helper (#449), and now the mobile catalog view.