### PR TITLE
Explain install error [118, -4] as a Tizen API-version mismatch

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -114,6 +114,7 @@
   "lblKeepWGTFile": "Preserve WGT file",
   "AuthorMismatch": "Author Certificate mismatch, please re-sign the package with correct certificate.",
   "certificateMismatch": "{0} is already installed with a different signing certificate, so your TV won't replace it in place — and this TV doesn't allow removing apps remotely over the network connection. Please delete {0} on the TV manually (open the Apps list, press and hold {0}, choose Remove), then install it again.",
+  "apiVersionMismatch": "Your TV can't run this app: it was built for a newer Tizen version than your TV has (an API-version mismatch — install error [118, -4]). This is not a certificate or sign-in problem, so re-signing won't help. You need a build of this app made for your TV's Tizen version; check for an older or compatible release, or this app may not support your TV model.",
   "FixYouTube153": "Fix YouTube Plugin (Error 153)",
   "lblBasePath": "Base Path",
   "lblJellyfinUsername": "Username",

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -25,6 +25,9 @@ namespace Apps2Samsung.Helpers.Core
             public const string DownloadFailed116 = "download failed[116]";
             public const string InstallFailed118012 = "install failed[118012]";
             public const string InstallFailed118Minus12 = "install failed[118, -12]";
+            // API-version incompatibility: the package targets a higher Tizen API level than the TV
+            // supports. Distinct from the generic [118] and the [118, -12] cert mismatch.
+            public const string InstallFailed118Minus4 = "install failed[118, -4]";
             public const string InstallFailed118 = "install failed[118]";
             public const string Installing100 = "installing[100]";
             public const string InstallCompleted = "install completed";
@@ -228,6 +231,7 @@ namespace Apps2Samsung.Helpers.Core
             public const string InsufficientSpace = "insufficientSpace";
             public const string AuthorMismatch = "AuthorMismatch";
             public const string CertificateMismatch = "certificateMismatch";
+            public const string ApiVersionMismatch = "apiVersionMismatch";
             public const string ModifyConfigRequired = "modiyConfigRequired";
             public const string DuidLimitReached = "duidLimitReached";
             public const string FailedTizenSdb = "FailedTizenSdb";

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -882,6 +882,19 @@ namespace Apps2Samsung.Services
                 return InstallResult.FailureResult(certMessage);
             }
 
+            // Handle API-version incompatibility ([118, -4] "Operation not allowed"): the package
+            // targets a higher Tizen API level than this TV supports. Not a certificate or privilege
+            // problem, and re-signing/overwriting can't help — the TV simply can't run this build.
+            // Give the user a clear reason instead of a raw error code.
+            if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus4))
+            {
+                _appSettings.TryOverwrite = false;
+                var apiMessage = Constants.LocalizationKeys.ApiVersionMismatch.Localized();
+                progress?.Invoke(apiMessage);
+                Trace.WriteLine($"[Install] API-version incompatibility ([118, -4]) on {tvIpAddress}: {installResults.Output}");
+                return InstallResult.FailureResult(apiMessage);
+            }
+
             // Handle package ID conflict error. Note: a service-component incompatibility
             // (the common cause on older TVs) is already handled before install in Step 3b,
             // so reaching here generally means a genuine id/config conflict.


### PR DESCRIPTION
## Why
`[118, -4] "Operation not allowed"` at install time means the package targets a **higher Tizen API level than the TV supports** — not a certificate, sign-in, or privilege problem. Until now it fell through to the generic failure path and surfaced a raw code, so a user with a perfectly-signed app had no idea why it wouldn't install (we chased it as a cert/partner issue ourselves).

Refs: [flutter-tizen TPK troubleshooting](https://github.com/flutter-tizen/flutter-tizen/wiki/TPK-installation-troubleshooting), [Tizen manifest docs](https://docs.tizen.org/application/tizen-studio/native-tools/manifest-text-editor/).

## What
- New error code `InstallFailed118Minus4 = "install failed[118, -4]"` (distinct from the generic `[118]` and the `[118, -12]` cert mismatch).
- Dedicated handler in `HandleInstallationResultAsync` — no pointless re-sign/overwrite retry (can't help); returns a clear message.
- New `apiVersionMismatch` string (en.json): explains it's a Tizen-version incompatibility and that re-signing won't help. All locales fall back to English for missing keys.

## Verified
`dotnet build` — 0 errors; en.json validated as JSON.