### PR TITLE
Mobile: wire Jellyfin settings store + register the patcher

### DIFF
--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -70,6 +70,11 @@ public static class MauiProgram
 		// "oblong" tiles, so a no-op oblong source — only user-supplied custom PNG icons apply here.
 		builder.Services.AddSingleton<IOblongIconSource, NoOblongIconSource>();
 		builder.Services.AddSingleton<IPackagePatcher, CustomIconPackagePatcher>();
+		// Jellyfin config injection (server URL + auto-login + custom CSS), configured via the
+		// Settings → Jellyfin page. No-ops when no server is set (empty JellyfinFullUrl).
+		builder.Services.AddSingleton<IPackagePatcher>(sp =>
+			new Apps2Samsung.Helpers.Jellyfin.JellyfinPackagePatcher(
+				sp.GetRequiredService<HttpClient>(), sp.GetRequiredService<IAppConfig>()));
 
 		// Install: download a .wgt and push it to the TV (patch -> resign -> [permit] -> install).
 		builder.Services.AddSingleton<WgtInstaller>();

--- a/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
+++ b/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
@@ -39,18 +39,22 @@ public sealed class MobileAppConfig : IAppConfig
     public string TvAppChannelsJson { get => MobileSettings.TvAppChannelsJson; set => MobileSettings.TvAppChannelsJson = value; }
 
     // ---- Jellyfin package patching ----
-    // Temporary stubs: the mobile head does not yet expose the Jellyfin patch settings, and the
-    // Jellyfin patcher is not registered in MauiProgram yet, so these are never read on mobile.
-    public string JellyfinFullUrl => string.Empty;             // TODO(PR B): wire to MobileSettings
-    public string JellyfinServerLocalAddress => string.Empty;  // TODO(PR B): wire to MobileSettings
-    public string JellyfinAccessToken => string.Empty;         // TODO(PR B): wire to MobileSettings
-    public string JellyfinUserId => string.Empty;              // TODO(PR B): wire to MobileSettings
-    public string JellyfinServerId => string.Empty;            // TODO(PR B): wire to MobileSettings
-    public string JellyfinServerName => string.Empty;          // TODO(PR B): wire to MobileSettings
-    public bool UseServerScripts => false;                     // TODO(PR B): wire to MobileSettings
-    public bool PatchYoutubePlugin => false;                   // TODO(PR B): wire to MobileSettings
-    public bool EnableDevLogs => false;                        // TODO(PR B): wire to MobileSettings
-    public string CustomCss => string.Empty;                   // TODO(PR B): wire to MobileSettings
-    public string DisabledPluginIds => string.Empty;          // TODO(PR B): wire to MobileSettings
-    public string LocalIp => string.Empty;                     // TODO(PR B): wire to MobileSettings
+    // Backed by the Settings → Jellyfin page (MobileSettings). Read by the shared
+    // JellyfinPackagePatcher at install to inject server URL + auto-login + custom CSS.
+    public string JellyfinFullUrl => Apps2Samsung.Helpers.Core.UrlHelper.NormalizeServerUrl(MobileSettings.JellyfinServerUrl);
+    public string JellyfinServerLocalAddress => MobileSettings.JellyfinServerLocalAddress;
+    public string JellyfinAccessToken => MobileSettings.JellyfinAccessToken;
+    public string JellyfinUserId => MobileSettings.JellyfinUserId;
+    public string JellyfinServerId => MobileSettings.JellyfinServerId;
+    public string JellyfinServerName => MobileSettings.JellyfinServerName;
+    public string CustomCss => MobileSettings.JellyfinCustomCss;
+    public bool PatchYoutubePlugin => MobileSettings.JellyfinPatchYoutube;
+
+    // Not exposed on mobile: "Use server scripts" (unneeded + relies on a bundled esbuild binary
+    // that isn't shipped on Android) and its plugin opt-outs; dev-logs (streams to a desktop-only
+    // websocket listener, no counterpart on the phone).
+    public bool UseServerScripts => false;
+    public string DisabledPluginIds => string.Empty;
+    public bool EnableDevLogs => false;
+    public string LocalIp => string.Empty;
 }

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -19,6 +19,14 @@ public static class MobileSettings
 	private const string KeyTvAppChannels = "tvapp_channels_json";
 	private const string KeyPartnerSigning = "partner_signing";
 	private const string KeyGitHubToken = "github_token"; // SecureStorage
+	private const string KeyJellyfinServerUrl = "jellyfin_server_url";
+	private const string KeyJellyfinUserId = "jellyfin_user_id";
+	private const string KeyJellyfinServerId = "jellyfin_server_id";
+	private const string KeyJellyfinServerName = "jellyfin_server_name";
+	private const string KeyJellyfinServerLocalAddress = "jellyfin_server_local_address";
+	private const string KeyJellyfinCustomCss = "jellyfin_custom_css";
+	private const string KeyJellyfinPatchYoutube = "jellyfin_patch_youtube";
+	private const string KeyJellyfinAccessToken = "jellyfin_access_token"; // SecureStorage
 
 	/// <summary>Uninstall the previous version before installing (desktop: "Remove old version").</summary>
 	public static bool DeletePreviousInstall
@@ -66,8 +74,9 @@ public static class MobileSettings
 		set => Preferences.Set(KeyManualDuids, value ?? string.Empty);
 	}
 
-	// SecureStorage is async; cache the token so callers on the request path can read it synchronously.
+	// SecureStorage is async; cache secrets so callers on the request path can read them synchronously.
 	private static string _gitHubToken = string.Empty;
