### PR TITLE
Stage 4: shared file logging (mobile debuggability)

### DIFF
--- a/Apps2Samsung.Core/Configuration/IAppConfig.cs
+++ b/Apps2Samsung.Core/Configuration/IAppConfig.cs
@@ -1,0 +1,50 @@
+namespace Apps2Samsung.Configuration
+{
+    /// <summary>
+    /// The slice of user settings that the shared Core services (certificate provisioning + reuse,
+    /// install orchestration, package patchers) need to read. Each head implements it over its own
+    /// store — the desktop's <c>settings.json</c> god-object, or the mobile head's MAUI Preferences —
+    /// so the moved logic no longer depends on a particular app's settings type.
+    ///
+    /// This is deliberately the *shared subset*, not everything each head persists (the desktop keeps
+    /// far more — Jellyfin server creds, theme, etc.). Grows only as later stages move more logic into
+    /// Core.
+    /// </summary>
+    public interface IAppConfig
+    {
+        // ---- Install behaviour ----
+        /// <summary>Uninstall the previous version before installing.</summary>
+        bool DeletePreviousInstall { get; set; }
+        /// <summary>Launch the app on the TV after a successful install.</summary>
+        bool OpenAfterInstall { get; set; }
+        /// <summary>Keep the downloaded/patched .wgt instead of deleting it.</summary>
+        bool KeepWgtFile { get; set; }
+        /// <summary>Allow an overwrite-install (retry after removing the old copy). Transient control flag.</summary>
+        bool TryOverwrite { get; set; }
+
+        // ---- Catalog ----
+        /// <summary>List every Jellyfin release rather than only the latest.</summary>
+        bool ShowAllJellyfinVersions { get; set; }
+        /// <summary>GitHub PAT used to avoid API rate limits (empty if unset). Read-only on the request path.</summary>
+        string GitHubToken { get; }
+
+        // ---- Signing / certificates ----
+        /// <summary>Opt-in Partner-level distributor signing (default Public).</summary>
+        bool PartnerSigning { get; set; }
+        /// <summary>Per-install bump to Partner because the selected package declares a restricted
+        /// privilege. Runtime-only (not persisted).</summary>
+        bool RequiresPartnerSigning { get; set; }
+        /// <summary>Force a fresh Samsung login + profile even when a reusable cert exists.</summary>
+        bool ForceSamsungLogin { get; set; }
+        /// <summary>Extra TV DUIDs to pre-authorize in the distributor cert (newline/comma separated).</summary>
+        string ManualDuids { get; set; }
+        /// <summary>Directory that holds the generated signing profiles (e.g. "Jelly2Sams - Public/Partner").</summary>
+        string CertificateStorePath { get; }
+
+        // ---- Package patching ----
+        /// <summary>JSON map { appKey -> "oblong" | custom launcher PNG path } applied to a wgt at install.</summary>
+        string CustomAppIconsJson { get; set; }
+        /// <summary>JSON array of { name, url } TVApp channels injected into a TVApp wgt at install.</summary>
+        string TvAppChannelsJson { get; set; }
+    }
+}

--- a/Apps2Samsung.Core/Diagnostics/FileLog.cs
+++ b/Apps2Samsung.Core/Diagnostics/FileLog.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Apps2Samsung.Diagnostics
+{
+    /// <summary>
+    /// Shared file logging. Routes <see cref="Trace"/> output to
+    /// <c>&lt;logDirectory&gt;/debug_&lt;timestamp&gt;.log</c>. Both heads call
+    /// <see cref="Initialize"/> once at startup — the desktop next to the binary, the mobile head in
+    /// its app-data dir — so the Core services' Trace diagnostics are persisted and the mobile app is
+    /// actually debuggable (it previously logged only to the transient Android debug console).
+    /// </summary>
+    public static class FileLog
+    {
+        private static bool _initialized;
+
+        /// <summary>The debug log file created by <see cref="Initialize"/> (null until initialized).</summary>
+        public static string? CurrentLogFile { get; private set; }
+
+        /// <summary>Adds a file trace listener under <paramref name="logDirectory"/>. Idempotent and
+        /// never throws — logging must not take down startup.</summary>
+        public static void Initialize(string logDirectory)
+        {
+            if (_initialized) return;
+            _initialized = true;
+            try
+            {
+                Directory.CreateDirectory(logDirectory);
+                var dtg = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss-fff");
+                CurrentLogFile = Path.Combine(logDirectory, $"debug_{dtg}.log");
+                Trace.Listeners.Add(new FileTraceListener(CurrentLogFile));
+                Trace.AutoFlush = true;
+            }
+            catch { /* diagnostics must never crash the app */ }
+        }
+    }
+}

