### PR TITLE
Mobile: add Settings → Jellyfin page

### DIFF
--- a/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Apps2Samsung.Mobile.Pages.JellyfinSettingsPage"
+             Title="Jellyfin"
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#141414}">
+
+    <ContentPage.Resources>
+        <Style x:Key="Divider" TargetType="BoxView">
+            <Setter Property="HeightRequest" Value="1" />
+            <Setter Property="Color" Value="{AppThemeBinding Light=#E2E2E2, Dark=#333}" />
+            <Setter Property="Margin" Value="0,4" />
+        </Style>
+        <Style x:Key="Hint" TargetType="Label">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="Opacity" Value="0.6" />
+        </Style>
+        <Style x:Key="Field" TargetType="Border">
+            <Setter Property="Padding" Value="8,0" />
+            <Setter Property="StrokeThickness" Value="1" />
+            <Setter Property="StrokeShape" Value="RoundRectangle 6" />
+            <Setter Property="Stroke" Value="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}" />
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=White, Dark=#2A2A2A}" />
+        </Style>
+    </ContentPage.Resources>
+
+    <ScrollView>
+        <Border Margin="12" Padding="16" StrokeThickness="1"
+                StrokeShape="RoundRectangle 8"
+                Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
+                BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
+            <VerticalStackLayout Spacing="14">
+
+                <!-- Header banner with a back affordance -->
+                <Border BackgroundColor="#2C3E50" Padding="12,18" StrokeThickness="0" StrokeShape="RoundRectangle 8">
+                    <Grid ColumnDefinitions="44,*,44" VerticalOptions="Center">
+                        <Button Grid.Column="0" Text="‹" FontSize="26" TextColor="White"
+                                BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                                WidthRequest="44" HeightRequest="44" Clicked="OnBackClicked" />
+                        <Label Grid.Column="1" Text="Jellyfin server" TextColor="White" FontAttributes="Bold"
+                               VerticalOptions="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                    </Grid>
+                </Border>
+
+                <Label Style="{StaticResource Hint}"
+                       Text="Point installed Jellyfin apps at your server and sign in once, so the TV app opens straight to your library. These settings are baked into the Jellyfin package when you install it." />
+
+                <!-- Server URL -->
+                <Label Text="Server URL" FontAttributes="Bold" FontSize="14" />
+                <Border Style="{StaticResource Field}">
+                    <Entry x:Name="ServerUrlEntry" Keyboard="Url" Placeholder="http://192.168.1.10:8096"
+                           BackgroundColor="Transparent" Unfocused="OnServerUrlUnfocused" />
+                </Border>
+                <Label Style="{StaticResource Hint}"
+                       Text="Full address including http:// or https:// and the port. Include a base path too if you use a reverse proxy (e.g. https://media.example.com/jellyfin)." />
+
+                <BoxView Style="{StaticResource Divider}" />
+
+                <!-- Auto-login -->
+                <Label Text="Auto-login (optional)" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Sign in to bake credentials into the package so the TV app skips the login screen. Leave blank to only set the server address." />
+                <Border Style="{StaticResource Field}">
+                    <Entry x:Name="UsernameEntry" Placeholder="Username" BackgroundColor="Transparent" />
+                </Border>
+                <Grid ColumnDefinitions="*,44" ColumnSpacing="8">
+                    <Border Grid.Column="0" Style="{StaticResource Field}">
+                        <Entry x:Name="PasswordEntry" IsPassword="True" Placeholder="Password" BackgroundColor="Transparent" />
+                    </Border>
+                    <Button Grid.Column="1" x:Name="PwEyeBtn" Text="👁" FontSize="16"
+                            BackgroundColor="Transparent" BorderWidth="1"
+                            BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                            Padding="0" WidthRequest="44" HeightRequest="44" CornerRadius="6"
+                            Clicked="OnTogglePasswordVisibility" />
+                </Grid>
+                <Button x:Name="SignInBtn" Text="Connect &amp; sign in" Clicked="OnSignInClicked"
+                        HorizontalOptions="Start" BackgroundColor="#2C3E50" TextColor="White"
+                        CornerRadius="6" Padding="16,8" />
+                <Label x:Name="StatusLabel" Style="{StaticResource Hint}" IsVisible="False" />
+                <Button x:Name="SignOutBtn" Text="Clear saved sign-in" Clicked="OnSignOutClicked"
+                        HorizontalOptions="Start" IsVisible="False"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#B00020, Dark=#FF6B6B}" />
+
+                <BoxView Style="{StaticResource Divider}" />
+
+                <!-- YouTube fix -->
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                    <Label Grid.Column="0" Text="Fix YouTube trailers (error 153)" VerticalOptions="Center" />
+                    <Switch Grid.Column="1" x:Name="YoutubeSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
+                </Grid>
+                <Label Style="{StaticResource Hint}"
+                       Text="Patches the YouTube-trailers plugin so trailers play on Tizen instead of failing with error 153." />
+
+                <BoxView Style="{StaticResource Divider}" />
+
+                <!-- Custom CSS -->
+                <Label Text="Custom CSS" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Injected into the Jellyfin web client. Use it to tweak the look, or paste an @import for a community theme." />
+                <Border Style="{StaticResource Field}" Padding="8,4">
+                    <Editor x:Name="CssEditor" HeightRequest="120" Placeholder="/* your CSS here */"
+                            BackgroundColor="Transparent" Unfocused="OnCssUnfocused" />
+                </Border>
+
+            </VerticalStackLayout>
+        </Border>
+    </ScrollView>
+
+</ContentPage>