+	private static string _jellyfinAccessToken = string.Empty;
 
 	/// <summary>The GitHub PAT (empty if unset). Backed by <see cref="SecureStorage"/>.</summary>
 	public static string GitHubToken => _gitHubToken;
@@ -77,6 +86,9 @@ public static class MobileSettings
 	{
 		try { _gitHubToken = await SecureStorage.GetAsync(KeyGitHubToken) ?? string.Empty; }
 		catch { _gitHubToken = string.Empty; }
+
+		try { _jellyfinAccessToken = await SecureStorage.GetAsync(KeyJellyfinAccessToken) ?? string.Empty; }
+		catch { _jellyfinAccessToken = string.Empty; }
 	}
 
 	public static async Task SetGitHubTokenAsync(string? value)
@@ -88,6 +100,74 @@ public static class MobileSettings
 				SecureStorage.Remove(KeyGitHubToken);
 			else
 				await SecureStorage.SetAsync(KeyGitHubToken, _gitHubToken);
+		}
+		catch { /* secure storage unavailable — keep the in-memory value for this run */ }
+	}
+
+	// ---- Jellyfin (Settings → Jellyfin): injected into a Jellyfin .wgt at install by the shared
+	// JellyfinPackagePatcher via IAppConfig/MobileAppConfig. ----
+
+	/// <summary>Full Jellyfin server URL as entered by the user (scheme://host:port[/base]).</summary>
+	public static string JellyfinServerUrl
+	{
+		get => Preferences.Get(KeyJellyfinServerUrl, string.Empty);
+		set => Preferences.Set(KeyJellyfinServerUrl, value ?? string.Empty);
+	}
+
+	/// <summary>Authenticated user id (from username/password login); paired with the access token.</summary>
+	public static string JellyfinUserId
+	{
+		get => Preferences.Get(KeyJellyfinUserId, string.Empty);
+		set => Preferences.Set(KeyJellyfinUserId, value ?? string.Empty);
+	}
+
+	/// <summary>Real server GUID from /System/Info/Public (prevents ServerMismatch on auto-login).</summary>
+	public static string JellyfinServerId
+	{
+		get => Preferences.Get(KeyJellyfinServerId, string.Empty);
+		set => Preferences.Set(KeyJellyfinServerId, value ?? string.Empty);
+	}
+
+	/// <summary>Human-readable server name shown in the Jellyfin server picker.</summary>
+	public static string JellyfinServerName
+	{
+		get => Preferences.Get(KeyJellyfinServerName, string.Empty);
+		set => Preferences.Set(KeyJellyfinServerName, value ?? string.Empty);
+	}
+
+	/// <summary>Server's self-reported LAN address, used as a reachable fallback in the server list.</summary>
+	public static string JellyfinServerLocalAddress
+	{
+		get => Preferences.Get(KeyJellyfinServerLocalAddress, string.Empty);
+		set => Preferences.Set(KeyJellyfinServerLocalAddress, value ?? string.Empty);
+	}
+
+	/// <summary>User custom CSS injected into index.html (empty = none).</summary>
+	public static string JellyfinCustomCss
+	{
+		get => Preferences.Get(KeyJellyfinCustomCss, string.Empty);
+		set => Preferences.Set(KeyJellyfinCustomCss, value ?? string.Empty);
+	}
+
+	/// <summary>Apply the YouTube-plugin ("error 153") fix to the package.</summary>
+	public static bool JellyfinPatchYoutube
+	{
+		get => Preferences.Get(KeyJellyfinPatchYoutube, false);
+		set => Preferences.Set(KeyJellyfinPatchYoutube, value);
+	}
+
+	/// <summary>Jellyfin access token (empty if unset). Backed by <see cref="SecureStorage"/>.</summary>
+	public static string JellyfinAccessToken => _jellyfinAccessToken;
+
+	public static async Task SetJellyfinAccessTokenAsync(string? value)
+	{
+		_jellyfinAccessToken = value?.Trim() ?? string.Empty;
+		try
+		{
+			if (string.IsNullOrEmpty(_jellyfinAccessToken))
+				SecureStorage.Remove(KeyJellyfinAccessToken);
+			else
+				await SecureStorage.SetAsync(KeyJellyfinAccessToken, _jellyfinAccessToken);
 		}
 		catch { /* secure storage unavailable — keep the in-memory value for this run */ }
 	}


### PR DESCRIPTION
**PR B of the mobile-Jellyfin work** (follows #473).

Makes the mobile head able to inject Jellyfin config at install — today it injects nothing.

- **MobileSettings**: new Jellyfin fields — server URL, user id, server id/name/local-address, custom CSS, YouTube-fix toggle; **access token in SecureStorage** (same pattern as the GitHub PAT, cached for synchronous reads).
- **MobileAppConfig**: maps those to the `IAppConfig` Jellyfin members (`JellyfinFullUrl` normalized via the now-shared `UrlHelper`).
- **MauiProgram**: registers the shared `JellyfinPackagePatcher` as an `IPackagePatcher`, so `WgtInstaller` applies it (server URL + auto-login + custom CSS) before re-signing.

**Not exposed on mobile** (hard-wired off): *Use server scripts* (unneeded + esbuild binary absent on Android) and *dev-logs* (desktop-only websocket listener).

**Inert until PR C**: there's no UI to set a server URL yet, so `JellyfinFullUrl` is empty and the patcher no-ops. Safe to merge alone. Mobile builds **0 errors**.

Next: **PR C** — the Settings → Jellyfin page (server URL, username/password login, custom CSS, YouTube toggle).