### PR TITLE
Skip draft releases when resolving the Tizen SDB binary

### DIFF
--- a/Apps2Samsung.Core/Models/GitHubRelease.cs
+++ b/Apps2Samsung.Core/Models/GitHubRelease.cs
@@ -19,6 +19,13 @@ namespace Apps2Samsung.Models
         [JsonPropertyName("published_at")]
         public string PublishedAt { get; set; } = string.Empty;
 
+        // GitHub always sorts draft releases to the TOP of the /releases list, and drafts appear
+        // there once the request is authenticated (token/gh). A draft's asset browser_download_url
+        // 404s, so blindly taking releases[0] breaks whenever a release run leaves a draft behind.
+        // Callers must skip drafts and take the newest published release.
+        [JsonPropertyName("draft")]
+        public bool Draft { get; set; }
+
         [JsonPropertyName("assets")]
         public List<Asset> Assets { get; set; } = new();
 

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -114,6 +114,7 @@
   "lblKeepWGTFile": "Preserve WGT file",
   "AuthorMismatch": "Author Certificate mismatch, please re-sign the package with correct certificate.",
   "certificateMismatch": "{0} is already installed with a different signing certificate, so your TV won't replace it in place — and this TV doesn't allow removing apps remotely over the network connection. Please delete {0} on the TV manually (open the Apps list, press and hold {0}, choose Remove), then install it again.",
+  "apiVersionMismatch": "Your TV can't run this app: it was built for a newer Tizen version than your TV has (an API-version mismatch — install error [118, -4]). This is not a certificate or sign-in problem, so re-signing won't help. You need a build of this app made for your TV's Tizen version; check for an older or compatible release, or this app may not support your TV model.",
   "FixYouTube153": "Fix YouTube Plugin (Error 153)",
   "lblBasePath": "Base Path",
   "lblJellyfinUsername": "Username",

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/Constants.cs
@@ -25,6 +25,9 @@ namespace Apps2Samsung.Helpers.Core
             public const string DownloadFailed116 = "download failed[116]";
             public const string InstallFailed118012 = "install failed[118012]";
             public const string InstallFailed118Minus12 = "install failed[118, -12]";
+            // API-version incompatibility: the package targets a higher Tizen API level than the TV
+            // supports. Distinct from the generic [118] and the [118, -12] cert mismatch.
+            public const string InstallFailed118Minus4 = "install failed[118, -4]";
             public const string InstallFailed118 = "install failed[118]";
             public const string Installing100 = "installing[100]";
             public const string InstallCompleted = "install completed";
@@ -228,6 +231,7 @@ namespace Apps2Samsung.Helpers.Core
             public const string InsufficientSpace = "insufficientSpace";
             public const string AuthorMismatch = "AuthorMismatch";
             public const string CertificateMismatch = "certificateMismatch";
+            public const string ApiVersionMismatch = "apiVersionMismatch";
             public const string ModifyConfigRequired = "modiyConfigRequired";
             public const string DuidLimitReached = "duidLimitReached";
             public const string FailedTizenSdb = "FailedTizenSdb";

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -144,7 +144,9 @@ namespace Apps2Samsung.Services
 
                 var json = await response.Content.ReadAsStringAsync();
                 var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(json, JsonSerializerOptionsProvider.Default);
-                var firstRelease = releases?.FirstOrDefault();
+                // Skip drafts: GitHub sorts them to the top of the list once authenticated, but their
+                // assets aren't downloadable. Take the newest published release.
+                var firstRelease = releases?.FirstOrDefault(r => !r.Draft);
 
                 if (firstRelease == null)
                     throw new InvalidOperationException("No releases found");
@@ -163,7 +165,9 @@ namespace Apps2Samsung.Services
             {
                 var json = await _httpClient.GetStringAsync(AppSettings.Default.TizenSdb);
                 var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(json, JsonSerializerOptionsProvider.Default);
-                var firstRelease = (releases?.FirstOrDefault()) ?? throw new InvalidOperationException("No releases found");
+                // Skip drafts: GitHub sorts them to the top once authenticated, but a draft's asset
+                // browser_download_url 404s. Take the newest published release.
+                var firstRelease = (releases?.FirstOrDefault(r => !r.Draft)) ?? throw new InvalidOperationException("No releases found");
                 string nameMatch = PlatformService.GetAssetPlatformIdentifier();
 
                 var matchedAsset = firstRelease.Assets.FirstOrDefault(a =>

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -882,6 +882,19 @@ namespace Apps2Samsung.Services
                 return InstallResult.FailureResult(certMessage);
             }
 
+            // Handle API-version incompatibility ([118, -4] "Operation not allowed"): the package
+            // targets a higher Tizen API level than this TV supports. Not a certificate or privilege
+            // problem, and re-signing/overwriting can't help — the TV simply can't run this build.
+            // Give the user a clear reason instead of a raw error code.
+            if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus4))
+            {
+                _appSettings.TryOverwrite = false;
+                var apiMessage = Constants.LocalizationKeys.ApiVersionMismatch.Localized();
+                progress?.Invoke(apiMessage);
+                Trace.WriteLine($"[Install] API-version incompatibility ([118, -4]) on {tvIpAddress}: {installResults.Output}");
+                return InstallResult.FailureResult(apiMessage);
+            }
+
             // Handle package ID conflict error. Note: a service-component incompatibility
             // (the common cause on older TVs) is already handled before install in Step 3b,
             // so reaching here generally means a genuine id/config conflict.


### PR DESCRIPTION
## Symptom
On startup the beta app failed with **`Initialization failed … 404 (Not Found)`** in `DownloadTizenSdbAsync` → `DownloadPackageAsync`. Not a token/rate-limit issue — the token was set.

## Cause
The tool takes `releases[0]` from `api.github.com/repos/PatrickSt1991/tizen-sdb/releases`. GitHub **sorts draft releases to the top** of that list once the request is authenticated, and a **draft's asset `browser_download_url` 404s**. A stray leftover draft (`v1.1.0`, `untagged-…`) therefore hijacked the pick over the real published **v1.1.1**, and the 404 killed startup.

(Immediate unblock: the stray draft was deleted, so `releases[0]` is now published v1.1.1 — verified HTTP 200. This PR prevents recurrence.)

## Fix
- Model the `draft` field on `GitHubRelease`.
- Select the newest **non-draft** release in both `GetLatestTizenSdbVersionAsync` and `DownloadTizenSdbAsync` (`FirstOrDefault(r => !r.Draft)`).

Scoped to the **Tizen SDB** path only — the main app catalog intentionally serves drafts the tool downloads with a token, so that flow is untouched.

## Verified
`dotnet build` — 0 errors.