### PR TITLE
Send distributor privilege_level lowercase (match official Tizen client)

### DIFF
--- a/Apps2Samsung.Core/Certificate/TizenCertificateService.cs
+++ b/Apps2Samsung.Core/Certificate/TizenCertificateService.cs
@@ -241,7 +241,11 @@ namespace Apps2Samsung.Services
         private async Task<(byte[] profileXml, byte[] distributorCert)> PostDistributorCsrAsync(string accessToken, string userId, byte[] csrBytes, CertificatePrivilegeLevel level)
         {
             var certificateHelper = new CertificateHelper();
-            var privilegeLevel = level.ToString(); // "Public" or "Partner"
+            // svdca expects a LOWERCASE privilege_level ("public"/"partner") — the official Tizen
+            // extension sends lowercase, and the server treats anything that isn't exactly "partner"
+            // as public. Sending "Partner" (the enum's ToString) silently yielded a PUBLIC cert, which
+            // is why partner privileges (e.g. vpnservice) never unlocked. Lowercase it to match.
+            var privilegeLevel = level.ToString().ToLowerInvariant(); // "public" or "partner"
 
             var v1Content = new MultipartFormDataContent
             {


### PR DESCRIPTION
HTTP-intercept of the official Tizen VS Code extension shows its `svdca` distributor requests (v1 + v3) send **`privilege_level=partner`** (lowercase). We were sending the enum's `ToString()` → `"Partner"`/`"Public"`.

svdca accepts either today — verified two ways: the live partner capture succeeded, and the existing `Jelly2Sams - Partner` profile is a genuine Partner-CA cert (`GrantedPrivilege: Partner`). So this is a **byte-for-byte fidelity tweak**, not a behavioural fix — it just makes our request identical to the official client in case a future server build tightens the check.

One-line change in `PostDistributorCsrAsync`: `level.ToString().ToLowerInvariant()`. `dotnet build` — 0 errors.