### PR TITLE
Mobile: correct stale Settings certificate note

### DIFF
--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -125,10 +125,10 @@
 
                 <BoxView Style="{StaticResource Divider}" />
 
-                <!-- Certificate note (mobile provisions automatically) -->
+                <!-- Certificate note (auto-provisioned + reused; Public/Partner via the toggle above) -->
                 <Label Text="Certificate" FontAttributes="Bold" FontSize="14" />
                 <Label Style="{StaticResource Hint}"
-                       Text="On mobile the signing certificate is provisioned automatically from your Samsung account during install — no manual certificate selection is needed." />
+                       Text="Signing certificates are created and reused automatically from your Samsung account — one cert per TV, reused across installs, so you're not asked to sign in every time. Public is used by default; turn on Partner signing above only for apps that need a restricted privilege (e.g. VPN)." />
 
             </VerticalStackLayout>
         </Border>


### PR DESCRIPTION
The Settings → Certificate note still said *"the signing certificate is provisioned automatically … no manual certificate selection is needed."* That's now misleading after cert reuse + Partner signing landed on mobile.

Reworded to describe the actual behavior:
- Certs are **created and reused** automatically (one per TV, no repeated Samsung sign-in).
- **Public** is used by default.
- The **Partner signing** toggle above is the real Public/Partner choice.

Text-only change in `SettingsPage.xaml`. Mobile project builds clean locally (net10.0-android, Release).