### PR TITLE
Stage 3 (mobile UI): Settings → App icons page

### DIFF
--- a/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Apps2Samsung.Mobile.Pages.AppIconsPage"
+             Title="App icons"
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#141414}">
+    <ScrollView>
+        <Border Margin="12" Padding="16" StrokeThickness="1"
+                StrokeShape="RoundRectangle 8"
+                Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
+                BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
+            <VerticalStackLayout Spacing="14">
+
+                <!-- Header banner with a back affordance -->
+                <Border BackgroundColor="#2C3E50" Padding="12,18" StrokeThickness="0" StrokeShape="RoundRectangle 8">
+                    <Grid ColumnDefinitions="44,*,44" VerticalOptions="Center">
+                        <Button Grid.Column="0" Text="‹" FontSize="26" TextColor="White"
+                                BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                                WidthRequest="44" HeightRequest="44" Clicked="OnBackClicked" />
+                        <Label Grid.Column="1" Text="App icons" TextColor="White" FontAttributes="Bold"
+                               VerticalOptions="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                    </Grid>
+                </Border>
+
+                <Label FontSize="12" Opacity="0.6"
+                       Text="Give an app a custom launcher icon. Enter the app name as it appears in the app list (e.g. &quot;Jellyfin&quot; or &quot;TizenYouTube&quot;) and pick a PNG — it's applied to that package when you install it." />
+
+                <VerticalStackLayout x:Name="IconsContainer" Spacing="10" />
+
+                <Button Text="+ Add app icon" Clicked="OnAddIcon" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
+
+            </VerticalStackLayout>
+        </Border>
+    </ScrollView>
+</ContentPage>

--- a/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Apps2Samsung.Mobile.Services;
+using Microsoft.Maui.Storage;
+
+namespace Apps2Samsung.Mobile.Pages;
+
+/// <summary>
+/// Settings → App icons. Lets the user map an app (by a name substring of its .wgt, e.g. "Jellyfin")
+/// to a custom launcher PNG; the map is persisted in <see cref="MobileSettings.CustomAppIconsJson"/>
+/// and applied at install by the shared <c>CustomIconPackagePatcher</c>. Built as dynamic rows to
+/// mirror the TVApp-channels editor (no data binding), for robustness.
+/// </summary>
+public partial class AppIconsPage : ContentPage
+{
+	private readonly List<IconRow> _rows = new();
+
+	private sealed record IconRow(View Container, Entry Key, Label PathLabel)
+	{
+		public string? IconPath { get; set; }
+	}
+
+	public AppIconsPage()
+	{
+		InitializeComponent();
+		foreach (var (key, value) in LoadMap())
+			AddRow(key, value);
+	}
+
+	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
+
+	private void OnAddIcon(object? sender, EventArgs e) => AddRow(string.Empty, string.Empty);
+
+	private void AddRow(string key, string value)
+	{
+		var keyEntry = new Entry { Text = key, Placeholder = "App name (e.g. Jellyfin)", BackgroundColor = Colors.Transparent };
+		var pathLabel = new Label
+		{
+			FontSize = 12,
+			Opacity = 0.6,
+			LineBreakMode = LineBreakMode.TailTruncation,
+			VerticalOptions = LayoutOptions.Center,
+		};
+		var chooseBtn = new Button { Text = "Choose…", FontSize = 13, Padding = new Thickness(10, 0), HeightRequest = 40, CornerRadius = 6 };
+		var removeBtn = new Button
+		{
+			Text = "✕",
+			FontSize = 14,
+			Padding = 0,
+			WidthRequest = 40,
+			HeightRequest = 40,
+			CornerRadius = 6,
+			BackgroundColor = Colors.Transparent,
+			BorderWidth = 1,
+			BorderColor = Color.FromArgb("#CDD3D8"),
+			TextColor = Color.FromArgb("#B00020"),
+		};
+
+		var grid = new Grid
+		{
+			ColumnSpacing = 8,
+			RowSpacing = 2,
+			ColumnDefinitions =
+			{
+				new ColumnDefinition(GridLength.Star),
+				new ColumnDefinition(GridLength.Auto),
+				new ColumnDefinition(new GridLength(40)),
+			},
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
+			},
+		};
+		Grid.SetColumn(keyEntry, 0); Grid.SetRow(keyEntry, 0);
+		Grid.SetColumn(chooseBtn, 1); Grid.SetRow(chooseBtn, 0);
+		Grid.SetColumn(removeBtn, 2); Grid.SetRow(removeBtn, 0);
+		Grid.SetColumn(pathLabel, 0); Grid.SetRow(pathLabel, 1); Grid.SetColumnSpan(pathLabel, 3);
+		grid.Children.Add(keyEntry);
+		grid.Children.Add(chooseBtn);
+		grid.Children.Add(removeBtn);
+		grid.Children.Add(pathLabel);
+
+		var row = new IconRow(grid, keyEntry, pathLabel)
+		{
+			IconPath = string.IsNullOrWhiteSpace(value) ? null : value,
+		};
+		pathLabel.Text = DescribePath(row.IconPath);
+
+		keyEntry.Unfocused += (_, _) => Save();
+		chooseBtn.Clicked += async (_, _) => { await PickAsync(row); Save(); };
+		removeBtn.Clicked += (_, _) =>
+		{
+			IconsContainer.Children.Remove(grid);
+			_rows.Remove(row);
+			Save();
+		};
+
+		_rows.Add(row);
+		IconsContainer.Children.Add(grid);
+	}
+
+	private static string DescribePath(string? path) =>
+		string.IsNullOrWhiteSpace(path) ? "No icon chosen" : $"Icon: {Path.GetFileName(path)}";
+
+	private async Task PickAsync(IconRow row)
+	{
+		try
+		{
+			var result = await FilePicker.Default.PickAsync(new PickOptions
+			{
+				PickerTitle = "Select a launcher icon (PNG)",
+				FileTypes = FilePickerFileType.Images,
+			});
+			if (result is null)
+				return;
+
+			// Copy into app data so the path stays valid after the picker URI is released.
+			var dir = Path.Combine(FileSystem.AppDataDirectory, "app-icons");
+			Directory.CreateDirectory(dir);
+			var baseName = string.Concat((row.Key.Text ?? "icon").Select(c => char.IsLetterOrDigit(c) ? c : '_'));
+			if (string.IsNullOrWhiteSpace(baseName)) baseName = "icon";
+			var dest = Path.Combine(dir, baseName + Path.GetExtension(result.FileName));
+			using (var src = await result.OpenReadAsync())
+			using (var dst = File.Create(dest))
+				await src.CopyToAsync(dst);
+
+			row.IconPath = dest;
+			row.PathLabel.Text = DescribePath(dest);
+		}
+		catch (Exception ex)
+		{
+			await DisplayAlert("App icons", $"Couldn't set the icon: {ex.Message}", "OK");
+		}
+	}
+
+	private void Save()
+	{
+		var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var r in _rows)
+		{
+			var k = r.Key.Text?.Trim();
+			if (string.IsNullOrWhiteSpace(k) || string.IsNullOrWhiteSpace(r.IconPath))
+				continue;
+			map[k!] = r.IconPath!;
+		}
+		MobileSettings.CustomAppIconsJson = JsonSerializer.Serialize(map);
+	}
+
+	private static Dictionary<string, string> LoadMap()
+	{
+		var json = MobileSettings.CustomAppIconsJson;
+		if (string.IsNullOrWhiteSpace(json))
+			return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		try
+		{
+			return JsonSerializer.Deserialize<Dictionary<string, string>>(json) is { } m
+				? new Dictionary<string, string>(m, StringComparer.OrdinalIgnoreCase)
+				: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		}
+		catch
+		{
+			return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		}
+	}
+}

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -113,6 +113,18 @@
 
                 <BoxView Style="{StaticResource Divider}" />
 
