### PR TITLE
chore: update nix-shell dotnet to dotnet 10

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ let
 
     targetPkgs = p: with p; [
       # Build and Run
-      dotnet-sdk_8
+      dotnet-sdk_10
       patchelf
       file
       stdenv.cc.cc.lib
@@ -65,7 +65,7 @@ let
           -p:PublishSingleFile=false \
           -p:PublishTrimmed=false
 
-      Jellyfin2Samsung-CrossOS/bin/Release/net8.0/linux-x64/publish/Apps2Samsung
+      Jellyfin2Samsung-CrossOS/bin/Release/net10.0/linux-x64/publish/Apps2Samsung
     '';
   };
 


### PR DESCRIPTION
# Update nix-shell dotnet to dotnet 10

## Branch
- [x] I branched off beta (not master) to develop this feature/fix

## Description
Updated shell.nix to use dotnet 10 instead of 8, to match the rest of the project.

This is to fix the following error after running `nix-shell`:
```output
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been renamed to 'libx11'
evaluation warning: The xorg package set has been deprecated, 'xorg.libICE' has been renamed to 'libice'
evaluation warning: The xorg package set has been deprecated, 'xorg.libSM' has been renamed to 'libsm'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXext' has been renamed to 'libxext'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXext' has been renamed to 'libxext'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXi' has been renamed to 'libxi'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXrandr' has been renamed to 'libxrandr'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXrender' has been renamed to 'libxrender'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXinerama' has been renamed to 'libxinerama'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcomposite' has been renamed to 'libxcomposite'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXdamage' has been renamed to 'libxdamage'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXfixes' has been renamed to 'libxfixes'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXtst' has been renamed to 'libxtst'
  Determining projects to restore...
/nix/store/wwbh38sd57i6dv91pqr8czc1mj5sm51h-dotnet-sdk-8.0.422/share/dotnet/sdk/8.0.422/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 10.0. Download the .NET SDK from https://aka.ms/dotnet/download [/home/zack/dev/Apps2Samsung/Apps2Samsung.Core/Apps2Samsung.Core.csproj]
/nix/store/wwbh38sd57i6dv91pqr8czc1mj5sm51h-dotnet-sdk-8.0.422/share/dotnet/sdk/8.0.422/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(166,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.  Either target .NET 8.0 or lower, or use a version of the .NET SDK that supports .NET 10.0. Download the .NET SDK from https://aka.ms/dotnet/download [/home/zack/dev/Apps2Samsung/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj]
/nix/store/06nhy0vi76qdbw8mhmg5zb84y0v2ilhj-apps2samsung-entry: line 12: Jellyfin2Samsung-CrossOS/bin/Release/net8.0/linux-x64/publish/Apps2Samsung: No such file or directory
```

---

## Type of Change

- [x] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [x] My code follows the existing project structure and style  
- [x] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [x] I have verified that the installer still works with the underlying CLI  

---
