### PR TITLE
Mobile: install error-recovery + actionable failure messages

### DIFF
--- a/Apps2Samsung.Core/Sdb/TizenInstallDiagnostics.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstallDiagnostics.cs
@@ -1,0 +1,52 @@
+using System;
+using Apps2Samsung.Helpers.Core;
+
+namespace Apps2Samsung.Sdb
+{
+    /// <summary>
+    /// Interprets the raw output of a Tizen install so both heads agree on what a failure means. The
+    /// <b>classification</b> lives here once; each head keeps its own recovery/messaging around it
+    /// (the desktop's localized retry state machine, the mobile head's single overwrite retry).
+    /// </summary>
+    public static class TizenInstallDiagnostics
+    {
+        private const StringComparison IC = StringComparison.OrdinalIgnoreCase;
+
+        /// <summary>Environmental transport failure (reset/lost connection) — retrying the same push
+        /// can't help; it's a VPN/firewall/Wi-Fi issue, not a packaging one.</summary>
+        public static bool IsTransportLost(string? output) =>
+            Has(output, Constants.TizenErrorCodes.TransportConnectionLost) ||
+            Has(output, Constants.TizenErrorCodes.ConnectionResetByPeer);
+
+        /// <summary>Not enough free space on the TV ([116]).</summary>
+        public static bool IsInsufficientSpace(string? output) =>
+            Has(output, Constants.TizenErrorCodes.DownloadFailed116);
+
+        /// <summary>The installed copy was signed with a different certificate ([118012] / [118, -12]);
+        /// Tizen won't overwrite it — the old copy must be removed first.</summary>
+        public static bool IsCertificateMismatch(string? output) =>
+            Has(output, Constants.TizenErrorCodes.InstallFailed118012) ||
+            Has(output, Constants.TizenErrorCodes.InstallFailed118Minus12);
+
+        /// <summary>The package targets a newer Tizen API level than the TV supports ([118, -4]) —
+        /// re-signing/overwriting can't help.</summary>
+        public static bool IsApiVersionMismatch(string? output) =>
+            Has(output, Constants.TizenErrorCodes.InstallFailed118Minus4);
+
+        /// <summary>A package-id / config conflict ([118], not the more specific variants above).</summary>
+        public static bool IsPackageIdConflict(string? output) =>
+            Has(output, Constants.TizenErrorCodes.InstallFailed118);
+
+        /// <summary>A generic reported failure.</summary>
+        public static bool IsGenericFailure(string? output) =>
+            Has(output, Constants.TizenErrorCodes.Failed);
+
+        /// <summary>The output indicates the install actually succeeded.</summary>
+        public static bool IndicatesSuccess(string? output) =>
+            Has(output, Constants.TizenErrorCodes.Installing100) ||
+            Has(output, Constants.TizenErrorCodes.InstallCompleted);
+
+        private static bool Has(string? output, string token) =>
+            !string.IsNullOrEmpty(output) && output.Contains(token, IC);
+    }
+}

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -2,7 +2,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Xml.Linq;
-using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using Apps2Samsung.Packaging;
@@ -131,30 +130,27 @@ public sealed class WgtInstaller
 	private async Task<ProcessResult> RecoverInstallAsync(
 		string tvIp, string wgtPath, string sdkToolPath, string? packageId, ProcessResult failed, Action<string>? progress)
 	{
-		const StringComparison IC = StringComparison.OrdinalIgnoreCase;
 		var output = failed.Output ?? string.Empty;
 
 		// Environmental — a broken route to the TV. Retrying the same push can't help.
-		if (output.Contains(Constants.TizenErrorCodes.TransportConnectionLost, IC) ||
-			output.Contains(Constants.TizenErrorCodes.ConnectionResetByPeer, IC))
+		if (TizenInstallDiagnostics.IsTransportLost(output))
 			throw new InvalidOperationException(
 				"Connection to the TV was interrupted. Check Wi-Fi (and that the TV is awake), then try again.");
 
 		// API-version mismatch: the app targets a newer Tizen than this TV supports — a different build
 		// is needed, not a retry.
-		if (output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus4, IC))
+		if (TizenInstallDiagnostics.IsApiVersionMismatch(output))
 			throw new InvalidOperationException(
 				"This TV's Tizen version is too old for this app (API-version mismatch [118, -4]). Try an older build if one is available.");
 
-		bool certMismatch = output.Contains(Constants.TizenErrorCodes.InstallFailed118012, IC) ||
-							 output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus12, IC);
-		bool outOfSpace = output.Contains(Constants.TizenErrorCodes.DownloadFailed116, IC);
+		bool certMismatch = TizenInstallDiagnostics.IsCertificateMismatch(output);
+		bool outOfSpace = TizenInstallDiagnostics.IsInsufficientSpace(output);
 
 		// Recoverable by removing the old copy first: certificate mismatch, insufficient space,
 		// package-id conflict, or a generic failure. Try exactly one clean reinstall.
 		bool recoverable = certMismatch || outOfSpace ||
