### PR TITLE
Mobile: add 'Share debug log' button to Settings

### DIFF
--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -142,6 +142,18 @@
                 <Label Style="{StaticResource Hint}"
                        Text="Signing certificates are created and reused automatically from your Samsung account — one cert per TV, reused across installs, so you're not asked to sign in every time. Public is used by default; turn on Partner signing above only for apps that need a restricted privilege (e.g. VPN)." />
 
+                <BoxView Style="{StaticResource Divider}" />
+
+                <!-- Diagnostics -->
+                <Label Text="Diagnostics" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Export this session's debug log to send when reporting a problem." />
+                <Button Text="📤 Share debug log" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="14,8"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                        Clicked="OnShareLogClicked" />
+
             </VerticalStackLayout>
         </Border>
     </ScrollView>

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -1,7 +1,10 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using Apps2Samsung.Mobile.Services;
+using Microsoft.Maui.ApplicationModel.DataTransfer;
+using Microsoft.Maui.Storage;
 
 namespace Apps2Samsung.Mobile.Pages;
 
@@ -44,6 +47,32 @@ public partial class SettingsPage : ContentPage
 	private async void OnAppIconsClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new AppIconsPage());
 
 	private async void OnJellyfinClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new JellyfinSettingsPage());
+
+	// Hands the current session's debug log to the OS share sheet. The file lives in private app
+	// storage (FileSystem.AppDataDirectory/Logs) with no way to reach it otherwise, so this is how a
+	// user gets logs off the phone when reporting an issue. Saving is set up in MauiProgram via FileLog.
+	private async void OnShareLogClicked(object? sender, EventArgs e)
+	{
+		var logPath = Apps2Samsung.Diagnostics.FileLog.CurrentLogFile;
+		if (string.IsNullOrEmpty(logPath) || !File.Exists(logPath))
+		{
+			await DisplayAlert("Debug log", "No log file is available for this session yet.", "OK");
+			return;
+		}
+
+		try
+		{
+			await Share.Default.RequestAsync(new ShareFileRequest
+			{
+				Title = "Apps2Samsung debug log",
+				File = new ShareFile(logPath),
+			});
+		}
+		catch (Exception ex)
+		{
+			await DisplayAlert("Debug log", $"Couldn't share the log: {ex.Message}", "OK");
+		}
+	}
 
 	private void OnToggleTokenVisibility(object? sender, EventArgs e)
 	{


### PR DESCRIPTION
Closes the loop on mobile debuggability. Stage 4 already saves the session log to `AppData/Logs/debug_<ts>.log`, but it's trapped in private app storage.

A new **Diagnostics** section on Settings hands `FileLog.CurrentLogFile` to the OS share sheet (`Share.RequestAsync` + `ShareFileRequest`), so you can send the log (email, Drive, etc.) when reporting an issue. Friendly alert if no log exists yet.

Mobile builds **0 errors**. Quick phone test: Settings → Share debug log → share sheet opens with the log file.