--- a/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Apps2Samsung.Helpers.API;
+using Apps2Samsung.Helpers.Core;
+using Apps2Samsung.Mobile.Services;
+
+namespace Apps2Samsung.Mobile.Pages;
+
+/// <summary>
+/// Settings → Jellyfin. Sets the server URL and (optionally) signs in so the shared
+/// <c>JellyfinPackagePatcher</c> can bake the server address + auto-login credentials + custom CSS
+/// into a Jellyfin .wgt at install. Mirrors the desktop Jellyfin settings, minus the desktop-only
+/// bits (server scripts / plugin patches, dev-logs, multi-user admin, playback prefs). Values persist
+/// eagerly to <see cref="MobileSettings"/>, matching the other mobile settings pages.
+/// </summary>
+public partial class JellyfinSettingsPage : ContentPage
+{
+	private bool _loaded;
+
+	public JellyfinSettingsPage()
+	{
+		InitializeComponent();
+	}
+
+	protected override void OnAppearing()
+	{
+		base.OnAppearing();
+
+		_loaded = false;
+		ServerUrlEntry.Text = MobileSettings.JellyfinServerUrl;
+		CssEditor.Text = MobileSettings.JellyfinCustomCss;
+		YoutubeSwitch.IsToggled = MobileSettings.JellyfinPatchYoutube;
+		_loaded = true;
+
+		RefreshSignInState();
+	}
+
+	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
+
+	private void OnServerUrlUnfocused(object? sender, FocusEventArgs e)
+	{
+		if (_loaded)
+			MobileSettings.JellyfinServerUrl = ServerUrlEntry.Text?.Trim() ?? string.Empty;
+	}
+
+	private void OnCssUnfocused(object? sender, FocusEventArgs e)
+	{
+		if (_loaded)
+			MobileSettings.JellyfinCustomCss = CssEditor.Text ?? string.Empty;
+	}
+
+	private void OnToggle(object? sender, ToggledEventArgs e)
+	{
+		if (_loaded)
+			MobileSettings.JellyfinPatchYoutube = YoutubeSwitch.IsToggled;
+	}
+
+	private void OnTogglePasswordVisibility(object? sender, EventArgs e)
+	{
+		PasswordEntry.IsPassword = !PasswordEntry.IsPassword;
+		PwEyeBtn.Opacity = PasswordEntry.IsPassword ? 1.0 : 0.5;
+	}
+
+	private async void OnSignInClicked(object? sender, EventArgs e)
+	{
+		// Persist the latest URL first so the "no server" gate and auth use the same value.
+		MobileSettings.JellyfinServerUrl = ServerUrlEntry.Text?.Trim() ?? string.Empty;
+		var serverUrl = UrlHelper.NormalizeServerUrl(MobileSettings.JellyfinServerUrl);
+		var username = UsernameEntry.Text?.Trim() ?? string.Empty;
+		var password = PasswordEntry.Text ?? string.Empty;
+
+		if (string.IsNullOrWhiteSpace(serverUrl))
+		{
+			SetStatus("Enter a server URL first.", isError: true);
+			return;
+		}
+		if (string.IsNullOrWhiteSpace(username))
+		{
+			SetStatus("Enter a username to sign in (or just leave the server URL set).", isError: true);
+			return;
+		}
+
+		SignInBtn.IsEnabled = false;
+		SetStatus("Connecting…", isError: false);
+		try
+		{
+			// A dedicated client so auth-header mutations never touch the app's shared HttpClient.
+			using var http = new HttpClient();
+			var api = new JellyfinApiClient(http);
+
+			var (accessToken, userId, isAdmin, error) = await api.AuthenticateAsync(serverUrl, username, password);
+			if (string.IsNullOrEmpty(accessToken) || string.IsNullOrEmpty(userId))
+			{
+				SetStatus(error ?? "Sign-in failed. Check the server URL and credentials.", isError: true);
+				return;
+			}
+
+			await MobileSettings.SetJellyfinAccessTokenAsync(accessToken);
+			MobileSettings.JellyfinUserId = userId;
+
+			// Cache the real server GUID/name/LAN address so auto-login won't hit a ServerMismatch.
+			var info = await api.GetPublicSystemInfoAsync(serverUrl);
+			if (info is not null && !string.IsNullOrEmpty(info.Id))
+			{
+				MobileSettings.JellyfinServerId = info.Id;
+				MobileSettings.JellyfinServerName = info.ServerName ?? string.Empty;
+				MobileSettings.JellyfinServerLocalAddress = info.LocalAddress ?? string.Empty;
+			}
+
+			RefreshSignInState();
+			PasswordEntry.Text = string.Empty;
+		}
+		catch (Exception ex)
+		{
+			SetStatus($"Sign-in failed: {ex.Message}", isError: true);
+		}
+		finally
+		{
+			SignInBtn.IsEnabled = true;
+		}
+	}
+
+	private async void OnSignOutClicked(object? sender, EventArgs e)
+	{
+		await MobileSettings.SetJellyfinAccessTokenAsync(null);
+		MobileSettings.JellyfinUserId = string.Empty;
+		MobileSettings.JellyfinServerId = string.Empty;
+		MobileSettings.JellyfinServerName = string.Empty;
+		MobileSettings.JellyfinServerLocalAddress = string.Empty;
+		RefreshSignInState();
+	}
+
+	// Reflects whether saved credentials exist: shows a signed-in banner + the clear button, or a hint.
+	private void RefreshSignInState()
+	{
+		var signedIn = !string.IsNullOrEmpty(MobileSettings.JellyfinAccessToken)
+					   && !string.IsNullOrEmpty(MobileSettings.JellyfinUserId);
+		if (signedIn)
+		{
+			var name = MobileSettings.JellyfinServerName;
+			SetStatus(string.IsNullOrEmpty(name)
+				? "Signed in — auto-login will be baked into the package."
+				: $"Signed in to {name} — auto-login will be baked into the package.", isError: false);
+		}
+		else
+		{
+			StatusLabel.IsVisible = false;
+		}
+		SignOutBtn.IsVisible = signedIn;
+	}
+
+	private void SetStatus(string message, bool isError)
+	{
+		StatusLabel.Text = message;
+		StatusLabel.TextColor = isError ? Color.FromArgb("#B00020") : Color.FromArgb("#2E7D32");
+		StatusLabel.Opacity = 1.0;
+		StatusLabel.IsVisible = true;
+	}
+}

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -61,6 +61,18 @@
 
                 <BoxView Style="{StaticResource Divider}" />
 