-						   output.Contains(Constants.TizenErrorCodes.InstallFailed118, IC) ||
-						   output.Contains(Constants.TizenErrorCodes.Failed, IC);
+						   TizenInstallDiagnostics.IsPackageIdConflict(output) ||
+						   TizenInstallDiagnostics.IsGenericFailure(output);
 
 		if (recoverable && TryOverwriteEnabled && !string.IsNullOrWhiteSpace(packageId))
 		{
@@ -166,8 +162,7 @@ public sealed class WgtInstaller
 				return retry;
 
 			// Still failing after a clean slate — surface the most useful message.
-			if (retry.Output.Contains(Constants.TizenErrorCodes.InstallFailed118012, IC) ||
-				retry.Output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus12, IC))
+			if (TizenInstallDiagnostics.IsCertificateMismatch(retry.Output))
 				throw new InvalidOperationException(
 					"The TV already has this app signed with a different certificate. Remove it on the TV (Apps → delete), then install again.");
 

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -2,7 +2,9 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Xml.Linq;
+using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
 using Apps2Samsung.Packaging;
 using Apps2Samsung.Sdb;
 using Microsoft.Maui.Storage;
@@ -108,7 +110,7 @@ public sealed class WgtInstaller
 		progress?.Invoke("Installing on TV…");
 		var install = await _sdb.InstallAsync(tvIp, wgtPath, sdkToolPath);
 		if (install.ExitCode != 0)
-			throw new InvalidOperationException($"Install failed: {Detail(install.Error, install.Output)}");
+			install = await RecoverInstallAsync(tvIp, wgtPath, sdkToolPath, packageId, install, progress);
 
 		if (MobileSettings.OpenAfterInstall && !string.IsNullOrWhiteSpace(appId))
 		{
@@ -117,6 +119,70 @@ public sealed class WgtInstaller
 		}
 
 		return install.Output;
+	}
+
+	// Overwrite-install retry is on by default; the "Override existing app" setting (key shared with
+	// MobileSettings.TryOverwrite) can turn it off.
+	private static bool TryOverwriteEnabled => Preferences.Get("try_overwrite", true);
+
+	// Interprets a non-zero install result and, where it helps, removes the old copy and retries once —
+	// mirroring the desktop head's error-code handling. Returns the successful result or throws with an
+	// actionable message.
+	private async Task<ProcessResult> RecoverInstallAsync(
+		string tvIp, string wgtPath, string sdkToolPath, string? packageId, ProcessResult failed, Action<string>? progress)
+	{
+		const StringComparison IC = StringComparison.OrdinalIgnoreCase;
+		var output = failed.Output ?? string.Empty;
+
+		// Environmental — a broken route to the TV. Retrying the same push can't help.
+		if (output.Contains(Constants.TizenErrorCodes.TransportConnectionLost, IC) ||
+			output.Contains(Constants.TizenErrorCodes.ConnectionResetByPeer, IC))
+			throw new InvalidOperationException(
+				"Connection to the TV was interrupted. Check Wi-Fi (and that the TV is awake), then try again.");
+
+		// API-version mismatch: the app targets a newer Tizen than this TV supports — a different build
+		// is needed, not a retry.
+		if (output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus4, IC))
+			throw new InvalidOperationException(
+				"This TV's Tizen version is too old for this app (API-version mismatch [118, -4]). Try an older build if one is available.");
+
+		bool certMismatch = output.Contains(Constants.TizenErrorCodes.InstallFailed118012, IC) ||
+							 output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus12, IC);
+		bool outOfSpace = output.Contains(Constants.TizenErrorCodes.DownloadFailed116, IC);
+
+		// Recoverable by removing the old copy first: certificate mismatch, insufficient space,
+		// package-id conflict, or a generic failure. Try exactly one clean reinstall.
+		bool recoverable = certMismatch || outOfSpace ||
+						   output.Contains(Constants.TizenErrorCodes.InstallFailed118, IC) ||
+						   output.Contains(Constants.TizenErrorCodes.Failed, IC);
+
+		if (recoverable && TryOverwriteEnabled && !string.IsNullOrWhiteSpace(packageId))
+		{
+			progress?.Invoke("Install failed — removing the old copy and retrying…");
+			try { await _sdb.UninstallAsync(tvIp, packageId!); } catch { /* best-effort */ }
+
+			var retry = await _sdb.InstallAsync(tvIp, wgtPath, sdkToolPath);
+			if (retry.ExitCode == 0)
+				return retry;
+
+			// Still failing after a clean slate — surface the most useful message.
+			if (retry.Output.Contains(Constants.TizenErrorCodes.InstallFailed118012, IC) ||
+				retry.Output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus12, IC))
+				throw new InvalidOperationException(
+					"The TV already has this app signed with a different certificate. Remove it on the TV (Apps → delete), then install again.");
+
+			throw new InvalidOperationException($"Install failed: {Detail(retry.Error, retry.Output)}");
+		}
+
+		// Not retried (recovery off or no package id) — give the clearest message we can.
+		if (certMismatch)
+			throw new InvalidOperationException(
+				"The TV already has this app signed with a different certificate. Remove it on the TV (Apps → delete) and install again, or enable \"Override existing app\" in Settings.");
+		if (outOfSpace)
+			throw new InvalidOperationException(
+				"Not enough free space on the TV [116]. Remove some apps and try again, or enable \"Override existing app\" in Settings.");
+
+		throw new InvalidOperationException($"Install failed: {Detail(failed.Error, failed.Output)}");
 	}
 
 	// Reads the Tizen application id and package id from the package's config.xml. A .wgt is a zip;

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -900,8 +900,7 @@ namespace Apps2Samsung.Services
             // the host capturing the route to the TV, or an unstable Wi-Fi link — not a packaging
             // problem, so retrying or overwriting can't help. Fail fast with an actionable hint
             // instead of looping a re-sign+re-push over the same broken route.
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.TransportConnectionLost, StringComparison.OrdinalIgnoreCase) ||
-                installResults.Output.Contains(Constants.TizenErrorCodes.ConnectionResetByPeer, StringComparison.OrdinalIgnoreCase))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IsTransportLost(installResults.Output))
             {
                 _appSettings.TryOverwrite = false;
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
@@ -910,7 +909,7 @@ namespace Apps2Samsung.Services
             }
 
             // Handle insufficient space error
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.DownloadFailed116))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IsInsufficientSpace(installResults.Output))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
 
