### PR TITLE
Stage 0: shared IAppConfig settings contract in Core

### DIFF
--- a/Apps2Samsung.Core/Configuration/IAppConfig.cs
+++ b/Apps2Samsung.Core/Configuration/IAppConfig.cs
@@ -1,0 +1,50 @@
+namespace Apps2Samsung.Configuration
+{
+    /// <summary>
+    /// The slice of user settings that the shared Core services (certificate provisioning + reuse,
+    /// install orchestration, package patchers) need to read. Each head implements it over its own
+    /// store — the desktop's <c>settings.json</c> god-object, or the mobile head's MAUI Preferences —
+    /// so the moved logic no longer depends on a particular app's settings type.
+    ///
+    /// This is deliberately the *shared subset*, not everything each head persists (the desktop keeps
+    /// far more — Jellyfin server creds, theme, etc.). Grows only as later stages move more logic into
+    /// Core.
+    /// </summary>
+    public interface IAppConfig
+    {
+        // ---- Install behaviour ----
+        /// <summary>Uninstall the previous version before installing.</summary>
+        bool DeletePreviousInstall { get; set; }
+        /// <summary>Launch the app on the TV after a successful install.</summary>
+        bool OpenAfterInstall { get; set; }
+        /// <summary>Keep the downloaded/patched .wgt instead of deleting it.</summary>
+        bool KeepWgtFile { get; set; }
+        /// <summary>Allow an overwrite-install (retry after removing the old copy). Transient control flag.</summary>
+        bool TryOverwrite { get; set; }
+
+        // ---- Catalog ----
+        /// <summary>List every Jellyfin release rather than only the latest.</summary>
+        bool ShowAllJellyfinVersions { get; set; }
+        /// <summary>GitHub PAT used to avoid API rate limits (empty if unset). Read-only on the request path.</summary>
+        string GitHubToken { get; }
+
+        // ---- Signing / certificates ----
+        /// <summary>Opt-in Partner-level distributor signing (default Public).</summary>
+        bool PartnerSigning { get; set; }
+        /// <summary>Per-install bump to Partner because the selected package declares a restricted
+        /// privilege. Runtime-only (not persisted).</summary>
+        bool RequiresPartnerSigning { get; set; }
+        /// <summary>Force a fresh Samsung login + profile even when a reusable cert exists.</summary>
+        bool ForceSamsungLogin { get; set; }
+        /// <summary>Extra TV DUIDs to pre-authorize in the distributor cert (newline/comma separated).</summary>
+        string ManualDuids { get; set; }
+        /// <summary>Directory that holds the generated signing profiles (e.g. "Jelly2Sams - Public/Partner").</summary>
+        string CertificateStorePath { get; }
+
+        // ---- Package patching ----
+        /// <summary>JSON map { appKey -> "oblong" | custom launcher PNG path } applied to a wgt at install.</summary>
+        string CustomAppIconsJson { get; set; }
+        /// <summary>JSON array of { name, url } TVApp channels injected into a TVApp wgt at install.</summary>
+        string TvAppChannelsJson { get; set; }
+    }
+}

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -1,3 +1,4 @@
+using Apps2Samsung.Configuration;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Services;
 using Apps2Samsung.Mobile.Catalog;
@@ -32,6 +33,10 @@ public static class MauiProgram
 		// Ethernet/Wireless80211 and IPv4Mask is unavailable, so the Core scan's interface
 		// enumeration yields nothing. Feed the device's own IPv4 as the custom scan IP: the
 		// scanner then covers its /24 (the mask fallback), which finds TVs on the same LAN.
+		// Shared settings contract — the mobile head's settings adapted to Core's IAppConfig, so the
+		// shared cert/install/patcher services read settings uniformly across both heads.
+		builder.Services.AddSingleton<IAppConfig, MobileAppConfig>();
+
 		builder.Services.AddSingleton<INetworkService>(_ => new NetworkService(customIpProvider: NetworkInfo.GetLocalIPv4));
 
 		// The SDB engine needs a writable directory to persist its RSA auth keypair (the desktop

