### PR TITLE
Fix mobile build: missing using in CertificateProvisioner (CS0246)

### DIFF
--- a/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
+++ b/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
@@ -1,5 +1,6 @@
 using Apps2Samsung.Certificate;
 using Apps2Samsung.Configuration;
+using Apps2Samsung.Extensions;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using Microsoft.Maui.Storage;


### PR DESCRIPTION
The android-apk CI job failed with `CS0246: 'ProgressCallback' could not be found` in `CertificateProvisioner.cs`. My Stage 1 rewrite (#467) dropped `using Apps2Samsung.Extensions;` (where `ProgressCallback` lives). Restore it.

**Verified locally this time:** the full `Apps2Samsung.Mobile` (`net10.0-android`) project now builds with **0 errors** — including the App-icons page from #469/#470. (Turns out the maui-android workload is available here, so I can compile-verify mobile going forward.)