@@ -928,8 +927,7 @@ namespace Apps2Samsung.Services
 
             // Handle certificate mismatch: the installed copy was signed with a different
             // certificate, so Tizen refuses to overwrite it. The only fix is removing the old copy.
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118012) ||
-                installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus12))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IsCertificateMismatch(installResults.Output))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
 
@@ -955,7 +953,7 @@ namespace Apps2Samsung.Services
             // targets a higher Tizen API level than this TV supports. Not a certificate or privilege
             // problem, and re-signing/overwriting can't help — the TV simply can't run this build.
             // Give the user a clear reason instead of a raw error code.
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118Minus4))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IsApiVersionMismatch(installResults.Output))
             {
                 _appSettings.TryOverwrite = false;
                 var apiMessage = Constants.LocalizationKeys.ApiVersionMismatch.Localized();
@@ -967,7 +965,7 @@ namespace Apps2Samsung.Services
             // Handle package ID conflict error. Note: a service-component incompatibility
             // (the common cause on older TVs) is already handled before install in Step 3b,
             // so reaching here generally means a genuine id/config conflict.
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.InstallFailed118))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IsPackageIdConflict(installResults.Output))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
 
@@ -983,7 +981,7 @@ namespace Apps2Samsung.Services
             }
 
             // Handle generic failure
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.Failed))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IsGenericFailure(installResults.Output))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationFailed.Localized());
 
@@ -998,8 +996,7 @@ namespace Apps2Samsung.Services
             }
 
             // Handle success
-            if (installResults.Output.Contains(Constants.TizenErrorCodes.Installing100) ||
-                installResults.Output.Contains(Constants.TizenErrorCodes.InstallCompleted))
+            if (Apps2Samsung.Sdb.TizenInstallDiagnostics.IndicatesSuccess(installResults.Output))
             {
                 progress?.Invoke(Constants.LocalizationKeys.InstallationSuccessful.Localized());
 


### PR DESCRIPTION
Gap #3 (the robustness one). Mobile previously threw the raw failure on any non-zero install; a bad install was a dead end where desktop would recover.

Now the result is classified (mirroring desktop `HandleInstallationResultAsync`):
- **Transport/connection lost** → fail fast with a Wi-Fi hint (retry can't help).
- **API-version `[118, -4]`** → explain the TV's Tizen is too old, suggest an older build (no retry).
- **Cert mismatch `[118012]`/`[118, -12]`, space `[116]`, package-id conflict `[118]`, or generic** → remove the old copy and **reinstall once**; if it still fails, a specific message (cert mismatch → "remove it on the TV and reinstall").

The one-shot overwrite retry is gated on the `try_overwrite` preference (default **true**, same key as the Override-existing-app toggle in #483) — so it works on its own and respects that toggle once merged.

Mobile builds **0 errors**. Hard to unit-test the codes without a failing TV; the happy path is unchanged (success returns immediately).