### PR TITLE
Mobile: add Force-Samsung-login + Override-existing-app toggles

### DIFF
--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -92,6 +92,10 @@
                     <Switch Grid.Column="1" x:Name="RemoveOldSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
                 </Grid>
                 <Grid Style="{StaticResource ToggleRow}">
+                    <Label Grid.Column="0" Text="Override existing app" VerticalOptions="Center" />
+                    <Switch Grid.Column="1" x:Name="TryOverwriteSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
+                </Grid>
+                <Grid Style="{StaticResource ToggleRow}">
                     <Label Grid.Column="0" Text="Open after installation" VerticalOptions="Center" />
                     <Switch Grid.Column="1" x:Name="OpenAfterSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
                 </Grid>
@@ -109,6 +113,12 @@
                 </Grid>
                 <Label Style="{StaticResource Hint}"
                        Text="Partner signing is only needed for apps that use restricted privileges (e.g. VPN). Some TVs may reject partner-signed installs, and Samsung may not issue Partner certs for individual accounts. Leave off unless an app requires it." />
+                <Grid Style="{StaticResource ToggleRow}">
+                    <Label Grid.Column="0" Text="Force Samsung login" VerticalOptions="Center" />
+                    <Switch Grid.Column="1" x:Name="ForceLoginSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
+                </Grid>
+                <Label Style="{StaticResource Hint}"
+                       Text="Always sign in to Samsung and generate a fresh certificate, even when a reusable one already covers this TV. Normally off — leave it off unless signing is misbehaving." />
 
                 <BoxView Style="{StaticResource Divider}" />
 

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -33,6 +33,8 @@ public partial class SettingsPage : ContentPage
 		KeepWgtSwitch.IsToggled = MobileSettings.KeepWgtFile;
 		ShowAllJfSwitch.IsToggled = MobileSettings.ShowAllJellyfinVersions;
 		PartnerSigningSwitch.IsToggled = MobileSettings.PartnerSigning;
+		TryOverwriteSwitch.IsToggled = MobileSettings.TryOverwrite;
+		ForceLoginSwitch.IsToggled = MobileSettings.ForceSamsungLogin;
 
 		ChannelsContainer.Children.Clear();
 		_channelRows.Clear();
@@ -102,6 +104,8 @@ public partial class SettingsPage : ContentPage
 		MobileSettings.KeepWgtFile = KeepWgtSwitch.IsToggled;
 		MobileSettings.ShowAllJellyfinVersions = ShowAllJfSwitch.IsToggled;
 		MobileSettings.PartnerSigning = PartnerSigningSwitch.IsToggled;
+		MobileSettings.TryOverwrite = TryOverwriteSwitch.IsToggled;
+		MobileSettings.ForceSamsungLogin = ForceLoginSwitch.IsToggled;
 	}
 
 	private void OnAddChannel(object? sender, EventArgs e) => AddChannelRow(string.Empty, string.Empty);

--- a/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
+++ b/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
@@ -11,15 +11,13 @@ namespace Apps2Samsung.Mobile.Services;
 /// </summary>
 public sealed class MobileAppConfig : IAppConfig
 {
-    private const string KeyForceLogin = "force_samsung_login";
-    private const string KeyTryOverwrite = "try_overwrite";
     private const string KeyCustomIcons = "custom_app_icons_json";
 
     // ---- Install behaviour ----
     public bool DeletePreviousInstall { get => MobileSettings.DeletePreviousInstall; set => MobileSettings.DeletePreviousInstall = value; }
     public bool OpenAfterInstall { get => MobileSettings.OpenAfterInstall; set => MobileSettings.OpenAfterInstall = value; }
     public bool KeepWgtFile { get => MobileSettings.KeepWgtFile; set => MobileSettings.KeepWgtFile = value; }
-    public bool TryOverwrite { get => Preferences.Get(KeyTryOverwrite, true); set => Preferences.Set(KeyTryOverwrite, value); }
+    public bool TryOverwrite { get => MobileSettings.TryOverwrite; set => MobileSettings.TryOverwrite = value; }
 
     // ---- Catalog ----
     public bool ShowAllJellyfinVersions { get => MobileSettings.ShowAllJellyfinVersions; set => MobileSettings.ShowAllJellyfinVersions = value; }
@@ -29,7 +27,7 @@ public sealed class MobileAppConfig : IAppConfig
     public bool PartnerSigning { get => MobileSettings.PartnerSigning; set => MobileSettings.PartnerSigning = value; }
     // Runtime-only, per-install (mirrors the desktop's [JsonIgnore] RequiresPartnerSigning).
     public bool RequiresPartnerSigning { get; set; }
-    public bool ForceSamsungLogin { get => Preferences.Get(KeyForceLogin, false); set => Preferences.Set(KeyForceLogin, value); }
+    public bool ForceSamsungLogin { get => MobileSettings.ForceSamsungLogin; set => MobileSettings.ForceSamsungLogin = value; }
     public string ManualDuids { get => MobileSettings.ManualDuids; set => MobileSettings.ManualDuids = value; }
     // Root under which the generated signing profiles ("Jelly2Sams - Public/Partner") live.
     public string CertificateStorePath => Path.Combine(FileSystem.AppDataDirectory, "Certificate");

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -18,6 +18,8 @@ public static class MobileSettings
 	private const string KeyManualDuids = "manual_duids";
 	private const string KeyTvAppChannels = "tvapp_channels_json";
 	private const string KeyPartnerSigning = "partner_signing";
+	private const string KeyForceLogin = "force_samsung_login";
+	private const string KeyTryOverwrite = "try_overwrite";
 	private const string KeyGitHubToken = "github_token"; // SecureStorage
 	private const string KeyJellyfinServerUrl = "jellyfin_server_url";
 	private const string KeyJellyfinUserId = "jellyfin_user_id";
@@ -54,6 +56,22 @@ public static class MobileSettings
 	{
 		get => Preferences.Get(KeyShowAllJf, false);
 		set => Preferences.Set(KeyShowAllJf, value);
+	}
+
+	/// <summary>Force a fresh Samsung login + certificate even when a reusable one exists (desktop:
+	/// "Force Samsung login"). Off by default.</summary>
+	public static bool ForceSamsungLogin
+	{
+		get => Preferences.Get(KeyForceLogin, false);
+		set => Preferences.Set(KeyForceLogin, value);
+	}
+
+	/// <summary>Attempt an overwrite-install and, on failure, retry after removing the old copy
+	/// (desktop: "Override existing app"). On by default — matches the desktop's recovery behaviour.</summary>
+	public static bool TryOverwrite
+	{
+		get => Preferences.Get(KeyTryOverwrite, true);
+		set => Preferences.Set(KeyTryOverwrite, value);
 	}
 
 	/// <summary>


### PR DESCRIPTION
Gap #1 of the desktop→mobile parity batch. Desktop exposes these two toggles; mobile had the backing config but no UI.

- **Override existing app** (`TryOverwrite`, default on) — with the install toggles.
- **Force Samsung login** (default off) — with the signing options.

Both promoted to `MobileSettings` (single store; `MobileAppConfig` now delegates instead of holding its own Preferences keys). Mobile builds **0 errors**.