--- a/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
+++ b/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
@@ -1,0 +1,40 @@
+using Apps2Samsung.Configuration;
+using Microsoft.Maui.Storage;
+
+namespace Apps2Samsung.Mobile.Services;
+
+/// <summary>
+/// Adapts the mobile head's settings (the static <see cref="MobileSettings"/> + MAUI
+/// <see cref="Preferences"/>) to the shared <see cref="IAppConfig"/>, so Core services (cert
+/// provisioning/reuse, install, patchers) read settings the same way on both heads. Fields the
+/// mobile head didn't persist before (force-login, overwrite, custom icons) are added here.
+/// </summary>
+public sealed class MobileAppConfig : IAppConfig
+{
+    private const string KeyForceLogin = "force_samsung_login";
+    private const string KeyTryOverwrite = "try_overwrite";
+    private const string KeyCustomIcons = "custom_app_icons_json";
+
+    // ---- Install behaviour ----
+    public bool DeletePreviousInstall { get => MobileSettings.DeletePreviousInstall; set => MobileSettings.DeletePreviousInstall = value; }
+    public bool OpenAfterInstall { get => MobileSettings.OpenAfterInstall; set => MobileSettings.OpenAfterInstall = value; }
+    public bool KeepWgtFile { get => MobileSettings.KeepWgtFile; set => MobileSettings.KeepWgtFile = value; }
+    public bool TryOverwrite { get => Preferences.Get(KeyTryOverwrite, true); set => Preferences.Set(KeyTryOverwrite, value); }
+
+    // ---- Catalog ----
+    public bool ShowAllJellyfinVersions { get => MobileSettings.ShowAllJellyfinVersions; set => MobileSettings.ShowAllJellyfinVersions = value; }
+    public string GitHubToken => MobileSettings.GitHubToken;
+
+    // ---- Signing / certificates ----
+    public bool PartnerSigning { get => MobileSettings.PartnerSigning; set => MobileSettings.PartnerSigning = value; }
+    // Runtime-only, per-install (mirrors the desktop's [JsonIgnore] RequiresPartnerSigning).
+    public bool RequiresPartnerSigning { get; set; }
+    public bool ForceSamsungLogin { get => Preferences.Get(KeyForceLogin, false); set => Preferences.Set(KeyForceLogin, value); }
+    public string ManualDuids { get => MobileSettings.ManualDuids; set => MobileSettings.ManualDuids = value; }
+    // Root under which the generated signing profiles ("Jelly2Sams - Public/Partner") live.
+    public string CertificateStorePath => Path.Combine(FileSystem.AppDataDirectory, "Certificate");
+
+    // ---- Package patching ----
+    public string CustomAppIconsJson { get => Preferences.Get(KeyCustomIcons, string.Empty); set => Preferences.Set(KeyCustomIcons, value ?? string.Empty); }
+    public string TvAppChannelsJson { get => MobileSettings.TvAppChannelsJson; set => MobileSettings.TvAppChannelsJson = value; }
+}

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 
 namespace Apps2Samsung.Helpers
 {
-    public class AppSettings
+    public class AppSettings : Apps2Samsung.Configuration.IAppConfig
     {
         private const string FileName = "settings.json";
 
@@ -116,6 +116,12 @@ namespace Apps2Samsung.Helpers
         public bool LitefinUseOblongIcon { get; set; } = false;  // legacy: migrated into CustomAppIconsJson ("oblong")
         public string ManualDuids { get; set; } = "";  // extra Tizen DUIDs to pre-authorize in the distributor cert (one per line / comma-separated)
         public string CustomAppIconsJson { get; set; } = "";  // JSON map { appKey -> "oblong" | custom launcher PNG path } applied to the wgt at install
+
+        // ----- IAppConfig adapters (not serialized; map the interface onto existing state) -----
+        [JsonIgnore]
+        public bool KeepWgtFile { get => KeepWGTFile; set => KeepWGTFile = value; }
+        [JsonIgnore]
+        public string CertificateStorePath => CertificatePath;
 
         // ----- Updater settings -----
         public bool CheckForUpdatesOnStartup { get; set; } = true;


### PR DESCRIPTION
**Stage 0 of the desktop↔mobile code-sharing refactor** (prerequisite; no behaviour change).

Introduces `Apps2Samsung.Core/Configuration/IAppConfig` — the shared subset of settings the Core services moved in later stages need (install toggles, signing flags, `ManualDuids`, cert store path, `CustomAppIconsJson`, TVApp channels).

- **Desktop** `AppSettings` implements `IAppConfig` directly (+ `KeepWgtFile` / `CertificateStorePath` adapters over existing state).
- **Mobile** gets `MobileAppConfig` — an adapter over the static `MobileSettings` + MAUI `Preferences`, adding the few fields the mobile head didn't persist yet (force-login, overwrite, custom-icons). Registered in `MauiProgram`.

Lets the shared cert/install/patcher services (Stages 1–3) read settings uniformly instead of depending on a specific head's settings type.

Verified: Core + desktop `dotnet build` 0 errors. Mobile (MAUI) builds on CI.

**Stacked series — merge in order:** 0 → 4 → 1 → 2 → 3 → 5.