### PR TITLE
Desktop: delegate auto-profile cert provisioning to Core (de-dup)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/App.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/App.axaml.cs
@@ -114,6 +114,8 @@ namespace Apps2Samsung
 
             services.AddSingleton<SamsungLoginService>();
             services.AddSingleton<ISamsungLoginService>(sp => sp.GetRequiredService<SamsungLoginService>());
+            // Shared reuse-aware cert provisioning (single source of truth with the mobile head).
+            services.AddSingleton<Apps2Samsung.Certificate.CertificateProvisioningService>();
             services.AddSingleton<JellyfinApiClient>();
             services.AddSingleton<TizenApiClient>();
             services.AddSingleton<PluginManager>();

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -1,3 +1,4 @@
+using Apps2Samsung.Certificate;
 using Apps2Samsung.Extensions;
 using Apps2Samsung.Helpers;
 using Apps2Samsung.Helpers.API;
@@ -28,6 +29,7 @@ namespace Apps2Samsung.Services
         private readonly ProcessHelper _processHelper;
         private readonly ISdbEngine _sdb;
         private readonly ISamsungLoginService _login;
+        private readonly CertificateProvisioningService _provisioning;
 
         public string? TizenSdbPath { get; private set; }
         public string? PackageCertificate { get; set; }
@@ -40,7 +42,8 @@ namespace Apps2Samsung.Services
             JellyfinApiClient jellyfinApiClient,
             ProcessHelper processHelper,
             ISdbEngine sdb,
-            ISamsungLoginService samsungLogin)
+            ISamsungLoginService samsungLogin,
+            CertificateProvisioningService provisioning)
         {
             _httpClient = httpClient;
             _dialogService = dialogService;
@@ -49,6 +52,7 @@ namespace Apps2Samsung.Services
             _processHelper = processHelper;
             _sdb = sdb;
             _login = samsungLogin;
+            _provisioning = provisioning;
         }
 
         #region TizenSdb Management
@@ -589,6 +593,76 @@ namespace Apps2Samsung.Services
             // "sign in every time" bug (the dropdown often reverts to "(default)" even though
             // "Jelly2Sams - Public/Partner" exists).
             bool autoMode = string.IsNullOrEmpty(selectedCertificate) || IsAutoCertName(selectedCertificate);
+
+            // Auto profile (no real pick / "(default)" / a generated "Jelly2Sams - Public/Partner"):
+            // delegate the whole reuse/regenerate/mint decision to the shared Core
+            // CertificateProvisioningService, so desktop and mobile use one source of truth for cert
+            // reuse (it reuses a valid profile covering this TV with NO Samsung login, regenerates only
+            // the distributor when a DUID isn't covered, and mints a full profile otherwise / on force).
+            // The bundled "Jellyfin" cert and user-imported certs fall through to the original path
+            // below, unchanged.
+            if (!isBundledJellyfin && autoMode)
+            {
+                var caPath = Path.Combine(AppSettings.ProfilePath, "ca");
+                // Core emits progress as localization keys; localize them here at the boundary.
+                ProgressCallback? certProgress = progress is null ? null : new ProgressCallback(k => progress(k.Localized()));
+                try
+                {
+                    var profile = await _provisioning.EnsureAsync(
+                        deviceDuid: deviceInfo.Duid,
+                        level: requestedLevel,
+                        storePath: AppSettings.CertificatePath,
+                        caPath: caPath,
+                        manualDuids: ParseDuids(_appSettings.ManualDuids),
+                        forceLogin: _appSettings.ForceSamsungLogin,
+                        onLoginStarting: () =>
+                        {
+                            progress?.Invoke(Constants.LocalizationKeys.SamsungLogin.Localized());
+                            onSamsungLoginStarted?.Invoke();
+                        },
+                        progress: certProgress,
+                        ct: cancellationToken);
+
+                    PackageCertificate = profile.ProfileName;
+                    _appSettings.Certificate = profile.ProfileName;
+                    _appSettings.ChosenCertificates = new ExistingCertificates
+                    {
+                        Name = profile.ProfileName,
+                        Duid = deviceInfo.Duid,
+                        File = profile.AuthorP12
+                    };
+                    _appSettings.Save();
+
+                    // Permit-install for older Tizen versions (same as the manual path below).
+                    if (deviceInfo.TizenVersion <= pushVersion)
+                    {
+                        var deviceProfilePath = Path.Combine(Path.GetDirectoryName(profile.AuthorP12)!, Constants.Certificate.DeviceProfileFileName);
+                        var targetPath = deviceInfo.TizenVersion < intermediateVersion
+                            ? Constants.Defaults.HomeDeveloperPath
+                            : deviceInfo.SdkToolPath;
+                        await AllowPermitInstall(tvIpAddress, deviceProfilePath, targetPath);
+                    }
+
+                    return new CertificateResult
+                    {
+                        Success = true,
+                        RequiresResign = true,
+                        AuthorP12 = profile.AuthorP12,
+                        DistributorP12 = profile.DistributorP12,
+                        P12Password = profile.Password
+                    };
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine($"[Cert] Provisioning failed: {ex.Message}");
+                    await _dialogService.ShowErrorAsync(ex.Message);
+                    return new CertificateResult
+                    {
+                        Success = false,
+                        InstallResult = InstallResult.FailureResult(ex.Message)
+                    };
+                }
+            }
 
             // A full Samsung profile (fresh keypair + new author cert) is only needed when the user
             // forces a login, or there's genuinely no usable author cert for this level yet (first run


### PR DESCRIPTION
**Stage 2a**, rebased directly onto `beta` (supersedes the auto-closed #477; the 2b login-interface PR #476 is already merged).

The **auto-profile** path in `HandleCertificateAsync` now delegates the whole reuse/regenerate/mint decision to the shared `CertificateProvisioningService.EnsureAsync` — the exact code the mobile head already uses. One source of truth for the historically bug-prone cert-reuse logic across both heads.

**Verified byte-identical** so existing certs are *reused*, not regenerated: profile dir `Jelly2Sams - Public/Partner`, `author.p12`/`distributor.p12`/`password.txt`, and the 10-DUID cap all match between desktop and Core.

**Low-risk by design** — a pure *insert* of an early auto-path branch:
- Bundled `Jellyfin` cert (old TVs) and user-imported certs fall through to the **original code path, untouched**.
- Their helpers (`HasUsableAuthorCert`/`GetCoveredDuids`/`BuildDistributorDuids`) stay in place.

**Minor behaviour notes (auto path only):** a provisioning failure now shows the error dialog + fails (before, only auth-failure dialoged); the discrete 'creating certificate profile' progress line is subsumed into the shared service's progress. Functional selection/reuse is identical.

### Please test on hardware (cert code I can't runtime-verify):
1. Fresh install, no existing cert → one Samsung login, mint, install.
2. Second app, **same** TV → reuse silently, **no** login.
3. Second TV → one login, distributor regenerated (author kept), both stay overwritable.
4. Public↔Partner toggle → separate profiles, no clobber.

Desktop builds **0 errors**.