### PR TITLE
Capture the full session in the debug log (mobile)

### DIFF
--- a/Apps2Samsung.Core/Diagnostics/FileLog.cs
+++ b/Apps2Samsung.Core/Diagnostics/FileLog.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Apps2Samsung.Diagnostics
 {
@@ -10,6 +12,11 @@ namespace Apps2Samsung.Diagnostics
     /// <see cref="Initialize"/> once at startup — the desktop next to the binary, the mobile head in
     /// its app-data dir — so the Core services' Trace diagnostics are persisted and the mobile app is
     /// actually debuggable (it previously logged only to the transient Android debug console).
+    ///
+    /// Initialize also (a) tees <see cref="Console"/> stdout/stderr into the log, so output from lower
+    /// layers and third-party libraries (e.g. the in-process SDB engine) is captured off-device, and
+    /// (b) logs otherwise-unhandled exceptions. Combined with the heads routing their UI status +
+    /// caught exceptions through Trace, this makes the log a full session transcript.
     /// </summary>
     public static class FileLog
     {
@@ -18,8 +25,9 @@ namespace Apps2Samsung.Diagnostics
         /// <summary>The debug log file created by <see cref="Initialize"/> (null until initialized).</summary>
         public static string? CurrentLogFile { get; private set; }
 
-        /// <summary>Adds a file trace listener under <paramref name="logDirectory"/>. Idempotent and
-        /// never throws — logging must not take down startup.</summary>
+        /// <summary>Adds a file trace listener under <paramref name="logDirectory"/>, tees Console into
+        /// it, and logs unhandled exceptions. Idempotent and never throws — logging must not take down
+        /// startup.</summary>
         public static void Initialize(string logDirectory)
         {
             if (_initialized) return;
@@ -31,8 +39,78 @@ namespace Apps2Samsung.Diagnostics
                 CurrentLogFile = Path.Combine(logDirectory, $"debug_{dtg}.log");
                 Trace.Listeners.Add(new FileTraceListener(CurrentLogFile));
                 Trace.AutoFlush = true;
+
+                CaptureConsole();
+                HookGlobalExceptions();
+
+                Trace.WriteLine($"[FileLog] Logging started → {CurrentLogFile}");
             }
             catch { /* diagnostics must never crash the app */ }
+        }
+
+        /// <summary>Writes a line to the log via Trace. A convenience for heads/pages so they don't each
+        /// need a <c>using System.Diagnostics</c>; identical to <c>Trace.WriteLine</c>.</summary>
+        public static void Write(string message) => Trace.WriteLine(message);
+
+        // Tee Console.Out/Error through Trace so anything printed to stdout/stderr by any layer lands
+        // in the log too (while still reaching the original console / logcat).
+        private static bool _consoleCaptured;
+        private static void CaptureConsole()
+        {
+            if (_consoleCaptured) return;
+            _consoleCaptured = true;
+            try
+            {
+                Console.SetOut(new TraceTextWriter(Console.Out, "out"));
+                Console.SetError(new TraceTextWriter(Console.Error, "err"));
+            }
+            catch { /* console may be unavailable on some hosts */ }
+        }
+
+        // Last-resort capture: exceptions that escape the app still get a line in the log.
+        private static bool _exceptionsHooked;
+        private static void HookGlobalExceptions()
+        {
+            if (_exceptionsHooked) return;
+            _exceptionsHooked = true;
+            try
+            {
+                AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+                    Trace.WriteLine($"[FATAL] Unhandled exception: {e.ExceptionObject}");
+                TaskScheduler.UnobservedTaskException += (_, e) =>
+                {
+                    Trace.WriteLine($"[FATAL] Unobserved task exception: {e.Exception}");
+                    e.SetObserved();
+                };
+            }
+            catch { /* best-effort */ }
+        }
+
+        // Forwards Console writes to the original writer AND mirrors full lines to Trace (so they hit
+        // the file listener). Partial writes still reach the original console. Never recurses: the
+        // Trace file listener doesn't write to Console.
+        private sealed class TraceTextWriter : TextWriter
+        {
+            private readonly TextWriter _inner;
+            private readonly string _tag;
+
+            public TraceTextWriter(TextWriter inner, string tag)
+            {
+                _inner = inner;
+                _tag = tag;
+            }
+
+            public override Encoding Encoding => _inner.Encoding;
+
+            public override void Write(char value) => _inner.Write(value);
+            public override void Write(string? value) => _inner.Write(value);
+
+            public override void WriteLine(string? value)
+            {
+                _inner.WriteLine(value);
+                if (!string.IsNullOrEmpty(value))
+                    Trace.WriteLine($"[console:{_tag}] {value}");
+            }
         }
     }
 }

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -305,6 +305,7 @@ public partial class InstallerPage : ContentPage
 		}
 		catch (Exception ex)
 		{
+			System.Diagnostics.Trace.WriteLine($"[installer] Install failed: {ex}");
 			SetStatus($"Install failed: {ex.Message}");
 		}
 		finally
@@ -323,6 +324,11 @@ public partial class InstallerPage : ContentPage
 		}
 	}
 
-	private void SetStatus(string message) =>
+	private void SetStatus(string message)
+	{
+		// Mirror every status line to the debug log (timestamped) so the log is a full transcript of
+		// the scan/download/cert/install flow — not just the on-screen label.
+		System.Diagnostics.Trace.WriteLine($"[installer] {message}");
 		MainThread.BeginInvokeOnMainThread(() => StatusLabel.Text = message);
+	}
 }

--- a/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml.cs
@@ -152,6 +152,7 @@ public partial class JellyfinSettingsPage : ContentPage
 
 	private void SetStatus(string message, bool isError)
 	{
+		System.Diagnostics.Trace.WriteLine($"[jellyfin] {message}");
 		StatusLabel.Text = message;
 		StatusLabel.TextColor = isError ? Color.FromArgb("#B00020") : Color.FromArgb("#2E7D32");
 		StatusLabel.Opacity = 1.0;


### PR DESCRIPTION
**Fixes near-empty phone logs.** A pulled log contained a single line (`Scan complete…`) for a whole session — because the mobile head does **zero** `Trace` logging; every step/error goes through the UI status label, and only Core's Trace lines reached the file.

Now the log is a full transcript:
- **`SetStatus` → Trace** in InstallerPage (and the Jellyfin sign-in page): every scan/download/cert/install/error line is logged, timestamped.
- **Full exceptions** logged on install failure (stack + inner), not just `.Message`.
- **`FileLog.Initialize`** now tees `Console` stdout/stderr into the log (captures lower-layer / in-process SDB output) and hooks `AppDomain.UnhandledException` + `TaskScheduler.UnobservedTaskException` so crashes leave a line.

Shared `FileLog` change applies to both heads; desktop unaffected in practice. Desktop + mobile build **0 errors**.

Test: reproduce on the phone, Settings → Share debug log — the file should now show the whole flow instead of one line.