### PR TITLE
Share TV capability parsing + permit-install thresholds in Core

### DIFF
--- a/Apps2Samsung.Core/Sdb/TizenInstallSupport.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstallSupport.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading.Tasks;
+using Apps2Samsung.Helpers.Core;
+using Apps2Samsung.Interfaces;
+
+namespace Apps2Samsung.Sdb
+{
+    /// <summary>
+    /// A TV's <c>sdb capability</c> report reduced to the two fields the install path needs. Shared by
+    /// both heads: the desktop parsed this with regex while the mobile head hand-rolled its own
+    /// line splitter (and hardcoded the default path) — both parsed the <b>same</b> report, since the
+    /// mobile in-process engine deliberately shapes its output to match the desktop CLI's.
+    /// </summary>
+    public readonly record struct TizenCapabilities(string PlatformVersion, string SdkToolPath)
+    {
+        /// <summary>
+        /// Parse a capability report. A missing <c>platform_version</c> yields an empty string (callers
+        /// treat that as "unknown"); a missing <c>sdk_toolpath</c> falls back to the default staging path.
+        /// </summary>
+        public static TizenCapabilities Parse(string? capabilityOutput)
+        {
+            var output = capabilityOutput ?? string.Empty;
+
+            var versionMatch = RegexPatterns.TizenCapability.PlatformVersion.Match(output);
+            var platformVersion = versionMatch.Success ? versionMatch.Groups[1].Value.Trim() : string.Empty;
+
+            var pathMatch = RegexPatterns.TizenCapability.SdkToolPath.Match(output);
+            var sdkToolPath = pathMatch.Success ? pathMatch.Groups[1].Value.Trim() : Constants.Defaults.SdkToolPath;
+
+            return new TizenCapabilities(platformVersion, sdkToolPath);
+        }
+
+        /// <summary>The parsed platform version, or <c>null</c> when the report had none/was unparseable.</summary>
+        public Version? Version => System.Version.TryParse(PlatformVersion, out var v) ? v : null;
+    }
+
+    /// <summary>
+    /// The pre-install "permit" step. Older Samsung TVs must have the distributor device profile pushed
+    /// before an install is accepted; newer TVs carry the authorization inside the re-signed package.
+    /// Centralizes the version thresholds and target-path rule so both heads agree — the mobile head
+    /// previously kept its own hardcoded copies of these (4.0 / 3.0 / /home/developer).
+    /// </summary>
+    public static class TizenPermitInstall
+    {
+        private static readonly Version PushInstallMax = new(Constants.TizenVersions.PushInstallMax);
+        private static readonly Version IntermediateVersion = new(Constants.TizenVersions.IntermediateVersion);
+
+        /// <summary>True when the TV needs the device profile pushed before install (version ≤ 4.0).</summary>
+        public static bool IsRequired(Version? platformVersion) =>
+            platformVersion is not null && platformVersion <= PushInstallMax;
+
+        /// <summary>Staging path for the profile push: intermediate TVs (&lt; 3.0) use the fixed
+        /// developer home, otherwise the TV's reported SDK tool path.</summary>
+        public static string TargetPath(Version platformVersion, string sdkToolPath) =>
+            platformVersion < IntermediateVersion ? Constants.Defaults.HomeDeveloperPath : sdkToolPath;
+
+        /// <summary>Push the distributor device profile when the TV requires it; a no-op otherwise.</summary>
+        public static async Task EnsureAsync(
+            ISdbEngine sdb, string tvIpAddress, Version? platformVersion, string sdkToolPath, string deviceProfilePath)
+        {
+            if (!IsRequired(platformVersion))
+                return;
+
+            await sdb.PermitInstallAsync(tvIpAddress, deviceProfilePath, TargetPath(platformVersion!, sdkToolPath));
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Xml.Linq;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Packaging;
+using Apps2Samsung.Sdb;
 using Microsoft.Maui.Storage;
 
 namespace Apps2Samsung.Mobile.Services;
@@ -16,13 +17,6 @@ namespace Apps2Samsung.Mobile.Services;
 /// </summary>
 public sealed class WgtInstaller
 {
-	// Fallback install staging path when the TV's capability report doesn't include one.
-	private const string DefaultSdkToolPath = "/opt/usr/apps/tmp";
-	// Below this Tizen version the device profile must be pushed first (permit-install).
-	private static readonly Version PushInstallMax = new(4, 0);
-	private static readonly Version IntermediateVersion = new(3, 0);
-	private const string HomeDeveloperPath = "/home/developer";
-
 	private readonly ISdbEngine _sdb;
 	private readonly HttpClient _http;
 	private readonly IEnumerable<IPackagePatcher> _patchers;
@@ -62,8 +56,9 @@ public sealed class WgtInstaller
 	{
 		progress?.Invoke("Reading TV capabilities…");
 		var cap = await _sdb.CapabilityAsync(tvIp);
-		var sdkToolPath = ParseCapability(cap.Output, "sdk_toolpath") ?? DefaultSdkToolPath;
-		Version.TryParse(ParseCapability(cap.Output, "platform_version"), out var version);
+		var caps = TizenCapabilities.Parse(cap.Output);
+		var sdkToolPath = caps.SdkToolPath;
+		var version = caps.Version;
 
 		// The Tizen app/package ids live in the package's config.xml; needed to remove an old
 		// version before install and/or launch the app afterwards.
@@ -76,13 +71,13 @@ public sealed class WgtInstaller
 		}
 
 		// Older TVs (<= 4.0) need the distributor device profile pushed before install; newer TVs
-		// carry the authorization in the re-signed package itself.
-		if (version is not null && version <= PushInstallMax)
+		// carry the authorization in the re-signed package itself. Thresholds live in Core so both
+		// heads agree.
+		if (TizenPermitInstall.IsRequired(version))
 		{
 			progress?.Invoke("Authorizing device…");
 			var profileXml = Path.Combine(cert.ProfileDir, "device-profile.xml");
-			var target = version < IntermediateVersion ? HomeDeveloperPath : sdkToolPath;
-			await _sdb.PermitInstallAsync(tvIp, profileXml, target);
+			await TizenPermitInstall.EnsureAsync(_sdb, tvIp, version, sdkToolPath, profileXml);
 		}
 
 		// Apply per-app modifications before signing — e.g. inject the user's TVApp channels
@@ -151,19 +146,6 @@ public sealed class WgtInstaller
 		{
 			return (null, null);
 		}
-	}
-
-	// Pulls a "  key: value" line out of the capability report.
-	private static string? ParseCapability(string output, string key)
-	{
-		foreach (var line in output.Split('\n'))
-		{
-			var marker = key + ":";
-			var i = line.IndexOf(marker, StringComparison.OrdinalIgnoreCase);
-			if (i >= 0)
-				return line[(i + marker.Length)..].Trim();
-		}
-		return null;
 	}
 
 	private static string Detail(string error, string output) =>

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -531,7 +531,6 @@ namespace Apps2Samsung.Services
 
             Version certVersion = new(Constants.TizenVersions.CertificateRequired);
             Version pushVersion = new(Constants.TizenVersions.PushInstallMax);
-            Version intermediateVersion = new(Constants.TizenVersions.IntermediateVersion);
 
             bool requiresResign = deviceInfo.TizenVersion >= certVersion ||
                                   deviceInfo.TizenVersion <= pushVersion ||
@@ -633,15 +632,10 @@ namespace Apps2Samsung.Services
                     };
                     _appSettings.Save();
 
-                    // Permit-install for older Tizen versions (same as the manual path below).
-                    if (deviceInfo.TizenVersion <= pushVersion)
-                    {
-                        var deviceProfilePath = Path.Combine(Path.GetDirectoryName(profile.AuthorP12)!, Constants.Certificate.DeviceProfileFileName);
-                        var targetPath = deviceInfo.TizenVersion < intermediateVersion
-                            ? Constants.Defaults.HomeDeveloperPath
-                            : deviceInfo.SdkToolPath;
-                        await AllowPermitInstall(tvIpAddress, deviceProfilePath, targetPath);
-                    }
+                    // Permit-install for older Tizen versions (thresholds shared with Core).
+                    await Apps2Samsung.Sdb.TizenPermitInstall.EnsureAsync(
+                        _sdb, tvIpAddress, deviceInfo.TizenVersion, deviceInfo.SdkToolPath,
+                        Path.Combine(Path.GetDirectoryName(profile.AuthorP12)!, Constants.Certificate.DeviceProfileFileName));
 
                     return new CertificateResult
                     {
@@ -777,16 +771,10 @@ namespace Apps2Samsung.Services
                 PackageCertificate = reuseAutoCert ? AutoCertProfileName(requestedLevel) : selectedCertificate;
             }
 
-            // Handle permit install for older Tizen versions
-            if (deviceInfo.TizenVersion <= pushVersion)
-            {
-                var deviceProfilePath = Path.Combine(Path.GetDirectoryName(authorp12)!, Constants.Certificate.DeviceProfileFileName);
-                var targetPath = deviceInfo.TizenVersion < intermediateVersion
-                    ? Constants.Defaults.HomeDeveloperPath
-                    : deviceInfo.SdkToolPath;
-
-                await AllowPermitInstall(tvIpAddress, deviceProfilePath, targetPath);
-            }
+            // Handle permit install for older Tizen versions (thresholds shared with Core).
+            await Apps2Samsung.Sdb.TizenPermitInstall.EnsureAsync(
+                _sdb, tvIpAddress, deviceInfo.TizenVersion, deviceInfo.SdkToolPath,
+                Path.Combine(Path.GetDirectoryName(authorp12)!, Constants.Certificate.DeviceProfileFileName));
 
             return new CertificateResult
             {
@@ -1053,14 +1041,8 @@ namespace Apps2Samsung.Services
         private async Task<(string tizenOs, string sdkToolPath)> FetchCapabilitiesAsync(string tvIpAddress)
         {
             var output = await _sdb.CapabilityAsync(tvIpAddress);
-
-            var versionMatch = RegexPatterns.TizenCapability.PlatformVersion.Match(output.Output);
-            string tizenOs = versionMatch.Success ? versionMatch.Groups[1].Value.Trim() : string.Empty;
-
-            var pathMatch = RegexPatterns.TizenCapability.SdkToolPath.Match(output.Output);
-            string sdkToolPath = pathMatch.Success ? pathMatch.Groups[1].Value.Trim() : Constants.Defaults.SdkToolPath;
-
-            return (tizenOs, sdkToolPath);
+            var caps = Apps2Samsung.Sdb.TizenCapabilities.Parse(output.Output);
+            return (caps.PlatformVersion, caps.SdkToolPath);
         }
 
         private async Task<string> GetTvDuidAsync(string tvIpAddress)
@@ -1158,11 +1140,6 @@ namespace Apps2Samsung.Services
         private async Task<ProcessResult> UninstallPackageAsync(string tvIpAddress, string packageId)
         {
             return await _sdb.UninstallAsync(tvIpAddress, packageId);
-        }
-
-        private async Task AllowPermitInstall(string tvIpAddress, string deviceXml, string sdkToolPath)
-        {
-            await _sdb.PermitInstallAsync(tvIpAddress, deviceXml, sdkToolPath);
         }
 
         #endregion


### PR DESCRIPTION
**Stage 2 — the safe de-dup subset** (we agreed against the full install-spine extraction: too much risk on the just-validated install path for little gain, since patchers/resign/install are already shared via `ISdbEngine`/`IPackagePatcher`).

New `Apps2Samsung.Core/Sdb/TizenInstallSupport.cs`:
- **`TizenCapabilities.Parse`** — capability report → platform version + sdk tool path (with default fallback).
- **`TizenPermitInstall`** — the older-TV device-profile push: version thresholds (≤4.0) + target-path rule (<3.0 → `/home/developer`).

Both heads now use them:
- **Mobile** `WgtInstaller`: drops its hardcoded `4.0`/`3.0`/`/home/developer`/default-toolpath copies and its hand-rolled line parser.
- **Desktop** `TizenInstallerService`: `FetchCapabilitiesAsync` uses the shared parse (same regex); both permit-install spots use `TizenPermitInstall.EnsureAsync`; the trivial `AllowPermitInstall` wrapper + an unused local are removed.

**Behaviour-preserving** — identical constants/regexes/thresholds, purely mechanical. Desktop + mobile both build **0 errors**.

Worth a quick sanity install on a TV (any Tizen version) since it touches the desktop install path, but there's no logic change — just where the numbers live.