### PR TITLE
Stage 1: shared cert provisioning + reuse in Core (mobile reuses certs)

### DIFF
--- a/Apps2Samsung.Core/Certificate/CertificateProvisioningService.cs
+++ b/Apps2Samsung.Core/Certificate/CertificateProvisioningService.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Apps2Samsung.Extensions;
+using Apps2Samsung.Helpers.Tizen.Certificate;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+
+namespace Apps2Samsung.Certificate
+{
+    /// <summary>A signing profile ensured for an install.</summary>
+    public sealed record CertificateProfile(
+        string AuthorP12,
+        string DistributorP12,
+        string Password,
+        string ProfileDir,
+        string ProfileName,
+        CertificatePrivilegeLevel Level);
+
+    /// <summary>
+    /// Provisions and — crucially — <b>reuses</b> Samsung signing profiles, shared by both heads.
+    /// Reuse rules (previously desktop-only, which is why the mobile head regenerated a cert on every
+    /// install):
+    /// <list type="bullet">
+    /// <item>A valid author cert whose distributor already covers the TV's DUID (and any manual DUIDs)
+    /// is reused with <b>no Samsung login</b>.</item>
+    /// <item>If the author exists but the DUID isn't covered, only the distributor is regenerated
+    /// (author keypair kept, so already-installed apps stay overwritable).</item>
+    /// <item>Otherwise a full profile is minted.</item>
+    /// </list>
+    /// Public and Partner live in separate <c>"Jelly2Sams - Public/Partner"</c> folders so switching
+    /// level never clobbers the other. A Samsung login (<see cref="ISamsungLoginService"/>) is only
+    /// triggered when a regenerate/full-profile is actually needed.
+    /// </summary>
+    public sealed class CertificateProvisioningService
+    {
+        public const string ProfileBaseName = "Jelly2Sams";
+        private const string AuthorFileName = "author.p12";
+        private const string DistributorFileName = "distributor.p12";
+        private const string PasswordFileName = "password.txt";
+        private const int MaxDistributorDuids = 10;
+
+        private readonly ITizenCertificateService _certService;
+        private readonly ISamsungLoginService _login;
+
+        public CertificateProvisioningService(ITizenCertificateService certService, ISamsungLoginService login)
+        {
+            _certService = certService;
+            _login = login;
+        }
+
+        /// <summary>The profile folder name for a level, e.g. "Jelly2Sams - Partner".</summary>
+        public static string ProfileName(CertificatePrivilegeLevel level) =>
+            $"{ProfileBaseName} - {(level == CertificatePrivilegeLevel.Partner ? "Partner" : "Public")}";
+
+        /// <summary>
+        /// Ensure a signing profile for <paramref name="level"/> that covers <paramref name="deviceDuid"/>
+        /// (+ <paramref name="manualDuids"/>), reusing an existing one when possible. Only performs a
+        /// Samsung login when a full profile or a distributor regen is required.
+        /// </summary>
+        /// <param name="storePath">Root dir holding the level profiles (e.g. IAppConfig.CertificateStorePath).</param>
+        /// <param name="caPath">Dir containing the Samsung CA files.</param>
+        /// <param name="onLoginStarting">Invoked right before a Samsung login is triggered (heads use it
+        /// to switch UI); not called on the silent-reuse path.</param>
+        public async Task<CertificateProfile> EnsureAsync(
+            string deviceDuid,
+            CertificatePrivilegeLevel level,
+            string storePath,
+            string caPath,
+            IEnumerable<string>? manualDuids = null,
+            bool forceLogin = false,
+            Action? onLoginStarting = null,
+            ProgressCallback? progress = null,
+            CancellationToken ct = default)
+        {
+            if (!TizenDuid.IsValid(deviceDuid))
+                throw new ArgumentException("A valid TV DUID is required.", nameof(deviceDuid));
+
+            var profileName = ProfileName(level);
+            var profileDir = Path.Combine(storePath, profileName);
+
+            var manual = (manualDuids ?? Enumerable.Empty<string>())
+                .Where(TizenDuid.IsValid)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            bool hasAuthor = HasUsableAuthorCert(profileDir);
+            var covered = hasAuthor
+                ? GetCoveredDuids(profileDir)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            bool duidsCovered = covered.Contains(deviceDuid) && manual.All(covered.Contains);
+
+            bool needsFullProfile = forceLogin || !hasAuthor;
+            bool needsDistributorOnly = !needsFullProfile && !duidsCovered;
+
+            // ---- Silent reuse: valid author + DUID already covered ----
+            if (!needsFullProfile && !needsDistributorOnly)
+            {
+                var pw = File.ReadAllText(Path.Combine(profileDir, PasswordFileName)).Trim();
+                return new CertificateProfile(
+                    Path.Combine(profileDir, AuthorFileName),
+                    Path.Combine(profileDir, DistributorFileName),
+                    pw, profileDir, profileName, level);
+            }
+
+            // ---- A Samsung login is required ----
+            onLoginStarting?.Invoke();
+            var auth = await _login.LoginAsync(ct);
+            if (string.IsNullOrEmpty(auth.access_token))
+                throw new InvalidOperationException("Failed to authenticate with the Samsung account.");
+
+            var duids = BuildDistributorDuids(deviceDuid, manual, covered);
+
+            string authorP12, distributorP12, password;
+            if (needsFullProfile)
+            {
+                (authorP12, distributorP12, password) = await _certService.GenerateProfileAsync(
+                    duids, auth.access_token, auth.userId, auth.inputEmailID, profileDir, caPath, level, progress);
+            }
+            else
+            {
+                // Reuse the author keypair; only the distributor cert is regenerated.
+                distributorP12 = await _certService.RegenerateDistributorAsync(
+                    profileDir, duids, auth.access_token, auth.userId, auth.inputEmailID, caPath, level, progress);
+                authorP12 = Path.Combine(profileDir, AuthorFileName);
+                password = File.ReadAllText(Path.Combine(profileDir, PasswordFileName)).Trim();
+            }
+
+            return new CertificateProfile(authorP12, distributorP12, password, profileDir, profileName, level);
+        }
+
+        /// <summary>True if the profile dir has a loadable, unexpired author cert.</summary>
+        public static bool HasUsableAuthorCert(string certDir)
+        {
+            try
+            {
+                var authorP12 = Path.Combine(certDir, AuthorFileName);
+                var passwordFile = Path.Combine(certDir, PasswordFileName);
+                if (!File.Exists(authorP12) || !File.Exists(passwordFile))
+                    return false;
+
+                var password = File.ReadAllText(passwordFile).Trim();
+#pragma warning disable SYSLIB0057 // matches the proven loader used elsewhere; legacy PKCS#12 support
+                using var cert = new X509Certificate2(authorP12, password, X509KeyStorageFlags.Exportable);
+#pragma warning restore SYSLIB0057
+                return cert.NotAfter.Date >= DateTime.Today;
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[Cert] Author cert check failed for '{certDir}': {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>DUIDs already covered by the distributor cert in <paramref name="certDir"/>.</summary>
+        public static HashSet<string> GetCoveredDuids(string certDir)
+        {
+            try
+            {
+                var passwordFile = Path.Combine(certDir, PasswordFileName);
+                if (!File.Exists(passwordFile))
+                    return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                var password = File.ReadAllText(passwordFile).Trim();
+                var distributor = Path.Combine(certDir, DistributorFileName);
+                return new CertificateHelper().GetCertificateDuids(distributor, password);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[Cert] Could not read covered DUIDs from '{certDir}': {ex.Message}");
+                return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        /// <summary>The DUID set a (re)generated distributor cert should cover: this TV first, then
+        /// manual entries, then already-covered ones — capped at Samsung's per-cert limit.</summary>
+        public static IReadOnlyCollection<string> BuildDistributorDuids(
+            string currentDuid, IEnumerable<string> manual, IEnumerable<string> covered)
+        {
+            var ordered = new List<string>();
+            void Add(string d)
+            {
+                if (TizenDuid.IsValid(d) && !ordered.Contains(d.Trim(), StringComparer.OrdinalIgnoreCase))
+                    ordered.Add(d.Trim());
+            }
+
+            Add(currentDuid);
+            foreach (var d in manual) Add(d);
+            foreach (var d in covered) Add(d);
+
+            return ordered.Count > MaxDistributorDuids
+                ? ordered.Take(MaxDistributorDuids).ToList()
+                : ordered;
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -1,3 +1,4 @@
+using Apps2Samsung.Certificate;
 using Apps2Samsung.Configuration;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Services;
@@ -59,6 +60,9 @@ public static class MauiProgram
 		builder.Services.AddSingleton(new HttpClient());
 		builder.Services.AddSingleton<ITizenCertificateService>(sp =>
 			new TizenCertificateService(sp.GetRequiredService<HttpClient>(), CertificateEndpoints.Default));
+		// Shared reuse-aware provisioning: reuses a valid profile covering the TV and only logs in
+		// when it must (re)generate. Depends on the shared cert service + this head's login service.
+		builder.Services.AddSingleton<CertificateProvisioningService>();
 		builder.Services.AddSingleton<CertificateProvisioner>();
 
 		// Install: download a .wgt and push it to the TV (resign -> [permit] -> install).

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -286,18 +286,14 @@ public partial class InstallerPage : ContentPage
 		string? wgtPath = null;
 		try
 		{
-			if (!_session.IsSignedIn)
-			{
-				SetStatus("Signing in to Samsung…");
-				_session.Auth = await _loginService.LoginAsync();
-			}
-
 			// Download first so we can inspect the package's declared privileges before signing.
 			wgtPath = custom ? _customWgtPath! : await _installer.DownloadAsync(asset!.DownloadUrl, SetStatus);
 
 			// Partner if the manifest declared it OR the .wgt itself needs a partner-level privilege.
 			var needsPartner = requirePartner || WgtPrivileges.RequiresPartner(wgtPath);
-			var cert = await _certProvisioner.ProvisionAsync(tvIp, _session.Auth!, needsPartner, SetStatus);
+			// Provisioning reuses a valid cert already covering this TV and only triggers a Samsung
+			// sign-in when it must (re)generate — so no login prompt when a cert is already in place.
+			var cert = await _certProvisioner.ProvisionAsync(tvIp, needsPartner, SetStatus);
 			await _installer.InstallAsync(tvIp, wgtPath, cert, SetStatus);
 
 			SetStatus($"✓ Installed {appName}. Open the TV's Apps list to launch it.");

--- a/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
+++ b/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
@@ -1,5 +1,5 @@
-using System.Linq;
-using Apps2Samsung.Extensions;
+using Apps2Samsung.Certificate;
+using Apps2Samsung.Configuration;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using Microsoft.Maui.Storage;
@@ -7,10 +7,11 @@ using Microsoft.Maui.Storage;
 namespace Apps2Samsung.Mobile.Services;
 
 /// <summary>
-/// Ties Samsung sign-in to certificate provisioning on the mobile head: reads the target TV's DUID
-/// via the in-process engine, then drives the shared <see cref="ITizenCertificateService"/> to mint
-/// the author + distributor PKCS#12s. Materializes the bundled Samsung CA files to a real filesystem
-/// path first (the cert service reads them via <c>File.*</c>, and Android package assets aren't files).
+/// Mobile certificate provisioning. Reads the target TV's DUID via the in-process engine, materializes
+/// the bundled Samsung CA files to a real path, then drives the shared
+/// <see cref="CertificateProvisioningService"/> — which <b>reuses</b> a valid signing profile that
+/// already covers the TV and only triggers a Samsung login when it must (re)generate. (Previously the
+/// mobile head minted a fresh cert — and forced a login — on every install.)
 /// </summary>
 public sealed class CertificateProvisioner
 {
@@ -18,17 +19,19 @@ public sealed class CertificateProvisioner
 	private static readonly string[] CaFiles = { "vd_tizen_dev_author_ca.cer", "vd_tizen_dev_public2.crt", "vd_tizen_dev_partner2.crt" };
 
 	private readonly ISdbEngine _sdb;
-	private readonly ITizenCertificateService _certService;
+	private readonly CertificateProvisioningService _provisioning;
+	private readonly IAppConfig _config;
 
-	public CertificateProvisioner(ISdbEngine sdb, ITizenCertificateService certService)
+	public CertificateProvisioner(ISdbEngine sdb, CertificateProvisioningService provisioning, IAppConfig config)
 	{
 		_sdb = sdb;
-		_certService = certService;
+		_provisioning = provisioning;
+		_config = config;
 	}
 
 	public sealed record Result(string AuthorP12, string DistributorP12, string Password, string ProfileDir, string Duid);
 
-	public async Task<Result> ProvisionAsync(string tvIp, SamsungAuth auth, bool requirePartner = false, Action<string>? progress = null)
+	public async Task<Result> ProvisionAsync(string tvIp, bool requirePartner = false, Action<string>? progress = null)
 	{
 		progress?.Invoke("Reading TV DUID…");
 		var duidResult = await _sdb.DuidAsync(tvIp);
@@ -39,35 +42,25 @@ public sealed class CertificateProvisioner
 				$"Could not read a valid TV DUID{(string.IsNullOrWhiteSpace(duidResult.Error) ? "." : $": {duidResult.Error}")}");
 
 		var caPath = await MaterializeCaAsync();
-		var profileDir = Path.Combine(FileSystem.AppDataDirectory, "TizenProfile");
 
-		// The target TV's DUID, plus any extra DUIDs the user pre-authorized in settings, so one
-		// certificate can cover several TVs.
-		var duids = new[] { duid }
-			.Concat(MobileSettings.ParseDuids())
-			.Where(TizenDuid.IsValid)
-			.Distinct(StringComparer.OrdinalIgnoreCase)
-			.ToArray();
-
-		// Opt-in Partner signing (experimental) — needed only by apps that use restricted
-		// privileges (e.g. vpnservice). Partner if the global toggle is on OR the selected package
-		// declares it needs it; default stays Public.
-		var level = (MobileSettings.PartnerSigning || requirePartner)
+		// Opt-in Partner signing (experimental) — needed only by apps that use restricted privileges
+		// (e.g. vpnservice). Partner if the global toggle is on OR the selected package declares it.
+		var level = (_config.PartnerSigning || requirePartner)
 			? CertificatePrivilegeLevel.Partner
 			: CertificatePrivilegeLevel.Public;
 
 		ProgressCallback? cb = progress is null ? null : new ProgressCallback(progress);
-		var (authorP12, distributorP12, password) = await _certService.GenerateProfileAsync(
-			duids: duids,
-			accessToken: auth.access_token,
-			userId: auth.userId,
-			userEmail: auth.inputEmailID,
-			outputPath: profileDir,
-			caPath: caPath,
+		var profile = await _provisioning.EnsureAsync(
+			deviceDuid: duid,
 			level: level,
+			storePath: _config.CertificateStorePath,
+			caPath: caPath,
+			manualDuids: MobileSettings.ParseDuids(),
+			forceLogin: _config.ForceSamsungLogin,
+			onLoginStarting: () => progress?.Invoke("Signing in to Samsung…"),
 			progress: cb);
 
-		return new Result(authorP12, distributorP12, password, profileDir, duid);
+		return new Result(profile.AuthorP12, profile.DistributorP12, profile.Password, profile.ProfileDir, duid);
 	}
 
 	// Copies the bundled CA certs to <AppData>/ca once, returning that directory.


### PR DESCRIPTION
**Stage 1** — fixes the original problem: **certificates weren't reusable on mobile** (it minted a fresh cert and forced a Samsung login on every install).

## What
New `Apps2Samsung.Core/Certificate/CertificateProvisioningService` with the reuse logic that was previously desktop-only:
- valid author cert + distributor already covers the TV's DUID (+ manual DUIDs) → **reuse, no login**;
- author exists but DUID not covered → **regenerate distributor only** (keeps the author keypair);
- otherwise → full profile. Public/Partner in separate `Jelly2Sams - Public/Partner` folders. A Samsung login (`ISamsungLoginService`) fires **only** when a (re)generate is needed.

## Mobile now uses it
- `CertificateProvisioner` delegates to the shared service (via `IAppConfig` + the mobile login service).
- `InstallerPage` drops the **eager pre-login** — sign-in now happens inside provisioning only when required.

## Desktop
Unchanged in this PR. Its equivalent logic lives inside `TizenInstallerService`, so it adopts this shared service in **Stage 2** (install orchestration) rather than doing risky cert surgery here.

Verified: Core + desktop `dotnet build` 0 errors. **Mobile (MAUI) compiles on your CI.**

Base `beta` (Stages 0 + 4 already merged).