### PR TITLE
Manifest: point community packages at the org repo

### DIFF
--- a/third-party-apps.json
+++ b/third-party-apps.json
@@ -70,7 +70,7 @@
     },
     {
       "id": "tizen-community",
-      "url": "https://api.github.com/repos/PatrickSt1991/tizen-community-packages/releases",
+      "url": "https://api.github.com/repos/Apps2Samsung/tizen-community-packages/releases",
       "prefix": "",
       "displayName": "Tizen Community",
       "take": 1,


### PR DESCRIPTION
Repoint the `tizen-community` provider URL from `PatrickSt1991/tizen-community-packages` → **`Apps2Samsung/tizen-community-packages`** (both repos currently mirror the same releases; this makes the org repo the canonical source).

This is the **live-fetched** manifest (`raw.githubusercontent.com/.../main/third-party-apps.json`), so it takes effect for all users immediately — no app update needed. Pairs with the code change in #463 (icon list derives community apps from this provider's live assets).