### PR TITLE
Mobile Jellyfin: Test-connection button + mDNS warning

### DIFF
--- a/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml
@@ -54,6 +54,17 @@
                 </Border>
                 <Label Style="{StaticResource Hint}"
                        Text="Full address including http:// or https:// and the port. Include a base path too if you use a reverse proxy (e.g. https://media.example.com/jellyfin)." />
+                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                    <Button Grid.Column="0" x:Name="TestBtn" Text="Test connection" Clicked="OnTestConnectionClicked"
+                            BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="14,6"
+                            HorizontalOptions="Start"
+                            BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
+                    <Label Grid.Column="1" x:Name="ServerTestLabel" Style="{StaticResource Hint}"
+                           VerticalOptions="Center" IsVisible="False" />
+                </Grid>
+                <Label x:Name="MdnsWarning" IsVisible="False" FontSize="12" TextColor="#B8860B"
+                       Text="⚠️ .local (mDNS) addresses are often unreliable on Samsung TVs. Prefer the server's IP address if you can." />
 
                 <BoxView Style="{StaticResource Divider}" />
 

--- a/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/JellyfinSettingsPage.xaml.cs
@@ -33,6 +33,7 @@ public partial class JellyfinSettingsPage : ContentPage
 		YoutubeSwitch.IsToggled = MobileSettings.JellyfinPatchYoutube;
 		_loaded = true;
 
+		UpdateMdnsWarning(ServerUrlEntry.Text);
 		RefreshSignInState();
 	}
 
@@ -42,6 +43,68 @@ public partial class JellyfinSettingsPage : ContentPage
 	{
 		if (_loaded)
 			MobileSettings.JellyfinServerUrl = ServerUrlEntry.Text?.Trim() ?? string.Empty;
+		UpdateMdnsWarning(ServerUrlEntry.Text);
+	}
+
+	// Checks the server is reachable without needing credentials (GETs /System/Info/Public via the
+	// shared Core API client), so the user can verify the address before signing in or installing.
+	private async void OnTestConnectionClicked(object? sender, EventArgs e)
+	{
+		var url = UrlHelper.NormalizeServerUrl(ServerUrlEntry.Text?.Trim() ?? string.Empty);
+		if (string.IsNullOrWhiteSpace(url))
+		{
+			ShowTest("Enter a server URL first.", isError: true);
+			return;
+		}
+
+		TestBtn.IsEnabled = false;
+		ShowTest("Testing…", isError: false);
+		try
+		{
+			using var http = new HttpClient();
+			var api = new JellyfinApiClient(http);
+			var info = await api.GetPublicSystemInfoAsync(url);
+			if (info is not null && !string.IsNullOrEmpty(info.Id))
+				ShowTest(string.IsNullOrEmpty(info.ServerName) ? "✓ Reachable." : $"✓ Reachable — {info.ServerName}.", isError: false);
+			else
+				ShowTest("Couldn't reach a Jellyfin server at that address.", isError: true);
+		}
+		catch (Exception ex)
+		{
+			ShowTest($"Couldn't reach the server: {ex.Message}", isError: true);
+		}
+		finally
+		{
+			TestBtn.IsEnabled = true;
+		}
+	}
+
+	private void ShowTest(string message, bool isError)
+	{
+		ServerTestLabel.Text = message;
+		ServerTestLabel.TextColor = isError ? Color.FromArgb("#B00020") : Color.FromArgb("#2E7D32");
+		ServerTestLabel.Opacity = 1.0;
+		ServerTestLabel.IsVisible = true;
+	}
+
+	// Warn when the host is an mDNS (.local) name — Tizen TVs resolve these unreliably.
+	private void UpdateMdnsWarning(string? url)
+	{
+		MdnsWarning.IsVisible = IsMdnsHost(url);
+	}
+
+	private static bool IsMdnsHost(string? url)
+	{
+		if (string.IsNullOrWhiteSpace(url))
+			return false;
+		var s = url.Trim();
+		var scheme = s.IndexOf("://", StringComparison.Ordinal);
+		if (scheme >= 0) s = s[(scheme + 3)..];
+		var slash = s.IndexOf('/');
+		if (slash >= 0) s = s[..slash];
+		var colon = s.IndexOf(':');
+		if (colon >= 0) s = s[..colon];
+		return s.TrimEnd('.').EndsWith(".local", StringComparison.OrdinalIgnoreCase);
 	}
 
 	private void OnCssUnfocused(object? sender, FocusEventArgs e)


### PR DESCRIPTION
Gap #5 (final of the concrete gaps). Adds the desktop server-config helpers to the mobile Jellyfin page:

- **Test connection** — verifies the server is reachable **without credentials** (GET `/System/Info/Public` via the shared Core `JellyfinApiClient` — no duplicated logic) and shows the server name.
- **mDNS warning** — flags `.local` host names, which Tizen TVs resolve unreliably.

The desktop's 3-mode input switch (IP:Port / IP:Port:Path / Full URL) is intentionally **not** ported — the single full-URL field is simpler on mobile and covers all three.

Mobile builds **0 errors**.