### PR TITLE
ci: serialize macOS + Android release uploads (fix transient 5xx)

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -359,7 +359,11 @@ jobs:
 # ======================================================
   android-apk:
     runs-on: ubuntu-latest
-    needs: beta-release
+    # Serialize the release-asset uploads: run after macos-app so the two jobs don't
+    # delete+overwrite the same release concurrently (which triggered GitHub 5xx "Server
+    # Error"s). Still runs even if macos-app fails, as long as the release itself was created.
+    needs: [beta-release, macos-app]
+    if: ${{ always() && needs.beta-release.result == 'success' }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -411,7 +411,11 @@ jobs:
 # ======================================================
   android-apk:
     runs-on: ubuntu-latest
-    needs: stable-release
+    # Serialize the release-asset uploads: run after macos-app so the two jobs don't
+    # delete+overwrite the same release concurrently (which triggered GitHub 5xx "Server
+    # Error"s). Still runs even if macos-app fails, as long as the release itself was created.
+    needs: [stable-release, macos-app]
+    if: ${{ always() && needs.stable-release.result == 'success' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `macos-app` and `android-apk` jobs run in parallel and both delete+overwrite assets on the **same** release tag, which occasionally triggers a GitHub **5xx 'Server Error'** during upload (`action-gh-release` has no retry) — that's what failed the macOS job on the last beta run (the build itself was fine; it died uploading the 4th asset).

Fix: `android-apk` now `needs: [*, macos-app]` so the two upload phases don't overlap. It still runs if macos-app fails (`if: always() && <release-job> == 'success'`), so the APK isn't held hostage to a macOS flake. Applied to **beta** and **stable**.

No build-logic change; verified both YAMLs parse.