### PR TITLE
Desktop: route Samsung login through ISamsungLoginService

### DIFF
--- a/Jellyfin2Samsung-CrossOS/App.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/App.axaml.cs
@@ -113,6 +113,7 @@ namespace Apps2Samsung
             });
 
             services.AddSingleton<SamsungLoginService>();
+            services.AddSingleton<ISamsungLoginService>(sp => sp.GetRequiredService<SamsungLoginService>());
             services.AddSingleton<JellyfinApiClient>();
             services.AddSingleton<TizenApiClient>();
             services.AddSingleton<PluginManager>();

--- a/Jellyfin2Samsung-CrossOS/Services/SamsungLoginService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/SamsungLoginService.cs
@@ -1,4 +1,5 @@
 using Apps2Samsung.Helpers.Core;
+using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -14,7 +15,7 @@ using System.Web;
 
 namespace Apps2Samsung.Services
 {
-    public class SamsungLoginService
+    public class SamsungLoginService : ISamsungLoginService
     {
         private IWebHost? _callbackServer;
 
@@ -22,6 +23,14 @@ namespace Apps2Samsung.Services
             $"http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}{Constants.Samsung.CallbackPath}";
 
         public Action<SamsungAuth>? CallbackReceived;
+
+        /// <summary>
+        /// Instance entry point behind the shared <see cref="ISamsungLoginService"/>, so Core services
+        /// (e.g. CertificateProvisioningService) can drive the desktop login the same way as mobile.
+        /// Delegates to the existing static implementation.
+        /// </summary>
+        public Task<SamsungAuth> LoginAsync(CancellationToken cancellationToken = default)
+            => PerformSamsungLoginAsync(cancellationToken);
 
         public static Task<SamsungAuth> PerformSamsungLoginAsync()
         {

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -27,6 +27,7 @@ namespace Apps2Samsung.Services
         private readonly IEnumerable<IPackagePatcher> _packagePatchers;
         private readonly ProcessHelper _processHelper;
         private readonly ISdbEngine _sdb;
+        private readonly ISamsungLoginService _login;
 
         public string? TizenSdbPath { get; private set; }
         public string? PackageCertificate { get; set; }
@@ -38,7 +39,8 @@ namespace Apps2Samsung.Services
             IEnumerable<IPackagePatcher> packagePatchers,
             JellyfinApiClient jellyfinApiClient,
             ProcessHelper processHelper,
-            ISdbEngine sdb)
+            ISdbEngine sdb,
+            ISamsungLoginService samsungLogin)
         {
             _httpClient = httpClient;
             _dialogService = dialogService;
@@ -46,6 +48,7 @@ namespace Apps2Samsung.Services
             _packagePatchers = packagePatchers;
             _processHelper = processHelper;
             _sdb = sdb;
+            _login = samsungLogin;
         }
 
         #region TizenSdb Management
@@ -618,7 +621,7 @@ namespace Apps2Samsung.Services
                 progress?.Invoke(Constants.LocalizationKeys.SamsungLogin.Localized());
                 onSamsungLoginStarted?.Invoke();
 
-                SamsungAuth auth = await SamsungLoginService.PerformSamsungLoginAsync(cancellationToken);
+                SamsungAuth auth = await _login.LoginAsync(cancellationToken);
 
                 if (string.IsNullOrEmpty(auth.access_token))
                 {


### PR DESCRIPTION
**Stage 2b** — prep for de-duplicating certificate provisioning.

Desktop `SamsungLoginService` now implements the shared `ISamsungLoginService` (instance `LoginAsync` delegating to the existing static `PerformSamsungLoginAsync`), is registered for the interface in DI, and `TizenInstallerService` calls it via injection instead of the static method.

**No behaviour change** — `LoginAsync` just forwards to the static impl. This unblocks constructing Core's `CertificateProvisioningService` (which needs an `ISamsungLoginService`) on desktop in the next PR.

Desktop builds **0 errors**.