### PR TITLE
App-icons: list every community app from the live repo (#462)

### DIFF
--- a/Apps2Samsung.Core/Catalog/BuildInfoService.cs
+++ b/Apps2Samsung.Core/Catalog/BuildInfoService.cs
@@ -33,7 +33,7 @@ namespace Apps2Samsung.Catalog
         public const string DefaultJellyfinReadmeUrl =
             "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";
         public const string DefaultCommunityReadmeUrl =
-            "https://raw.githubusercontent.com/PatrickSt1991/tizen-community-packages/refs/heads/main/README.md";
+            "https://raw.githubusercontent.com/Apps2Samsung/tizen-community-packages/refs/heads/main/README.md";
 
         private static readonly Regex VersionsTable =
             new(@"## Versions\s*\n(?<table>(\|[^\n]+\n)+)", RegexOptions.Compiled);

--- a/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
@@ -70,7 +70,7 @@
     },
     {
       "id": "tizen-community",
-      "url": "https://api.github.com/repos/PatrickSt1991/tizen-community-packages/releases",
+      "url": "https://api.github.com/repos/Apps2Samsung/tizen-community-packages/releases",
       "prefix": "",
       "displayName": "Tizen Community",
       "take": 1,

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -138,7 +138,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string ReleaseInfo { get; set; } = "https://raw.githubusercontent.com/jeppevinkel/jellyfin-tizen-builds/refs/heads/master/README.md";
         [JsonIgnore]
-        public string CommunityInfo { get; set; } = "https://raw.githubusercontent.com/PatrickSt1991/tizen-community-packages/refs/heads/main/README.md";
+        public string CommunityInfo { get; set; } = "https://raw.githubusercontent.com/Apps2Samsung/tizen-community-packages/refs/heads/main/README.md";
         public AppSettings() { }
 
         /// <summary>

--- a/Jellyfin2Samsung-CrossOS/ViewModels/AppIconsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/AppIconsViewModel.cs
@@ -31,6 +31,7 @@ namespace Apps2Samsung.ViewModels
         private readonly ILocalizationService _localizationService;
         private readonly FileHelper _fileHelper;
         private readonly ProviderManifestService _providerManifestService;
+        private readonly AddLatestRelease _addLatestRelease;
 
         public ObservableCollection<AppIconEntry> AppIcons { get; } = new();
 
@@ -54,6 +55,7 @@ namespace Apps2Samsung.ViewModels
             _localizationService = localizationService;
             _fileHelper = fileHelper;
             _providerManifestService = new ProviderManifestService(httpClient);
+            _addLatestRelease = new AddLatestRelease(httpClient);
 
             _localizationService.LanguageChanged += OnLanguageChanged;
 
@@ -94,7 +96,33 @@ namespace Apps2Samsung.ViewModels
                 foreach (var provider in manifest.Providers)
                 {
                     if (provider.ExpandAssets)
-                        continue; // the community bundle expands into CommunityApps below
+                    {
+                        // Community bundle: derive one icon entry per real .wgt asset in the latest
+                        // release, so EVERY community app is offered and the list stays current with
+                        // the repo — instead of a hardcoded subset (see #462). Custom launcher icons
+                        // only apply to web apps, so skip native .tpk assets. Best-effort: a fetch
+                        // failure just yields no community rows rather than breaking the editor.
+                        if (string.IsNullOrWhiteSpace(provider.Url))
+                            continue;
+                        try
+                        {
+                            var releases = await _addLatestRelease.GetReleasesAsync(
+                                provider.Url, provider.Prefix, provider.DisplayName, provider.Take);
+                            foreach (var r in releases)
+                                foreach (var asset in r.Assets)
+                                {
+                                    if (!asset.FileName.EndsWith(".wgt", StringComparison.OrdinalIgnoreCase))
+                                        continue;
+                                    var name = Path.GetFileNameWithoutExtension(asset.FileName);
+                                    Add(name, name);
+                                }
+                        }
+                        catch (Exception ex)
+                        {
+                            Trace.WriteLine($"[AppIcons] Could not expand community assets from {provider.Url}: {ex.Message}");
+                        }
+                        continue;
+                    }
 
                     // All Jellyfin builds share the "Jellyfin" file-name root, so collapse the
                     // variants (AVPlay, Legacy, …) into a single entry that matches any of them.
@@ -104,9 +132,6 @@ namespace Apps2Samsung.ViewModels
                     else
                         Add(provider.DisplayName, provider.DisplayName);
                 }
-
-                foreach (var community in manifest.CommunityApps)
-                    Add(community.MatchName, community.MatchName);
 
                 var map = LoadIconMap();
                 foreach (var entry in entries)


### PR DESCRIPTION
Fixes #462 (custom icon for the now-standalone YouTube-Tizen), generally.

## Problem
The App-icons editor built its list from the manifest's **hardcoded `communityApps`** (11 entries), so most community apps — including `TizenYouTube`/`TizenTube` — had no custom-icon option. The *install* list already expands **all** community `.wgt`s via `expandAssets`; the icon editor just didn't.

## Fix
`AppIconsViewModel` now derives community rows from the **live latest-release assets** of the community provider (reusing `AddLatestRelease`, exactly like the install dropdown). Every community app appears automatically and stays current with the repo — no per-app manifest upkeep. Native `.tpk` assets are skipped (custom launcher icons only apply to web apps). The patcher's substring match (`fileName.IndexOf(key)`) means an asset-derived key like `TizenYouTube` matches `TizenYouTube.wgt`.

## Also
Repoint community sources from the personal repo to the org (`PatrickSt1991` → `Apps2Samsung`/tizen-community-packages): bundled manifest fallback, `BuildInfoService` README, `AppSettings.CommunityInfo`. (Root `third-party-apps.json` on `main` repointed separately.)

`dotnet build` — 0 errors.