--- a/Apps2Samsung.Core/Diagnostics/FileTraceListener.cs
+++ b/Apps2Samsung.Core/Diagnostics/FileTraceListener.cs
@@ -1,12 +1,18 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 
-namespace Apps2Samsung.Extensions
+namespace Apps2Samsung.Diagnostics
 {
+    /// <summary>
+    /// A <see cref="TraceListener"/> that appends every <see cref="Trace"/> line to a file, prefixed
+    /// with a timestamp. Shared by both heads via <see cref="FileLog"/> so diagnostics are persisted
+    /// off-device for debugging (on mobile this is what makes the app debuggable at all).
+    /// </summary>
     public sealed class FileTraceListener : TraceListener
     {
         private readonly string _filePath;
+        private readonly object _gate = new();
 
         public FileTraceListener(string filePath)
         {
@@ -17,16 +23,15 @@ namespace Apps2Samsung.Extensions
         public override void Write(string? message)
         {
             if (message == null) return;
-            File.AppendAllText(_filePath, message);
+            lock (_gate) File.AppendAllText(_filePath, message);
         }
 
         public override void WriteLine(string? message)
         {
             if (message == null) return;
-            File.AppendAllText(
+            lock (_gate) File.AppendAllText(
                 _filePath,
                 $"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {message}{Environment.NewLine}");
         }
     }
-
 }

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -1,3 +1,4 @@
+using Apps2Samsung.Configuration;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Services;
 using Apps2Samsung.Mobile.Catalog;
@@ -32,6 +33,10 @@ public static class MauiProgram
 		// Ethernet/Wireless80211 and IPv4Mask is unavailable, so the Core scan's interface
 		// enumeration yields nothing. Feed the device's own IPv4 as the custom scan IP: the
 		// scanner then covers its /24 (the mask fallback), which finds TVs on the same LAN.
+		// Shared settings contract — the mobile head's settings adapted to Core's IAppConfig, so the
+		// shared cert/install/patcher services read settings uniformly across both heads.
+		builder.Services.AddSingleton<IAppConfig, MobileAppConfig>();
+
 		builder.Services.AddSingleton<INetworkService>(_ => new NetworkService(customIpProvider: NetworkInfo.GetLocalIPv4));
 
 		// The SDB engine needs a writable directory to persist its RSA auth keypair (the desktop

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -14,6 +14,10 @@ public static class MauiProgram
 {
 	public static MauiApp CreateMauiApp()
 	{
+		// Persist Trace diagnostics to a file so the mobile app is actually debuggable (shared infra
+		// with the desktop head). Previously mobile only logged to the transient Android console.
+		Apps2Samsung.Diagnostics.FileLog.Initialize(System.IO.Path.Combine(FileSystem.AppDataDirectory, "Logs"));
+
 		var builder = MauiApp.CreateBuilder();
 		builder
 			.UseMauiApp<App>()

--- a/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
+++ b/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
@@ -1,0 +1,40 @@
+using Apps2Samsung.Configuration;
+using Microsoft.Maui.Storage;
+
+namespace Apps2Samsung.Mobile.Services;
+
+/// <summary>
+/// Adapts the mobile head's settings (the static <see cref="MobileSettings"/> + MAUI
+/// <see cref="Preferences"/>) to the shared <see cref="IAppConfig"/>, so Core services (cert
+/// provisioning/reuse, install, patchers) read settings the same way on both heads. Fields the
+/// mobile head didn't persist before (force-login, overwrite, custom icons) are added here.
+/// </summary>
+public sealed class MobileAppConfig : IAppConfig
+{
+    private const string KeyForceLogin = "force_samsung_login";
+    private const string KeyTryOverwrite = "try_overwrite";
+    private const string KeyCustomIcons = "custom_app_icons_json";
+
+    // ---- Install behaviour ----
+    public bool DeletePreviousInstall { get => MobileSettings.DeletePreviousInstall; set => MobileSettings.DeletePreviousInstall = value; }
+    public bool OpenAfterInstall { get => MobileSettings.OpenAfterInstall; set => MobileSettings.OpenAfterInstall = value; }
+    public bool KeepWgtFile { get => MobileSettings.KeepWgtFile; set => MobileSettings.KeepWgtFile = value; }
+    public bool TryOverwrite { get => Preferences.Get(KeyTryOverwrite, true); set => Preferences.Set(KeyTryOverwrite, value); }
+
+    // ---- Catalog ----
+    public bool ShowAllJellyfinVersions { get => MobileSettings.ShowAllJellyfinVersions; set => MobileSettings.ShowAllJellyfinVersions = value; }
+    public string GitHubToken => MobileSettings.GitHubToken;
+
+    // ---- Signing / certificates ----
+    public bool PartnerSigning { get => MobileSettings.PartnerSigning; set => MobileSettings.PartnerSigning = value; }
+    // Runtime-only, per-install (mirrors the desktop's [JsonIgnore] RequiresPartnerSigning).
+    public bool RequiresPartnerSigning { get; set; }
+    public bool ForceSamsungLogin { get => Preferences.Get(KeyForceLogin, false); set => Preferences.Set(KeyForceLogin, value); }
+    public string ManualDuids { get => MobileSettings.ManualDuids; set => MobileSettings.ManualDuids = value; }
+    // Root under which the generated signing profiles ("Jelly2Sams - Public/Partner") live.
+    public string CertificateStorePath => Path.Combine(FileSystem.AppDataDirectory, "Certificate");
+
+    // ---- Package patching ----
+    public string CustomAppIconsJson { get => Preferences.Get(KeyCustomIcons, string.Empty); set => Preferences.Set(KeyCustomIcons, value ?? string.Empty); }
+    public string TvAppChannelsJson { get => MobileSettings.TvAppChannelsJson; set => MobileSettings.TvAppChannelsJson = value; }
+}

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 
 namespace Apps2Samsung.Helpers
 {
-    public class AppSettings
+    public class AppSettings : Apps2Samsung.Configuration.IAppConfig
     {
         private const string FileName = "settings.json";
 
@@ -116,6 +116,12 @@ namespace Apps2Samsung.Helpers
         public bool LitefinUseOblongIcon { get; set; } = false;  // legacy: migrated into CustomAppIconsJson ("oblong")
         public string ManualDuids { get; set; } = "";  // extra Tizen DUIDs to pre-authorize in the distributor cert (one per line / comma-separated)
         public string CustomAppIconsJson { get; set; } = "";  // JSON map { appKey -> "oblong" | custom launcher PNG path } applied to the wgt at install
+
+        // ----- IAppConfig adapters (not serialized; map the interface onto existing state) -----
+        [JsonIgnore]
+        public bool KeepWgtFile { get => KeepWGTFile; set => KeepWGTFile = value; }
+        [JsonIgnore]
+        public string CertificateStorePath => CertificatePath;
 
         // ----- Updater settings -----
         public bool CheckForUpdatesOnStartup { get; set; } = true;

--- a/Jellyfin2Samsung-CrossOS/Program.cs
+++ b/Jellyfin2Samsung-CrossOS/Program.cs
@@ -11,15 +11,8 @@ namespace Apps2Samsung
         [STAThread]
         public static void Main(string[] args)
         {
-            // Register trace listener BEFORE Avalonia starts
-            var logDir = AppContext.BaseDirectory;
-            string logFolder = Path.Combine(logDir, "Logs");
-            Directory.CreateDirectory(logFolder);
-            var dtg = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss-fff");
-            var logFile = Path.Combine(logFolder, $"debug_{dtg}.log");
-
-            Trace.Listeners.Add(new FileTraceListener(logFile));
-            Trace.AutoFlush = true;
+            // Route Trace to a file BEFORE Avalonia starts (shared with the mobile head via Core).
+            Apps2Samsung.Diagnostics.FileLog.Initialize(Path.Combine(AppContext.BaseDirectory, "Logs"));
 
 
             BuildAvaloniaApp()


### PR DESCRIPTION
**Stage 4** of the desktop↔mobile sharing refactor. Makes the **mobile head debuggable**.

Mobile previously logged only to the transient Android debug console (`builder.Logging.AddDebug()`), so install/cert failures left nothing to inspect. Desktop already routed `Trace` to `Logs/debug_*.log`.

- Move `FileTraceListener` → `Apps2Samsung.Core/Diagnostics`.
- Add `FileLog.Initialize(logDirectory)` (idempotent, never throws) that wires a timestamped `debug_*.log`.
- Desktop `Program.cs` and mobile `MauiProgram` both call it at startup — desktop next to the binary, mobile in its app-data dir.

Now the Core services' `Trace` diagnostics (cert/install/patchers) persist on both heads.

Verified: Core + desktop `dotnet build` 0 errors. Mobile on CI.

**Stacked on #465 — base is `stage0-settings-contract`; merge after Stage 0.**