+                <!-- Jellyfin server -->
+                <Label Text="Jellyfin" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Set your Jellyfin server address and sign in once, baked into the Jellyfin app when you install it." />
+                <Button Text="🎬 Configure Jellyfin server" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="14,8"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                        Clicked="OnJellyfinClicked" />
+
+                <BoxView Style="{StaticResource Divider}" />
+
                 <!-- Extra TV device IDs -->
                 <Label Text="Extra TV device IDs" FontAttributes="Bold" FontSize="14" />
                 <Border Padding="8,4" StrokeThickness="1" StrokeShape="RoundRectangle 6"

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -43,6 +43,8 @@ public partial class SettingsPage : ContentPage
 
 	private async void OnAppIconsClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new AppIconsPage());
 
+	private async void OnJellyfinClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new JellyfinSettingsPage());
+
 	private void OnToggleTokenVisibility(object? sender, EventArgs e)
 	{
 		TokenEntry.IsPassword = !TokenEntry.IsPassword;


### PR DESCRIPTION
**PR C of the mobile-Jellyfin work** (follows #473, #474). This is the user-facing piece.

Adds a **Settings → Jellyfin** page (reached via a *Configure Jellyfin server* button on Settings):
- **Server URL** — full address incl. scheme/port and optional reverse-proxy base path.
- **Auto-login (optional)** — username/password → access token + user id; caches the real server GUID / name / LAN address from `/System/Info/Public` so auto-login won't ServerMismatch. Shows signed-in state + a *Clear saved sign-in*.
- **Custom CSS** editor.
- **Fix YouTube trailers (error 153)** toggle.

Values persist to `MobileSettings`; the shared `JellyfinPackagePatcher` (registered in #474) bakes them into a Jellyfin `.wgt` at install. Sign-in uses a dedicated `HttpClient` (no mutation of the app's shared client); the token is stored in `SecureStorage`.

**Scope** (per decision): mirrors desktop minus the desktop-only pieces — no *Use server scripts*/plugin patches, no dev-logs, no multi-user admin, no server-side Playback prefs.

Mobile (net10.0-android, Release): **0 errors**. Merge #474 before this (already merged); this branch is rebased on the current `beta`.

After this merges, the whole mobile-Jellyfin feature is done — only the backlogged release-notes pass remains.