+                <!-- App icons -->
+                <Label Text="App icons" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Give an app a custom launcher icon, applied when you install it." />
+                <Button Text="🎨 Manage app icons" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="14,8"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                        Clicked="OnAppIconsClicked" />
+
+                <BoxView Style="{StaticResource Divider}" />
+
                 <!-- Certificate note (mobile provisions automatically) -->
                 <Label Text="Certificate" FontAttributes="Bold" FontSize="14" />
                 <Label Style="{StaticResource Hint}"

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -41,6 +41,8 @@ public partial class SettingsPage : ContentPage
 
 	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
 
+	private async void OnAppIconsClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new AppIconsPage());
+
 	private void OnToggleTokenVisibility(object? sender, EventArgs e)
 	{
 		TokenEntry.IsPassword = !TokenEntry.IsPassword;

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -103,6 +103,15 @@ public static class MobileSettings
 	public static IReadOnlyList<TvChannel> GetTvAppChannels() =>
 		TvAppChannelInjector.ParseChannelsJson(TvAppChannelsJson);
 
+	/// <summary>Per-app custom launcher icons: JSON map { appKey -> "oblong" | custom PNG path },
+	/// applied to the wgt at install by the shared CustomIconPackagePatcher. (Same Preferences key as
+	/// MobileAppConfig.CustomAppIconsJson, so the settings page and the patcher share one store.)</summary>
+	public static string CustomAppIconsJson
+	{
+		get => Preferences.Get("custom_app_icons_json", string.Empty);
+		set => Preferences.Set("custom_app_icons_json", value ?? string.Empty);
+	}
+
 	/// <summary>Splits <see cref="ManualDuids"/> into individual DUIDs.</summary>
 	public static string[] ParseDuids() =>
 		ManualDuids.Split(new[] { '\n', '\r', ',', ';' },


### PR DESCRIPTION
**Stage 3 (part 2 — the mobile UI).** Lights up custom app-icons on mobile end-to-end. Stacked on the shared-patcher PR (#468).

Adds **Settings → App icons**: map an app (by a name substring of its `.wgt` — e.g. `Jellyfin`, `TizenYouTube`) to a custom launcher PNG. Persists to `MobileSettings.CustomAppIconsJson` (the same key the shared `CustomIconPackagePatcher` reads), so it's applied at install by the pipeline from #468. Picked PNGs are copied into app-data so the path survives.

Built as **dynamic rows** mirroring the existing TVApp-channels editor (no data binding) to minimise fragility.

⚠️ **Mobile-only, and I can't compile MAUI here** — I pattern-matched the existing pages closely, but this needs your **Android build to validate** (you flagged expecting a fix round or two). Everything else in the slice (#468) is build-verified on Core + desktop.

**Merge after #468.**