### PR TITLE
Show installed apps (+ uninstall) — Core + desktop + mobile

### DIFF
--- a/Apps2Samsung.Core/Models/InstalledApp.cs
+++ b/Apps2Samsung.Core/Models/InstalledApp.cs
@@ -1,0 +1,17 @@
+namespace Apps2Samsung.Models
+{
+    /// <summary>
+    /// One app reported installed on a TV by the <c>vd_applist</c> query, parsed by
+    /// <see cref="Apps2Samsung.Sdb.TizenInstalledApps"/>. Shared by both heads' "installed apps" view.
+    /// </summary>
+    public sealed record InstalledApp(
+        string Title,
+        string TizenId,
+        string Version,
+        string InstallDate,
+        bool IsRemovable)
+    {
+        /// <summary>Title if the TV reported one, otherwise the Tizen id — never empty.</summary>
+        public string DisplayName => string.IsNullOrWhiteSpace(Title) ? TizenId : Title;
+    }
+}

--- a/Apps2Samsung.Core/Sdb/TizenInstalledApps.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstalledApps.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Apps2Samsung.Models;
+
+namespace Apps2Samsung.Sdb
+{
+    /// <summary>
+    /// Parses the raw <c>vd_applist</c> output (the same listing already used to detect whether an app
+    /// is installed) into a list of <see cref="InstalledApp"/>, shared by both heads' "installed apps"
+    /// view. The listing is a sequence of per-app blocks separated by long dash rules, each line being
+    /// <c>--------------&lt;key&gt;   =&lt;value&gt;-------------</c>.
+    /// </summary>
+    public static class TizenInstalledApps
+    {
+        // A single "key = value" field line, tolerant of the surrounding dashes and alignment padding.
+        // The value is non-greedy up to the trailing 3+ dashes (single dashes inside e.g. a date/path
+        // don't terminate it).
+        private static readonly Regex FieldLine = new(
+            @"^\s*-{3,}\s*(?<key>[^\s=]+)\s*=\s*(?<val>.*?)\s*-{3,}\s*$",
+            RegexOptions.Compiled);
+
+        // A block-separator rule: a line of only dashes/whitespace (no '='), long enough to be a divider.
+        private static bool IsSeparator(string line) =>
+            !line.Contains('=') && line.Contains("----") && line.Replace("-", "").Trim().Length == 0;
+
+        /// <summary>Parse the applist output. Returns the apps sorted by display name (case-insensitive);
+        /// empty when the output is blank or an error/"no listing" response.</summary>
+        public static IReadOnlyList<InstalledApp> Parse(string? output)
+        {
+            var apps = new List<InstalledApp>();
+            if (string.IsNullOrWhiteSpace(output))
+                return apps;
+
+            var current = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            void Flush()
+            {
+                if (current.TryGetValue("app_tizen_id", out var id) && !string.IsNullOrWhiteSpace(id))
+                {
+                    apps.Add(new InstalledApp(
+                        Title: current.GetValueOrDefault("app_title", string.Empty),
+                        TizenId: id.Trim(),
+                        Version: current.GetValueOrDefault("app_version", string.Empty),
+                        InstallDate: current.GetValueOrDefault("install_date", string.Empty),
+                        IsRemovable: current.GetValueOrDefault("is_removable", string.Empty) == "1"));
+                }
+                current.Clear();
+            }
+
+            foreach (var raw in output.Replace("\r", string.Empty).Split('\n'))
+            {
+                if (IsSeparator(raw))
+                {
+                    Flush();
+                    continue;
+                }
+
+                var m = FieldLine.Match(raw);
+                if (m.Success)
+                    current[m.Groups["key"].Value.Trim()] = m.Groups["val"].Value.Trim();
+            }
+            Flush();
+
+            return apps
+                .GroupBy(a => a.TizenId, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .OrderBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Apps2Samsung.Mobile.Pages.InstalledAppsPage"
+             Title="Installed apps"
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#141414}">
+
+    <Grid RowDefinitions="Auto,Auto,*" Margin="12" RowSpacing="10">
+
+        <!-- Header banner with a back affordance -->
+        <Border Grid.Row="0" BackgroundColor="#2C3E50" Padding="12,18" StrokeThickness="0" StrokeShape="RoundRectangle 8">
+            <Grid ColumnDefinitions="44,*,44" VerticalOptions="Center">
+                <Button Grid.Column="0" Text="‹" FontSize="26" TextColor="White"
+                        BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                        WidthRequest="44" HeightRequest="44" Clicked="OnBackClicked" />
+                <Label Grid.Column="1" Text="Installed apps" TextColor="White" FontAttributes="Bold"
+                       VerticalOptions="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                <Button Grid.Column="2" x:Name="RefreshBtn" Text="⟳" FontSize="18" TextColor="White"
+                        BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                        WidthRequest="44" HeightRequest="44" Clicked="OnRefreshClicked" />
+            </Grid>
+        </Border>
+
+        <!-- Subtitle: count / status -->
+        <Label Grid.Row="1" x:Name="CountLabel" FontSize="12" Opacity="0.6" Text="Loading…" />
+
+        <!-- App list -->
+        <CollectionView Grid.Row="2" x:Name="AppsList">
+            <CollectionView.EmptyView>
+                <Label x:Name="EmptyLabel" Text="No apps to show." Padding="16"
+                       HorizontalTextAlignment="Center" Opacity="0.6" />
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Border Margin="0,4" Padding="12" StrokeThickness="1" StrokeShape="RoundRectangle 8"
+                            Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
+                            BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10" VerticalOptions="Center">
+                            <VerticalStackLayout Grid.Column="0" Spacing="2">
+                                <Label Text="{Binding DisplayName}" FontAttributes="Bold" FontSize="15"
+                                       LineBreakMode="TailTruncation" />
+                                <Label Text="{Binding TizenId}" FontSize="11" Opacity="0.55"
+                                       LineBreakMode="TailTruncation" />
+                                <Label Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55" />
+                            </VerticalStackLayout>
+                            <Button Grid.Column="1" Text="Uninstall" Clicked="OnUninstallClicked"
+                                    IsVisible="{Binding IsRemovable}" VerticalOptions="Center"
+                                    BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
+                                    BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                                    TextColor="{AppThemeBinding Light=#B00020, Dark=#FF6B6B}" />
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <!-- Busy overlay -->
+        <ActivityIndicator Grid.Row="2" x:Name="Busy" IsRunning="False" IsVisible="False"
+                           VerticalOptions="Center" HorizontalOptions="Center" Color="#2C3E50" />
+
+    </Grid>
+
+</ContentPage>

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+using Apps2Samsung.Sdb;
+
+namespace Apps2Samsung.Mobile.Pages;
+
+/// <summary>
+/// A quick overview of the apps installed on a TV (parsed from the shared <c>vd_applist</c> query via
+/// <see cref="TizenInstalledApps"/>), with a per-app uninstall for user-removable apps. Read-only for
+/// system apps.
+/// </summary>
+public partial class InstalledAppsPage : ContentPage
+{
+	private readonly ISdbEngine _sdb;
+	private readonly string _tvIp;
+	private readonly string _tvLabel;
+
+	public InstalledAppsPage(ISdbEngine sdb, string tvIp, string tvLabel)
+	{
+		InitializeComponent();
+		_sdb = sdb;
+		_tvIp = tvIp;
+		_tvLabel = tvLabel;
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		await LoadAsync();
+	}
+
+	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
+
+	private async void OnRefreshClicked(object? sender, EventArgs e) => await LoadAsync();
+
+	private async Task LoadAsync()
+	{
+		SetBusy(true, "Reading installed apps…");
+		try
+		{
+			var result = await _sdb.AppsAsync(_tvIp);
+			var apps = TizenInstalledApps.Parse(result?.Output);
+			AppsList.ItemsSource = apps;
+
+			if (apps.Count == 0)
+			{
+				EmptyLabel.Text = "Couldn't read the app list from this TV.";
+				CountLabel.Text = _tvLabel;
+			}
+			else
+			{
+				var removable = apps.Count(a => a.IsRemovable);
+				CountLabel.Text = $"{apps.Count} apps on {_tvLabel} · {removable} removable";
+			}
+		}
+		catch (Exception ex)
+		{
+			AppsList.ItemsSource = null;
+			EmptyLabel.Text = $"Couldn't read the app list: {ex.Message}";
+			CountLabel.Text = _tvLabel;
+		}
+		finally
+		{
+			SetBusy(false);
+		}
+	}
+
+	private async void OnUninstallClicked(object? sender, EventArgs e)
+	{
+		if (sender is not Button { BindingContext: InstalledApp app })
+			return;
+
+		var confirm = await DisplayAlert(
+			"Uninstall app",
+			$"Remove \"{app.DisplayName}\" from {_tvLabel}?\n\n({app.TizenId})",
+			"Uninstall", "Cancel");
+		if (!confirm)
+			return;
+
+		SetBusy(true, $"Uninstalling {app.DisplayName}…");
+		try
+		{
+			var result = await _sdb.UninstallAsync(_tvIp, app.TizenId);
+			// The TV reports a not-installed code when the app is already gone — treat that as success.
+			var ok = result.ExitCode == 0 ||
+					 (result.Output?.Contains("failed[132]", StringComparison.OrdinalIgnoreCase) ?? false);
+			if (!ok)
+			{
+				SetBusy(false);
+				await DisplayAlert("Uninstall failed",
+					string.IsNullOrWhiteSpace(result.Error) ? result.Output?.Trim() : result.Error, "OK");
+				return;
+			}
+		}
+		catch (Exception ex)
+		{
+			SetBusy(false);
+			await DisplayAlert("Uninstall failed", ex.Message, "OK");
+			return;
+		}
+
+		// Refresh so the removed app drops off the list.
+		await LoadAsync();
+	}
+
+	private void SetBusy(bool busy, string? status = null)
+	{
+		Busy.IsVisible = busy;
+		Busy.IsRunning = busy;
+		AppsList.IsVisible = !busy;
+		if (status is not null)
+			CountLabel.Text = status;
+	}
+}

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
@@ -75,6 +75,12 @@
                             Clicked="OnRefreshClicked" />
                 </Grid>
 
+                <!-- Quick peek at what's already on the selected TV -->
+                <Button Text="📋 Show installed apps" Clicked="OnShowInstalledAppsClicked"
+                        HorizontalOptions="Start" BackgroundColor="Transparent" BorderWidth="0"
+                        Padding="0" FontSize="13"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
+
                 <!-- Status bar -->
                 <Border BackgroundColor="#2C3E50" Padding="16" StrokeThickness="0" StrokeShape="RoundRectangle 6">
                     <Label x:Name="StatusLabel" Text="Ready for use…"

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -26,6 +26,7 @@ public partial class InstallerPage : ContentPage
 	private readonly CatalogService _catalog;
 	private readonly GitHubUpdateChecker _updateChecker;
 	private readonly SessionState _session;
+	private readonly ISdbEngine _sdb;
 
 	// Parallel lists backing the TV picker: IP + display label for each listed TV (discovered or
 	// manually added). The picker also shows a trailing ManualIpLabel entry that isn't in these.
@@ -46,7 +47,7 @@ public partial class InstallerPage : ContentPage
 
 	public InstallerPage(INetworkService networkService, ISamsungLoginService loginService,
 		CertificateProvisioner certProvisioner, WgtInstaller installer, CatalogService catalog,
-		GitHubUpdateChecker updateChecker, SessionState session)
+		GitHubUpdateChecker updateChecker, SessionState session, ISdbEngine sdb)
 	{
 		InitializeComponent();
 		_networkService = networkService;
@@ -56,6 +57,7 @@ public partial class InstallerPage : ContentPage
 		_catalog = catalog;
 		_updateChecker = updateChecker;
 		_session = session;
+		_sdb = sdb;
 
 		// Shows the app version (ApplicationDisplayVersion), so it stays in sync with the build.
 		VersionLabel.Text = $"v{AppInfo.Current.VersionString}";
@@ -255,6 +257,18 @@ public partial class InstallerPage : ContentPage
 		}
 		RebuildTvPicker(idx);
 		SetStatus($"Using TV at {ip}.");
+	}
+
+	private async void OnShowInstalledAppsClicked(object? sender, EventArgs e)
+	{
+		if (TvPicker.SelectedIndex < 0 || TvPicker.SelectedIndex >= _tvIps.Count)
+		{
+			SetStatus("Select a TV first (tap refresh to scan).");
+			return;
+		}
+		var tvIp = _tvIps[TvPicker.SelectedIndex];
+		var label = TvPicker.SelectedItem as string ?? tvIp;
+		await Navigation.PushAsync(new InstalledAppsPage(_sdb, tvIp, label));
 	}
 
 	private async void OnRefreshClicked(object? sender, EventArgs e) => await ScanAsync();

--- a/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
@@ -1,6 +1,7 @@
 ﻿using Apps2Samsung.Extensions;
 using Apps2Samsung.Models;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,5 +19,11 @@ namespace Apps2Samsung.Interfaces
         Task<string> EnsureTizenSdbAvailable();
         Task<string> DownloadPackageAsync(string downloadUrl, bool validateWgt = false);
         Task<InstallResult> InstallPackageAsync(string packageUrl, string tvIpAddress, CancellationToken cancellationToken, ProgressCallback? progress = null, Action? onSamsungLoginStarted = null);
+
+        /// <summary>Lists the apps installed on the TV (ensures the SDB binary, queries, parses).</summary>
+        Task<IReadOnlyList<Apps2Samsung.Models.InstalledApp>> GetInstalledAppsAsync(string tvIpAddress);
+
+        /// <summary>Uninstalls an app from the TV by its Tizen id. Returns the raw SDB result.</summary>
+        Task<Apps2Samsung.Models.ProcessResult> UninstallAppAsync(string tvIpAddress, string tizenId);
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -1035,6 +1035,33 @@ namespace Apps2Samsung.Services
             return output.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim() ?? string.Empty;
         }
 
+        public async Task<IReadOnlyList<InstalledApp>> GetInstalledAppsAsync(string tvIpAddress)
+        {
+            await EnsureTizenSdbAvailable();
+            try
+            {
+                var result = await _sdb.AppsAsync(tvIpAddress);
+                return Apps2Samsung.Sdb.TizenInstalledApps.Parse(result?.Output);
+            }
+            finally
+            {
+                await _sdb.DisconnectAsync(tvIpAddress);
+            }
+        }
+
+        public async Task<ProcessResult> UninstallAppAsync(string tvIpAddress, string tizenId)
+        {
+            await EnsureTizenSdbAvailable();
+            try
+            {
+                return await _sdb.UninstallAsync(tvIpAddress, tizenId);
+            }
+            finally
+            {
+                await _sdb.DisconnectAsync(tvIpAddress);
+            }
+        }
+
         private async Task<(string tizenOs, string sdkToolPath)> FetchCapabilitiesAsync(string tvIpAddress)
         {
             var output = await _sdb.CapabilityAsync(tvIpAddress);

--- a/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
@@ -1,0 +1,115 @@
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Apps2Samsung.ViewModels
+{
+    /// <summary>
+    /// Lists the apps installed on a TV (via <see cref="ITizenInstallerService.GetInstalledAppsAsync"/>,
+    /// which shares the Core parser with the mobile head) and offers a per-app uninstall for
+    /// user-removable apps.
+    /// </summary>
+    public partial class InstalledAppsViewModel : ViewModelBase
+    {
+        private readonly ITizenInstallerService _installer;
+        private readonly IDialogService _dialogService;
+        private readonly string _tvIp;
+
+        public string TvLabel { get; }
+
+        public ObservableCollection<InstalledApp> Apps { get; } = new();
+
+        [ObservableProperty]
+        private bool isBusy;
+
+        [ObservableProperty]
+        private string statusText = string.Empty;
+
+        public event Action? OnRequestClose;
+
+        public InstalledAppsViewModel(ITizenInstallerService installer, IDialogService dialogService, string tvIp, string tvLabel)
+        {
+            _installer = installer;
+            _dialogService = dialogService;
+            _tvIp = tvIp;
+            TvLabel = tvLabel;
+        }
+
+        [RelayCommand]
+        private async Task Load()
+        {
+            IsBusy = true;
+            StatusText = "Reading installed apps…";
+            try
+            {
+                var apps = await _installer.GetInstalledAppsAsync(_tvIp);
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    Apps.Clear();
+                    foreach (var a in apps)
+                        Apps.Add(a);
+                });
+                var removable = apps.Count(a => a.IsRemovable);
+                StatusText = apps.Count == 0
+                    ? "Couldn't read the app list from this TV."
+                    : $"{apps.Count} apps · {removable} removable";
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"Couldn't read the app list: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task Uninstall(InstalledApp? app)
+        {
+            if (app is null || IsBusy)
+                return;
+
+            var confirm = await _dialogService.ShowConfirmationAsync(
+                "Uninstall app",
+                $"Remove \"{app.DisplayName}\" from {TvLabel}?\n\n({app.TizenId})",
+                "Uninstall", "Cancel");
+            if (!confirm)
+                return;
+
+            IsBusy = true;
+            StatusText = $"Uninstalling {app.DisplayName}…";
+            try
+            {
+                var result = await _installer.UninstallAppAsync(_tvIp, app.TizenId);
+                // "failed[132]" = not installed — already gone, treat as success.
+                var ok = result.ExitCode == 0 ||
+                         (result.Output?.Contains("failed[132]", StringComparison.OrdinalIgnoreCase) ?? false);
+                if (!ok)
+                {
+                    IsBusy = false;
+                    await _dialogService.ShowErrorAsync(
+                        string.IsNullOrWhiteSpace(result.Error) ? result.Output?.Trim() ?? "Uninstall failed." : result.Error);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                IsBusy = false;
+                await _dialogService.ShowErrorAsync(ex.Message);
+                return;
+            }
+
+            await Load();
+        }
+
+        [RelayCommand]
+        private void Close() => OnRequestClose?.Invoke();
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -593,6 +593,35 @@ namespace Apps2Samsung.ViewModels
         }
 
         [RelayCommand]
+        private async Task ShowInstalledAppsAsync()
+        {
+            try
+            {
+                if (SelectedDevice is null ||
+                    string.IsNullOrWhiteSpace(SelectedDevice.IpAddress) ||
+                    SelectedDevice.IpAddress == L("lblOther"))
+                {
+                    await _dialogService.ShowMessageAsync("Installed apps", "Select a TV first.");
+                    return;
+                }
+
+                if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+                    return;
+
+                var label = string.IsNullOrWhiteSpace(SelectedDevice.DisplayText)
+                    ? SelectedDevice.IpAddress
+                    : SelectedDevice.DisplayText;
+                var vm = new InstalledAppsViewModel(_tizenInstaller, _dialogService, SelectedDevice.IpAddress, label);
+                var window = new Views.InstalledAppsWindow(vm);
+                await window.ShowDialog(desktop.MainWindow);
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowErrorAsync($"Failed to open installed apps: {ex}");
+            }
+        }
+
+        [RelayCommand]
         private async Task BrowseWgtAsync()
         {
             var mainWindow = Avalonia.Application.Current?.ApplicationLifetime is

--- a/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
@@ -1,0 +1,71 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:fa="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+        xmlns:viewModels="clr-namespace:Apps2Samsung.ViewModels"
+        xmlns:models="clr-namespace:Apps2Samsung.Models;assembly=Apps2Samsung.Core"
+        x:Class="Apps2Samsung.Views.InstalledAppsWindow"
+        x:Name="Root"
+        x:DataType="viewModels:InstalledAppsViewModel"
+        Width="560" MinWidth="460"
+        Height="620" MinHeight="420"
+        WindowStartupLocation="CenterOwner"
+        Title="Installed apps">
+
+    <Window.Styles>
+        <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.xaml"/>
+        <StyleInclude Source="avares://Apps2Samsung/Styles/Buttons.axaml"/>
+        <StyleInclude Source="avares://Apps2Samsung/Styles/TextBlocks.axaml"/>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource CardBackgroundFillColorDefaultBrush}" Padding="16">
+        <DockPanel LastChildFill="True">
+
+            <!-- Header -->
+            <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+                <StackPanel Grid.Column="0" Spacing="2">
+                    <TextBlock Text="Installed apps" FontSize="18" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding TvLabel}" FontSize="12" Opacity="0.6"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
+                    <Button Content="↻" Command="{Binding LoadCommand}" ToolTip.Tip="Refresh"/>
+                    <Button Content="✕" Command="{Binding CloseCommand}"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Status -->
+            <TextBlock DockPanel.Dock="Top" Text="{Binding StatusText}" FontSize="12" Opacity="0.7" Margin="0,4,0,8"/>
+
+            <!-- Busy indicator -->
+            <ProgressBar DockPanel.Dock="Top" IsIndeterminate="True" Height="3" Margin="0,0,0,8"
+                         IsVisible="{Binding IsBusy}"/>
+
+            <!-- App list -->
+            <ScrollViewer>
+                <ItemsControl ItemsSource="{Binding Apps}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="models:InstalledApp">
+                            <Border Margin="0,3" Padding="12"
+                                    Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                                    CornerRadius="8">
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                    <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="14"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="{Binding TizenId}" FontSize="11" Opacity="0.55"
+                                                   TextTrimming="CharacterEllipsis"/>
+                                        <TextBlock Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55"/>
+                                    </StackPanel>
+                                    <Button Grid.Column="1" Content="Uninstall" VerticalAlignment="Center"
+                                            IsVisible="{Binding IsRemovable}"
+                                            Command="{ReflectionBinding $parent[Window].DataContext.UninstallCommand}"
+                                            CommandParameter="{Binding}"/>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+
+        </DockPanel>
+    </Border>
+</Window>

--- a/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Apps2Samsung.ViewModels;
+
+namespace Apps2Samsung.Views
+{
+    public partial class InstalledAppsWindow : Window
+    {
+        public InstalledAppsWindow(InstalledAppsViewModel vm)
+        {
+            InitializeComponent();
+            DataContext = vm;
+            vm.OnRequestClose += Close;
+            // Kick off the initial load once the window is shown.
+            Opened += async (_, _) => await vm.LoadCommand.ExecuteAsync(null);
+        }
+
+        // Parameterless ctor for the XAML designer.
+        public InstalledAppsWindow() => InitializeComponent();
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -148,6 +148,15 @@
 					</Button>
 				</Grid>
 
+				<!-- Quick peek at what's already on the selected TV -->
+				<Button HorizontalAlignment="Left" Padding="0" Background="Transparent" BorderThickness="0"
+						Command="{Binding ShowInstalledAppsCommand}">
+					<StackPanel Orientation="Horizontal" Spacing="6">
+						<fa:SymbolIcon Symbol="List" Width="16" Height="16"/>
+						<TextBlock Text="Show installed apps" VerticalAlignment="Center"/>
+					</StackPanel>
+				</Button>
+
 			</StackPanel>
 
 			<!-- Status - Clean and simple -->


### PR DESCRIPTION
New shared feature: a **Show installed apps** overview for the selected TV, with a per-app **Uninstall**. Reuses the `vd_applist` query already used to detect whether an app is installed — no new SDB plumbing.

**Core (shared):**
- `InstalledApp` model + `Apps2Samsung.Sdb.TizenInstalledApps.Parse` — parses the applist blocks (title / tizen id / version / install date / removable) once, used by both heads.

**Mobile:**
- A **Show installed apps** link on the installer page → new `InstalledAppsPage` (CollectionView) listing apps, each with an **Uninstall** button (confirm prompt; only for user-removable apps). `ISdbEngine` injected into the page.

**Desktop:**
- A **Show installed apps** button by the TV picker → `InstalledAppsWindow` + `InstalledAppsViewModel`, same list + uninstall.
- `ITizenInstallerService` gains `GetInstalledAppsAsync` / `UninstallAppAsync` (ensure-sdb → query/uninstall → disconnect), keeping the VM UI-only.

Uninstall **confirms first**, treats `not installed [132]` as success, then refreshes the list. System apps show no Uninstall button.

Desktop + mobile build **0 errors**. (Desktop window UI I couldn't runtime-test — worth a quick look; the SDB lifecycle mirrors the install flow.)