### PR TITLE
docs: full professional landing site (desktop + Android, catalog, downloads)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,393 +4,527 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>Apps2Samsung — Install any app on your Samsung TV</title>
-  <meta name="description" content="Cross-platform (Windows, macOS, Linux) one-click installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Free and open source." />
-  <meta name="keywords" content="Samsung TV app installer, install apps Samsung TV, Samsung TV sideload, Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Moonlight Samsung TV, Moonfin, Litefin, AVPlay, Tizen community apps, Apps2Samsung, Jellyfin2Samsung, Patrick Stel" />
+  <title>Apps2Samsung — Install any app on your Samsung TV, from your desktop or phone</title>
+  <meta name="description" content="Free, open-source installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Runs on Windows, macOS, Linux and now Android." />
+  <meta name="keywords" content="Samsung TV app installer, install apps Samsung TV, Samsung TV sideload, Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Moonlight Samsung TV, Moonfin, Litefin, AVPlay, Tizen community apps, install apps from phone, Apps2Samsung, Jellyfin2Samsung, Patrick Stel" />
   <link rel="canonical" href="https://apps2samsung.madebypatrick.nl/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Apps2Samsung — Install any app on your Samsung TV" />
-  <meta property="og:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto your Samsung TV. Runs on Windows, macOS and Linux." />
+  <meta property="og:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto your Samsung TV. Runs on Windows, macOS, Linux — and now from your Android phone." />
   <meta property="og:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png" />
   <meta property="og:url" content="https://apps2samsung.madebypatrick.nl/" />
   <meta property="og:type" content="website" />
 
-  <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Apps2Samsung — Install any app on your Samsung TV">
-  <meta name="twitter:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto Samsung TVs from Windows, macOS or Linux.">
+  <meta name="twitter:description" content="Side-load Jellyfin, Moonlight and the whole community Tizen catalog onto Samsung TVs from Windows, macOS, Linux or your Android phone.">
   <meta name="twitter:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png">
 
-  <!-- Favicon -->
   <link rel="icon" href="/favicon.ico">
-  <meta name="theme-color" content="#16202B">
+  <meta name="theme-color" content="#0B1119">
 
-  <!-- Structured Data -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
     "name": "Apps2Samsung",
     "alternateName": ["Jellyfin2Samsung", "Samsung Jellyfin Installer"],
-    "operatingSystem": "Windows, macOS, Linux",
+    "operatingSystem": "Windows, macOS, Linux, Android",
     "applicationCategory": "UtilitiesApplication",
-    "author": {
-      "@type": "Person",
-      "name": "Patrick Stel"
-    },
-    "description": "Cross-platform desktop installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight and the whole community Tizen catalog.",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "author": { "@type": "Person", "name": "Patrick Stel" },
+    "description": "Cross-platform installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight and the whole community Tizen catalog. Runs on desktop and on Android.",
     "url": "https://apps2samsung.madebypatrick.nl/",
     "image": "https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png"
   }
   </script>
 
   <style>
-    body {
-      font-family: system-ui, -apple-system, sans-serif;
-      background: #16202B;
-      color: #ECF0F5;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      min-height: 100vh;
-      margin: 0;
-      padding: 20px;
+    :root{
+      --bg:#0B1119; --bg2:#0E1621; --surface:rgba(255,255,255,.035); --surface2:rgba(255,255,255,.06);
+      --border:rgba(255,255,255,.09); --border2:rgba(255,255,255,.14);
+      --text:#EAF1F8; --muted:#8DA1B8; --dim:#63768C;
+      --cyan:#2DC4EA; --blue:#00A4DC; --purple:#AA5CC3; --green:#4ADE80;
+      --grad:linear-gradient(120deg,#00A4DC 0%,#8E51C6 100%);
+      --grad-soft:linear-gradient(120deg,rgba(0,164,220,.18),rgba(170,92,195,.18));
+      --radius:16px; --maxw:1120px;
     }
-    main {
-      background: rgba(255,255,255,0.03);
-      border: 1px solid rgba(255,255,255,0.1);
-      border-radius: 16px;
-      padding: 40px;
-      max-width: 800px;
-      width: 100%;
-      text-align: center;
-      box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+    *{box-sizing:border-box}
+    html{scroll-behavior:smooth}
+    body{
+      margin:0; font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+      color:var(--text); line-height:1.6;
+      background:
+        radial-gradient(1200px 600px at 80% -10%,rgba(0,164,220,.16),transparent 60%),
+        radial-gradient(900px 500px at 0% 0%,rgba(170,92,195,.12),transparent 55%),
+        var(--bg);
+      -webkit-font-smoothing:antialiased;
     }
-    img.logo {
-      height: 72px;
-      margin-bottom: 12px;
-    }
-    h1 { font-size: 2.2rem; margin: .5em 0 .2em; }
-    h2 { color: #91A7BD; font-weight: 500; margin: 0 0 1.2em; }
-    h3 { color: #B9C9DA; font-size: 1.05rem; font-weight: 600; margin: 1.6em 0 .6em; letter-spacing: .02em; text-transform: uppercase; }
-    .btn {
-      display: inline-block;
-      padding: 10px 18px;
-      margin: 6px;
-      border-radius: 999px;
-      text-decoration: none;
-      color: #ffffff;
-      background: linear-gradient(90deg,#2563EB,#3B82F6);
-      font-weight: 600;
-      transition: transform 0.15s ease;
-    }
-    .btn:hover { filter: brightness(1.1); transform: translateY(-2px); }
-    .meta { margin: 1em 0; color: #8296AC; }
-    .chip {
-      display: inline-block;
-      border: 1px dashed rgba(255,255,255,0.2);
-      border-radius: 999px;
-      padding: 3px 10px;
-      margin: 4px 4px;
-      font-size: .9em;
-    }
-    .chip.solid {
-      border: 1px solid rgba(37,99,235,0.45);
-      background: rgba(37,99,235,0.10);
-      color: #B9C9DA;
-    }
-    /* highlight the visitor's detected OS */
-    .chip.detected {
-      border: 1px solid rgba(34,197,94,0.7);
-      background: rgba(34,197,94,0.15);
-      color: #ECF0F5;
-      box-shadow: 0 0 0 1px rgba(34,197,94,0.25);
-    }
-    .grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 10px;
-      text-align: left;
-      margin: 8px 0 4px;
-    }
-    .card {
-      background: rgba(255,255,255,0.03);
-      border: 1px solid rgba(255,255,255,0.08);
-      border-radius: 12px;
-      padding: 12px 14px;
-      font-size: .9em;
-      line-height: 1.4;
-    }
-    .card strong { color: #ECF0F5; display: block; margin-bottom: 2px; }
-    .card span { color: #8296AC; }
-    /* download list rows */
-    .dl-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 10px;
-      text-align: left;
-      margin: 8px 0 4px;
-    }
-    .dl-grid .card.detected {
-      border: 1px solid rgba(34,197,94,0.5);
-      background: rgba(34,197,94,0.06);
-    }
-    .dlrow {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: baseline;
-      gap: 6px 10px;
-      margin-top: 8px;
-      padding-top: 8px;
-      border-top: 1px solid rgba(255,255,255,0.06);
-    }
-    .dlrow:first-of-type { border-top: 0; padding-top: 0; }
-    .dlrow .arch { color: #B9C9DA; font-weight: 600; min-width: 92px; }
-    .dlrow a {
-      color: #4ADE80;
-      text-decoration: none;
-      border-bottom: 1px solid rgba(74,222,128,0.3);
-      font-size: .92em;
-    }
-    .dlrow a:hover { border-bottom-color: #4ADE80; }
-    .dlrow .sz { color: #64748B; font-size: .8em; }
-    .note { color: #64748B; font-size: .8em; margin-top: 6px; }
-    /* Responsive video container */
-    .video-wrapper {
-      position: relative;
-      padding-bottom: 56.25%; /* 16:9 ratio */
-      height: 0;
-      overflow: hidden;
-      border-radius: 12px;
-      box-shadow: 0 4px 20px rgba(0,0,0,0.3);
-      margin: 30px 0;
-    }
-    .video-wrapper iframe {
-      position: absolute;
-      top: 0; left: 0;
-      width: 100%; height: 100%;
-      border: 0;
-    }
+    a{color:inherit}
+    .wrap{max-width:var(--maxw); margin:0 auto; padding:0 22px}
+    .eyebrow{ text-transform:uppercase; letter-spacing:.14em; font-size:.72rem; font-weight:700; color:var(--cyan); }
+    h2.section{ font-size:clamp(1.6rem,3.2vw,2.3rem); margin:.2em 0 .1em; letter-spacing:-.02em; }
+    .lead{ color:var(--muted); max-width:640px; }
+    section{ padding:76px 0; }
+    .center{ text-align:center; margin:0 auto; }
+
+    /* ---------- nav ---------- */
+    header.nav{ position:sticky; top:0; z-index:50; backdrop-filter:blur(12px);
+      background:rgba(11,17,25,.72); border-bottom:1px solid var(--border); }
+    .nav-inner{ display:flex; align-items:center; gap:18px; height:64px; }
+    .brand{ display:flex; align-items:center; gap:10px; font-weight:800; letter-spacing:-.02em; text-decoration:none; }
+    .brand svg{ width:30px; height:30px; }
+    .brand b{ font-size:1.05rem }
+    .nav-links{ display:flex; gap:22px; margin-left:12px; }
+    .nav-links a{ color:var(--muted); text-decoration:none; font-size:.92rem; font-weight:500; }
+    .nav-links a:hover{ color:var(--text) }
+    .nav-cta{ margin-left:auto; display:flex; gap:10px; align-items:center }
+    @media(max-width:820px){ .nav-links{display:none} }
+
+    /* ---------- buttons ---------- */
+    .btn{ display:inline-flex; align-items:center; gap:8px; padding:11px 20px; border-radius:999px;
+      text-decoration:none; font-weight:650; font-size:.95rem; border:1px solid transparent;
+      transition:transform .15s ease,filter .15s ease,background .2s; cursor:pointer; }
+    .btn.primary{ background:var(--grad); color:#fff; box-shadow:0 8px 24px rgba(0,164,220,.28); }
+    .btn.primary:hover{ transform:translateY(-2px); filter:brightness(1.08) }
+    .btn.ghost{ background:var(--surface); color:var(--text); border-color:var(--border2) }
+    .btn.ghost:hover{ background:var(--surface2); transform:translateY(-2px) }
+    .btn.sm{ padding:8px 15px; font-size:.86rem }
+
+    /* ---------- hero ---------- */
+    .hero{ padding:64px 0 40px; display:grid; grid-template-columns:1.05fr .95fr; gap:48px; align-items:center; }
+    .hero h1{ font-size:clamp(2.1rem,5vw,3.4rem); line-height:1.05; letter-spacing:-.03em; margin:.35em 0 .3em; }
+    .hero h1 .accent{ background:var(--grad); -webkit-background-clip:text; background-clip:text; color:transparent; }
+    .hero p.sub{ color:var(--muted); font-size:1.1rem; max-width:560px; }
+    .hero-cta{ display:flex; flex-wrap:wrap; gap:12px; margin:26px 0 18px; }
+    .os-row{ display:flex; flex-wrap:wrap; gap:8px; align-items:center; color:var(--dim); font-size:.85rem }
+    .pill{ display:inline-flex; align-items:center; gap:6px; padding:5px 12px; border-radius:999px;
+      border:1px solid var(--border); background:var(--surface); font-size:.82rem; color:var(--muted) }
+    .pill.on{ border-color:rgba(74,222,128,.55); background:rgba(74,222,128,.12); color:var(--text) }
+    .verline{ margin-top:16px; font-size:.85rem; color:var(--dim) }
+    .verline b{ color:var(--muted) }
+
+    /* hero visual: a TV screen with an app grid + a phone */
+    .stage{ position:relative; }
+    .tv{ background:linear-gradient(180deg,#111b27,#0c141d); border:1px solid var(--border2); border-radius:18px;
+      padding:16px; box-shadow:0 30px 70px rgba(0,0,0,.5); }
+    .tv-bar{ display:flex; gap:6px; margin-bottom:12px; }
+    .tv-bar i{ width:9px; height:9px; border-radius:50%; background:#2a3a4d; display:block }
+    .app-grid{ display:grid; grid-template-columns:repeat(4,1fr); gap:10px; }
+    .tile{ aspect-ratio:1; border-radius:14px; display:flex; flex-direction:column; align-items:center; justify-content:center;
+      gap:6px; font-size:1.5rem; background:var(--surface2); border:1px solid var(--border);
+      color:#fff; font-weight:700; }
+    .tile small{ font-size:.6rem; color:var(--muted); font-weight:500 }
+    .tv-stand{ width:120px; height:10px; margin:0 auto; border-radius:0 0 10px 10px;
+      background:linear-gradient(180deg,#1a2836,#0c141d); }
+    .phone{ position:absolute; right:-6px; bottom:-26px; width:118px; background:#0c141d;
+      border:1px solid var(--border2); border-radius:20px; padding:10px 9px; box-shadow:0 20px 40px rgba(0,0,0,.55); }
+    .phone .scr{ background:var(--grad-soft); border:1px solid var(--border); border-radius:12px; padding:9px; }
+    .phone .ln{ height:7px; border-radius:4px; background:var(--surface2); margin:5px 0 }
+    .phone .ln.w{ width:70% }
+    .phone .go{ margin-top:8px; height:20px; border-radius:6px; background:var(--grad); display:flex;
+      align-items:center; justify-content:center; font-size:.52rem; color:#fff; font-weight:700 }
+    @media(max-width:900px){ .hero{ grid-template-columns:1fr; gap:30px } .phone{ display:none } }
+
+    /* ---------- android band ---------- */
+    .band{ background:var(--grad-soft); border:1px solid var(--border); border-radius:var(--radius); padding:34px;
+      display:grid; grid-template-columns:auto 1fr auto; gap:26px; align-items:center; }
+    .band .em{ font-size:2.6rem }
+    .band h3{ margin:0 0 4px; font-size:1.35rem }
+    .band p{ margin:0; color:var(--muted); max-width:640px }
+    @media(max-width:820px){ .band{ grid-template-columns:1fr; text-align:center; gap:16px } }
+
+    /* ---------- feature grid ---------- */
+    .grid{ display:grid; gap:16px; }
+    .g3{ grid-template-columns:repeat(3,1fr) }
+    .g4{ grid-template-columns:repeat(4,1fr) }
+    @media(max-width:900px){ .g3{grid-template-columns:repeat(2,1fr)} .g4{grid-template-columns:repeat(2,1fr)} }
+    @media(max-width:560px){ .g3,.g4{grid-template-columns:1fr} }
+    .card{ background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:20px; transition:border-color .2s,transform .2s; }
+    .card:hover{ border-color:var(--border2); transform:translateY(-3px) }
+    .card .ic{ font-size:1.5rem; margin-bottom:10px; display:block }
+    .card h4{ margin:0 0 6px; font-size:1.02rem }
+    .card p{ margin:0; color:var(--muted); font-size:.9rem }
+
+    /* ---------- apps gallery ---------- */
+    .app{ display:flex; gap:14px; align-items:flex-start; }
+    .app .badge{ flex:none; width:46px; height:46px; border-radius:12px; display:flex; align-items:center; justify-content:center;
+      font-size:1.35rem; background:var(--grad-soft); border:1px solid var(--border); }
+    .app h4{ margin:0 0 3px; font-size:1rem }
+    .app p{ margin:0; color:var(--muted); font-size:.87rem }
+    .tag{ display:inline-block; font-size:.7rem; font-weight:700; letter-spacing:.04em; text-transform:uppercase;
+      color:var(--cyan); border:1px solid rgba(45,196,234,.4); border-radius:999px; padding:2px 8px; margin-left:8px; vertical-align:middle }
+
+    /* ---------- steps ---------- */
+    .steps{ display:grid; grid-template-columns:repeat(3,1fr); gap:18px; counter-reset:s; }
+    @media(max-width:820px){ .steps{grid-template-columns:1fr} }
+    .step{ background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:24px; position:relative }
+    .step::before{ counter-increment:s; content:counter(s); position:absolute; top:-14px; left:20px;
+      width:34px; height:34px; border-radius:50%; background:var(--grad); color:#fff; font-weight:800;
+      display:flex; align-items:center; justify-content:center; box-shadow:0 6px 16px rgba(0,164,220,.3) }
+    .step h4{ margin:12px 0 6px; font-size:1.08rem }
+    .step p{ margin:0; color:var(--muted); font-size:.92rem }
+
+    /* ---------- downloads ---------- */
+    .dl-grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(230px,1fr)); gap:14px; }
+    .dl-card{ background:var(--surface); border:1px solid var(--border); border-radius:var(--radius); padding:18px 20px }
+    .dl-card.detected{ border-color:rgba(74,222,128,.5); background:rgba(74,222,128,.05) }
+    .dl-card strong{ display:block; margin-bottom:8px; font-size:1rem }
+    .dlrow{ display:flex; flex-wrap:wrap; align-items:baseline; gap:6px 10px; margin-top:8px; padding-top:8px; border-top:1px solid var(--border) }
+    .dlrow:first-of-type{ border-top:0; padding-top:0 }
+    .dlrow .arch{ color:var(--muted); font-weight:600; min-width:96px; font-size:.9rem }
+    .dlrow a{ color:var(--green); text-decoration:none; border-bottom:1px solid rgba(74,222,128,.3); font-size:.9rem }
+    .dlrow a:hover{ border-bottom-color:var(--green) }
+    .dlrow .sz{ color:var(--dim); font-size:.78rem }
+    .note{ color:var(--dim); font-size:.82rem; margin-top:10px }
+
+    /* ---------- video ---------- */
+    .video{ position:relative; padding-bottom:56.25%; height:0; overflow:hidden; border-radius:var(--radius);
+      border:1px solid var(--border); box-shadow:0 20px 50px rgba(0,0,0,.4); }
+    .video iframe{ position:absolute; inset:0; width:100%; height:100%; border:0 }
+
+    /* ---------- faq ---------- */
+    details{ background:var(--surface); border:1px solid var(--border); border-radius:14px; padding:2px 18px; margin-bottom:12px }
+    details[open]{ border-color:var(--border2) }
+    summary{ cursor:pointer; font-weight:650; padding:16px 0; list-style:none; display:flex; justify-content:space-between; align-items:center }
+    summary::-webkit-details-marker{ display:none }
+    summary::after{ content:"+"; color:var(--cyan); font-size:1.3rem; font-weight:400 }
+    details[open] summary::after{ content:"−" }
+    details p{ margin:0 0 16px; color:var(--muted); font-size:.94rem }
+    details a{ color:var(--green) }
+
+    /* ---------- footer ---------- */
+    footer{ border-top:1px solid var(--border); padding:44px 0 60px; color:var(--muted) }
+    .foot{ display:flex; flex-wrap:wrap; gap:26px; justify-content:space-between; align-items:flex-start }
+    .foot a{ color:var(--muted); text-decoration:none; display:block; padding:4px 0; font-size:.9rem }
+    .foot a:hover{ color:var(--text) }
+    .foot h5{ margin:0 0 8px; font-size:.78rem; text-transform:uppercase; letter-spacing:.1em; color:var(--dim) }
+    .copy{ margin-top:30px; font-size:.85rem; color:var(--dim) }
   </style>
 </head>
 <body>
-  <main>
-    <img class="logo" src="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.svg" alt="Apps2Samsung — Samsung TV app installer">
-    <h1>Apps2Samsung</h1>
-    <h2>Install any app on your Samsung TV, projector or smart monitor — Jellyfin, Moonlight and the whole community catalog, from Windows, macOS or Linux</h2>
 
-    <!-- Responsive YouTube Embed -->
-    <div class="video-wrapper">
-      <iframe src="https://www.youtube.com/embed/_8mSV5pW-ic"
-        title="How to Install Jellyfin on Samsung TV"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen>
-      </iframe>
+  <!-- ============ NAV ============ -->
+  <header class="nav">
+    <div class="wrap nav-inner">
+      <a class="brand" href="#top">
+        <svg viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="150" cy="150" r="140" fill="none" stroke="#2DC4EA" stroke-width="10" stroke-dasharray="345 20" transform="rotate(45 150 150)"/>
+          <circle cx="150" cy="30" r="7" fill="#2DC4EA"/><circle cx="270" cy="150" r="7" fill="#2DC4EA"/>
+          <circle cx="150" cy="150" r="90" fill="url(#hOuter)"/>
+          <circle cx="150" cy="150" r="60" fill="url(#hInner)"/>
+          <circle cx="150" cy="150" r="30" fill="#fff"/>
+          <defs>
+            <linearGradient id="hOuter" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00A4DC"/><stop offset="1" stop-color="#AA5CC3"/></linearGradient>
+            <linearGradient id="hInner" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00A4DC"/><stop offset="1" stop-color="#5B2C83"/></linearGradient>
+          </defs>
+        </svg>
+        <b>Apps2Samsung</b>
+      </a>
+      <nav class="nav-links">
+        <a href="#features">Features</a>
+        <a href="#apps">Apps</a>
+        <a href="#how">How it works</a>
+        <a href="#download">Download</a>
+        <a href="#faq">FAQ</a>
+      </nav>
+      <div class="nav-cta">
+        <a class="btn ghost sm" href="https://github.com/Apps2Samsung/Apps2Samsung" target="_blank" rel="noopener">GitHub ★</a>
+        <a class="btn primary sm" href="#download">Download</a>
+      </div>
     </div>
+  </header>
 
-    <div class="meta">
-      <span class="chip solid" data-os="win">🪟 Windows</span>
-      <span class="chip solid" data-os="macos">🍎 macOS</span>
-      <span class="chip solid" data-os="linux">🐧 Linux</span>
-      <br/>
-      <span class="chip">Latest version: <strong id="latestVersion">checking…</strong></span>
-      <span class="chip">Released on <strong id="releaseDate">—</strong></span>
+  <!-- ============ HERO ============ -->
+  <a id="top"></a>
+  <div class="wrap">
+    <section class="hero">
+      <div>
+        <span class="eyebrow">Free &amp; open source · No PC-to-TV cables</span>
+        <h1>Put <span class="accent">any app</span> on your Samsung TV.</h1>
+        <p class="sub">Apps2Samsung side-loads Jellyfin, Moonlight and the whole community Tizen catalog onto Samsung Smart TVs, projectors and monitors — from your <b>computer</b> or straight from your <b>Android phone</b>. It handles the Samsung developer certificate for you, so you just pick an app and click install.</p>
+        <div class="hero-cta">
+          <a class="btn primary" id="heroDownload" href="#download">⬇️ <span id="heroDownloadLabel">Download</span></a>
+          <a class="btn ghost" href="#apps">Browse the app catalog</a>
+        </div>
+        <div class="os-row">
+          <span class="pill" data-os="win">🪟 Windows</span>
+          <span class="pill" data-os="macos">🍎 macOS</span>
+          <span class="pill" data-os="linux">🐧 Linux</span>
+          <span class="pill" data-os="android">🤖 Android</span>
+        </div>
+        <div class="verline">Latest release <b id="latestVersion">checking…</b> · <b id="releaseDate">—</b></div>
+      </div>
+
+      <div class="stage">
+        <div class="tv">
+          <div class="tv-bar"><i></i><i></i><i></i></div>
+          <div class="app-grid">
+            <div class="tile" style="background:linear-gradient(135deg,#00A4DC,#AA5CC3)">🪼<small>Jellyfin</small></div>
+            <div class="tile">🎮<small>Moonlight</small></div>
+            <div class="tile">📺<small>TVApp</small></div>
+            <div class="tile">🌙<small>Moonfin</small></div>
+            <div class="tile">🔥<small>Fireplace</small></div>
+            <div class="tile">🟣<small>Twitch</small></div>
+            <div class="tile">👾<small>Doom</small></div>
+            <div class="tile">🚂<small>OpenTTD</small></div>
+          </div>
+        </div>
+        <div class="tv-stand"></div>
+        <div class="phone" aria-hidden="true">
+          <div class="scr">
+            <div class="ln w"></div><div class="ln"></div><div class="ln w"></div>
+            <div class="go">Install ▸</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <!-- ============ ANDROID BAND ============ -->
+  <div class="wrap">
+    <div class="band">
+      <div class="em">🤖</div>
+      <div>
+        <span class="eyebrow">New</span>
+        <h3>Now you can install from your phone</h3>
+        <p>The brand-new Android app turns your phone into the installer — scan for your TV, sign in to Samsung, pick an app and install, all from the couch. No laptop, no cables. Everything the desktop does, in your pocket.</p>
+      </div>
+      <a class="btn primary" href="#download">Get the Android app</a>
     </div>
+  </div>
 
-    <p>
-      <a id="downloadBtn" class="btn" href="#" target="_blank" rel="noopener">⬇️ <span id="downloadLabel">Download</span></a>
-      <a class="btn" href="https://github.com/Apps2Samsung/Apps2Samsung" target="_blank" rel="noopener">🧰 Source Code</a>
-    </p>
+  <!-- ============ FEATURES ============ -->
+  <div class="wrap">
+    <section id="features">
+      <span class="eyebrow">Why Apps2Samsung</span>
+      <h2 class="section">Everything the fiddly way used to need — automated.</h2>
+      <p class="lead">Side-loading a Tizen app normally means Tizen Studio, certificates, and command-line tools. Apps2Samsung does all of it behind one button.</p>
+      <div class="grid g3" style="margin-top:34px">
+        <div class="card"><span class="ic">🔎</span><h4>Automatic TV discovery</h4><p>Scans your network and lists the Samsung TVs ready to receive an install — or type an IP manually.</p></div>
+        <div class="card"><span class="ic">🔐</span><h4>Sign in to Samsung once</h4><p>Generates the developer certificate for you and reuses it per TV, so you're not asked to log in on every install.</p></div>
+        <div class="card"><span class="ic">🎬</span><h4>Jellyfin, ready to watch</h4><p>Bake in your server URL and auto-login, apply a community theme or custom CSS, and the YouTube-trailer fix — right at install.</p></div>
+        <div class="card"><span class="ic">📋</span><h4>See &amp; manage what's installed</h4><p>List the apps already on a TV at a glance and uninstall any of them in a tap.</p></div>
+        <div class="card"><span class="ic">🎨</span><h4>Custom launcher icons</h4><p>Give any app your own icon, applied to the package as it installs.</p></div>
+        <div class="card"><span class="ic">📺</span><h4>Your own IPTV channels</h4><p>Add name + m3u8 stream pairs and their play order, injected into the TVApp package.</p></div>
+        <div class="card"><span class="ic">🛟</span><h4>Resilient installs</h4><p>Clear, plain-language errors and automatic recovery for the common failures — no cryptic Tizen codes.</p></div>
+        <div class="card"><span class="ic">🧩</span><h4>Native apps too</h4><p>Installs native <code>.tpk</code> apps as well as web <code>.wgt</code> packages, plus your own custom builds.</p></div>
+        <div class="card"><span class="ic">💙</span><h4>Free &amp; open source</h4><p>MIT-licensed, no accounts, no telemetry. Built in the open on GitHub.</p></div>
+      </div>
+    </section>
+  </div>
 
-    <h3>All downloads</h3>
-    <div id="allDownloads" class="dl-grid">
-      <div class="card"><span>Loading builds…</span></div>
+  <!-- ============ APPS ============ -->
+  <div class="wrap">
+    <section id="apps">
+      <span class="eyebrow">The catalog</span>
+      <h2 class="section">Apps you can install</h2>
+      <p class="lead">The app pulls the newest builds live from the community package catalog — here's what's on the menu. Or bring your own <code>.wgt</code>/<code>.tpk</code>.</p>
+      <div class="grid g3" style="margin-top:34px">
+        <div class="card app"><div class="badge">🪼</div><div><h4>Jellyfin <span class="tag">5 builds</span></h4><p>The open-source media system. Multiple Tizen builds (10.10.z, 10.11.z, SmartHub, OSA, GrayFix, OblongIcon…), newest five picked automatically.</p></div></div>
+        <div class="card app"><div class="badge">▶️</div><div><h4>Jellyfin AVPlay</h4><p>AVPlay video-player patches for better Samsung playback — including a SmartHub variant.</p></div></div>
+        <div class="card app"><div class="badge">🕰️</div><div><h4>Jellyfin Legacy</h4><p>The 10.8.z build kept around for older Tizen models.</p></div></div>
+        <div class="card app"><div class="badge">🌙</div><div><h4>Moonfin</h4><p>Jellyfin fork tuned for the viewing experience on Samsung Smart TVs.</p></div></div>
+        <div class="card app"><div class="badge">🪶</div><div><h4>Litefin</h4><p>Lightweight Jellyfin client for a premium feel even on legacy hardware.</p></div></div>
+        <div class="card app"><div class="badge">🎮</div><div><h4>Moonlight</h4><p>Low-latency game streaming (NVIDIA GameStream / Sunshine) on the big screen.</p></div></div>
+        <div class="card app"><div class="badge">📺</div><div><h4>TVApp</h4><p>IPTV player — configure your own m3u8 channels and their order before installing.</p></div></div>
+        <div class="card app"><div class="badge">🟣</div><div><h4>Twitch</h4><p>Watch live streams right on your TV.</p></div></div>
+        <div class="card app"><div class="badge">🔥</div><div><h4>Fireplace</h4><p>A cozy ambient fireplace for the living room.</p></div></div>
+        <div class="card app"><div class="badge">👾</div><div><h4>Doom</h4><p>The classic, running on your television.</p></div></div>
+        <div class="card app"><div class="badge">🚂</div><div><h4>OpenTTD</h4><p>The Transport Tycoon Deluxe remake.</p></div></div>
+        <div class="card app"><div class="badge">➕</div><div><h4>Custom WGT / TPK</h4><p>Bring your own package — perfect for builds you maintain yourself.</p></div></div>
+      </div>
+      <p class="note">…and the rest of the <a href="https://github.com/Apps2Samsung/tizen-community-packages" target="_blank" rel="noopener" style="color:var(--green)">community package catalog</a>, kept up to date automatically.</p>
+    </section>
+  </div>
+
+  <!-- ============ HOW IT WORKS ============ -->
+  <div class="wrap">
+    <section id="how">
+      <span class="eyebrow">Three steps</span>
+      <h2 class="section">From download to watching, in minutes</h2>
+      <div class="steps" style="margin-top:40px">
+        <div class="step"><h4>Pick your TV</h4><p>Open the app on your computer or phone. It scans your network and lists Samsung TVs in developer mode — or enter the IP yourself.</p></div>
+        <div class="step"><h4>Choose an app</h4><p>Select Jellyfin, Moonlight, or anything from the catalog — and the exact version. Configure Jellyfin's server and theme if you like.</p></div>
+        <div class="step"><h4>Sign in once &amp; install</h4><p>Sign in to your Samsung account so the app can create the signing certificate. It's reused next time — then it installs to your TV.</p></div>
+      </div>
+      <div class="video" style="margin-top:44px">
+        <iframe src="https://www.youtube.com/embed/_8mSV5pW-ic" title="How to install Jellyfin on a Samsung TV"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </div>
+    </section>
+  </div>
+
+  <!-- ============ DOWNLOAD ============ -->
+  <div class="wrap">
+    <section id="download">
+      <span class="eyebrow">Get it</span>
+      <h2 class="section">Download Apps2Samsung</h2>
+      <p class="lead">Free, open source, and cross-platform. Grab the build for your system — the recommended one for your device is highlighted.</p>
+      <div class="hero-cta" style="margin:24px 0 30px">
+        <a class="btn primary" id="downloadBtn" href="#" target="_blank" rel="noopener">⬇️ <span id="downloadLabel">Download</span></a>
+        <a class="btn ghost" href="https://github.com/Apps2Samsung/Apps2Samsung/releases" target="_blank" rel="noopener">All releases on GitHub</a>
+      </div>
+      <div id="allDownloads" class="dl-grid">
+        <div class="dl-card"><span style="color:var(--muted)">Loading builds…</span></div>
+      </div>
+      <p class="note" id="archNote"></p>
+      <p class="note">📱 The Android build is a sideloaded <code>.apk</code> — open it on your phone and allow installs from your browser/files app. Desktop builds are unsigned beta artifacts built in CI.</p>
+    </section>
+  </div>
+
+  <!-- ============ FAQ ============ -->
+  <div class="wrap">
+    <section id="faq" style="max-width:820px">
+      <span class="eyebrow">Good to know</span>
+      <h2 class="section">Frequently asked</h2>
+      <div style="margin-top:30px">
+        <details open><summary>Which TVs are supported?</summary><p>Samsung Smart TVs, projectors and smart monitors running <b>Tizen</b> (roughly 2015 and newer). Older <b>Orsay</b> models are no longer supported — the unmaintained <a href="https://github.com/Apps2Samsung/Jellyfin-Orsay-Installer/releases" target="_blank" rel="noopener">legacy Orsay installer</a> remains available as-is.</p></details>
+        <details><summary>Do I need a Samsung account?</summary><p>Yes — Samsung's own developer flow requires signing in once so Apps2Samsung can create the signing certificate your TV needs. That certificate is then reused across installs, so you won't be asked again for the same TV.</p></details>
+        <details><summary>Is this safe? Is it official?</summary><p>Apps2Samsung uses Samsung's own developer/side-load mechanism — the same one Tizen Studio uses — it doesn't jailbreak or modify your TV's firmware. It's fully open source, so you can read exactly what it does. It isn't affiliated with Samsung or Jellyfin.</p></details>
+        <details><summary>Do I need Developer Mode on the TV?</summary><p>Yes. Enable Developer Mode on your Samsung TV (Apps → type 12345 → toggle on, set your computer/phone's IP), then scan for it in Apps2Samsung. This is the standard Tizen side-loading requirement.</p></details>
+        <details><summary>What does it cost?</summary><p>Nothing. It's free and MIT-licensed, with no accounts or telemetry. If it saved you time, a <a href="https://ko-fi.com/patrickstel" target="_blank" rel="noopener">🍺 coffee</a> is always appreciated.</p></details>
+        <details><summary>Can I add my own app?</summary><p>Absolutely — use the <b>Custom WGT/TPK</b> option to install a local package. Community apps live in the open <a href="https://github.com/Apps2Samsung/tizen-community-packages" target="_blank" rel="noopener">tizen-community-packages</a> repo, and contributions are welcome.</p></details>
+      </div>
+    </section>
+  </div>
+
+  <!-- ============ FOOTER ============ -->
+  <footer>
+    <div class="wrap">
+      <div class="foot">
+        <div style="max-width:280px">
+          <a class="brand" href="#top" style="margin-bottom:10px">
+            <svg viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <circle cx="150" cy="150" r="140" fill="none" stroke="#2DC4EA" stroke-width="10" stroke-dasharray="345 20" transform="rotate(45 150 150)"/>
+              <circle cx="150" cy="30" r="7" fill="#2DC4EA"/><circle cx="270" cy="150" r="7" fill="#2DC4EA"/>
+              <circle cx="150" cy="150" r="90" fill="url(#fOuter)"/><circle cx="150" cy="150" r="60" fill="url(#fInner)"/><circle cx="150" cy="150" r="30" fill="#fff"/>
+              <defs><linearGradient id="fOuter" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00A4DC"/><stop offset="1" stop-color="#AA5CC3"/></linearGradient>
+              <linearGradient id="fInner" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#00A4DC"/><stop offset="1" stop-color="#5B2C83"/></linearGradient></defs>
+            </svg><b>Apps2Samsung</b>
+          </a>
+          <p style="font-size:.88rem; color:var(--dim); margin:0">Install any app on your Samsung TV — from your desktop or your phone.</p>
+        </div>
+        <div>
+          <h5>Project</h5>
+          <a href="https://github.com/Apps2Samsung/Apps2Samsung" target="_blank" rel="noopener">Source code</a>
+          <a href="https://github.com/Apps2Samsung/Apps2Samsung/releases" target="_blank" rel="noopener">Releases</a>
+          <a href="https://github.com/Apps2Samsung/tizen-community-packages" target="_blank" rel="noopener">Community packages</a>
+          <a href="https://github.com/Apps2Samsung/Apps2Samsung/issues" target="_blank" rel="noopener">Report an issue</a>
+        </div>
+        <div>
+          <h5>Explore</h5>
+          <a href="#features">Features</a>
+          <a href="#apps">App catalog</a>
+          <a href="#how">How it works</a>
+          <a href="#download">Download</a>
+        </div>
+        <div>
+          <h5>Support</h5>
+          <a href="https://ko-fi.com/patrickstel" target="_blank" rel="noopener">🍺 Buy me a coffee</a>
+          <a href="#faq">FAQ</a>
+        </div>
+      </div>
+      <div class="copy">© <span id="year"></span> Patrick Stel · MIT-licensed · Not affiliated with Samsung or Jellyfin · Hosted on GitHub Pages</div>
     </div>
-    <p class="note" id="archNote"></p>
-
-    <h3>Apps you can install</h3>
-    <div class="grid">
-      <div class="card"><strong>Jellyfin</strong><span>Multiple Tizen builds (10.10.z, 10.11.z, SmartHub, OSA, GrayFix, OblongIcon and more) — picks the latest 5 releases automatically.</span></div>
-      <div class="card"><strong>Jellyfin AVPlay</strong><span>AVPlay video player patches for better Samsung TV compatibility, including a SmartHub variant.</span></div>
-      <div class="card"><strong>Jellyfin Legacy</strong><span>10.8.z build kept around for older Tizen models.</span></div>
-      <div class="card"><strong>Moonfin</strong><span>Jellyfin fork optimised for the viewing experience on Samsung Smart TVs.</span></div>
-      <div class="card"><strong>Litefin</strong><span>Lightweight Jellyfin client designed to run on legacy hardware.</span></div>
-      <div class="card"><strong>Moonlight</strong><span>Low-latency game streaming client (NVIDIA GameStream / Sunshine).</span></div>
-      <div class="card"><strong>Fireplace</strong><span>Cozy ambient fireplace for your TV.</span></div>
-      <div class="card"><strong>TVApp</strong><span>IPTV player — configure your own m3u8 channels (and their order) before install.</span></div>
-      <div class="card"><strong>Twitch</strong><span>Twitch live-streaming client.</span></div>
-      <div class="card"><strong>Club Info Board</strong><span>Digital info-board / signage app.</span></div>
-      <div class="card"><strong>Doom</strong><span>The classic Doom, running on your TV.</span></div>
-      <div class="card"><strong>Transport Tycoon Deluxe</strong><span>OpenTTD — the Transport Tycoon Deluxe remake.</span></div>
-      <div class="card"><strong>Nuvio</strong><span>Nuvio media streaming app.</span></div>
-      <div class="card"><strong>Custom WGT</strong><span>Bring your own .wgt — useful for builds you maintain yourself.</span></div>
-    </div>
-
-    <h3>What it does for you</h3>
-    <div class="grid">
-      <div class="card"><strong>🔎 Auto TV discovery</strong><span>Scans your network and lists Samsung TVs ready to receive an install.</span></div>
-      <div class="card"><strong>🔐 Tizen certificate handling</strong><span>Generates and manages the developer certificate, including the Samsung account login flow.</span></div>
-      <div class="card"><strong>🧩 Plugin patching</strong><span>Optional fixes such as the YouTube plugin patch baked right into the install step.</span></div>
-      <div class="card"><strong>🎨 Jellyfin themes</strong><span>One-click apply for popular community themes (Obsidian, Solaris, Nebula, Ember, Void).</span></div>
-      <div class="card"><strong>👥 Multi-user config</strong><span>Push Jellyfin preferences for one or many users in a single shot.</span></div>
-      <div class="card"><strong>🌍 Localised UI</strong><span>Multiple languages with full RTL support.</span></div>
-    </div>
-
-    <p class="note" style="margin:2em 0 0">
-      Orsay-based TVs (pre-2015 models) are no longer supported. The unmaintained
-      <a href="https://github.com/Apps2Samsung/Jellyfin-Orsay-Installer/releases"
-         target="_blank" rel="noopener" style="color:#4ADE80">legacy Orsay installer</a>
-      remains available as-is.
-    </p>
-
-    <p style="color:#8296AC;font-size:.9em">
-      © <span id="year"></span> Patrick Stel — Hosted on GitHub Pages
-    </p>
-  </main>
+  </footer>
 
   <script>
   (async function(){
     const owner='Apps2Samsung', repo='Apps2Samsung';
     const els={
-      ver:   document.getElementById('latestVersion'),
-      date:  document.getElementById('releaseDate'),
-      dl:    document.getElementById('downloadBtn'),
-      label: document.getElementById('downloadLabel'),
-      all:   document.getElementById('allDownloads'),
-      note:  document.getElementById('archNote')
+      ver:document.getElementById('latestVersion'), date:document.getElementById('releaseDate'),
+      dl:document.getElementById('downloadBtn'), label:document.getElementById('downloadLabel'),
+      heroDl:document.getElementById('heroDownload'), heroLabel:document.getElementById('heroDownloadLabel'),
+      all:document.getElementById('allDownloads'), note:document.getElementById('archNote')
     };
+    const OS_LABEL={ win:'🪟 Windows', macos:'🍎 macOS', linux:'🐧 Linux', android:'🤖 Android' };
+    const ARCH_LABEL={ x64:'x64 / Intel', arm64:'ARM64', apk:'.apk' };
+    const PREF={ win:['msi','zip'], macos:['dmg','tar.gz'], linux:['deb','tar.gz'], android:['apk'] };
+    const OS_ORDER=['win','macos','linux','android'];
+    const ARCH_ORDER=['x64','arm64','apk'];
 
-    const OS_LABEL   = { win:'🪟 Windows', macos:'🍎 macOS', linux:'🐧 Linux' };
-    const ARCH_LABEL = { x64:'x64 / Intel', arm64:'ARM64' };
-    // Preferred format per OS, most-recommended first (used for sorting + default pick).
-    const PREF       = { win:['msi','zip'], macos:['dmg','tar.gz'], linux:['deb','tar.gz'] };
-    const OS_ORDER   = ['win','macos','linux'];
-    const ARCH_ORDER = ['x64','arm64'];
-
-    // ---- platform detection -------------------------------------------------
     function detectOS(){
-      const p=(navigator.userAgentData?.platform||navigator.platform||navigator.userAgent||'').toLowerCase();
+      const ua=(navigator.userAgent||'').toLowerCase();
+      const p=(navigator.userAgentData?.platform||navigator.platform||ua).toLowerCase();
+      if(ua.includes('android')) return 'android';
       if(p.includes('win')) return 'win';
       if(p.includes('mac')) return 'macos';
-      if(p.includes('linux')||p.includes('android')) return 'linux';
+      if(p.includes('linux')) return 'linux';
       return null;
     }
-
     async function detectArch(os){
-      // Chromium exposes the real CPU arch via UA Client Hints (async, https only).
+      if(os==='android') return {arch:'apk', sure:true};
       try{
         if(navigator.userAgentData?.getHighEntropyValues){
           const h=await navigator.userAgentData.getHighEntropyValues(['architecture']);
           if(h.architecture==='arm') return {arch:'arm64', sure:true};
-          if(h.architecture==='x86') return {arch:'x64',   sure:true};
+          if(h.architecture==='x86') return {arch:'x64', sure:true};
         }
-      }catch(e){/* ignore */}
+      }catch(e){}
       const ua=(navigator.userAgent||'').toLowerCase();
       if(ua.includes('arm64')||ua.includes('aarch64')) return {arch:'arm64', sure:true};
-      // Safari / Firefox give us nothing reliable. Apple Silicon is the majority of
-      // active Macs, so default macOS to arm64 but flag it as a guess.
       if(os==='macos') return {arch:'arm64', sure:false};
       return {arch:'x64', sure:false};
     }
-
     function parseAsset(name){
+      if(/\.apk$/i.test(name)) return { os:'android', arch:'apk', ext:'apk' };
       const m=name.match(/-(linux|macos|win)-(x64|arm64)\.(.+)$/i);
       return m ? { os:m[1].toLowerCase(), arch:m[2].toLowerCase(), ext:m[3].toLowerCase() } : null;
     }
-
     const fmtDate=s=>new Date(s).toLocaleDateString(undefined,{year:'numeric',month:'short',day:'2-digit'});
-    const fmtSize=b=>b ? (b/1048576).toFixed(1)+' MB' : '';
+    const fmtSize=b=>b?(b/1048576).toFixed(1)+' MB':'';
+    async function tryFetch(u){ const r=await fetch(u,{headers:{'Accept':'application/vnd.github+json'},cache:'no-store'}); if(!r.ok) throw new Error(r.status); return r.json(); }
+    const releasesUrl=()=>`https://github.com/${owner}/${repo}/releases`;
 
-    async function tryFetch(u){
-      const r=await fetch(u,{headers:{'Accept':'application/vnd.github+json'},cache:'no-store'});
-      if(!r.ok) throw new Error(r.status);
-      return r.json();
-    }
-
-    function releasesUrl(){ return `https://github.com/${owner}/${repo}/releases/latest`; }
+    function setPrimary(href,label){ els.dl.href=href; els.label.textContent=label; els.heroDl.href=href; els.heroLabel.textContent=label; }
 
     try{
-      const d=await tryFetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`);
+      // Prefer the latest stable; fall back to the newest (pre)release if there's no stable yet.
+      let d;
+      try{ d=await tryFetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`); }
+      catch(e){ const list=await tryFetch(`https://api.github.com/repos/${owner}/${repo}/releases?per_page=1`); d=list[0]; }
+
       const tag=d.tag_name||d.name, date=d.published_at||d.created_at;
       els.ver.textContent=tag||'unknown';
       els.date.textContent=date?fmtDate(date):'n/a';
 
-      // Group assets: os -> arch -> [ {ext,url,size} ]
       const groups={};
       for(const a of (d.assets||[])){
-        const p=parseAsset(a.name);
-        if(!p) continue;
-        (groups[p.os] = groups[p.os] || {});
-        (groups[p.os][p.arch] = groups[p.os][p.arch] || []);
+        const p=parseAsset(a.name); if(!p) continue;
+        (groups[p.os]=groups[p.os]||{}); (groups[p.os][p.arch]=groups[p.os][p.arch]||[]);
         groups[p.os][p.arch].push({ ext:p.ext, url:a.browser_download_url, size:a.size });
       }
-      // Sort each arch's files by preferred format.
-      for(const os in groups){
-        const pref=PREF[os]||[];
-        for(const arch in groups[os]){
-          groups[os][arch].sort((x,y)=>{
-            const ix=pref.indexOf(x.ext), iy=pref.indexOf(y.ext);
-            return (ix<0?99:ix)-(iy<0?99:iy);
-          });
-        }
-      }
+      for(const os in groups){ const pref=PREF[os]||[]; for(const arch in groups[os]){
+        groups[os][arch].sort((x,y)=>{ const ix=pref.indexOf(x.ext), iy=pref.indexOf(y.ext); return (ix<0?99:ix)-(iy<0?99:iy); });
+      }}
 
-      // ---- pick the best default download for this visitor -----------------
-      const os=detectOS();
-      const { arch, sure }=await detectArch(os);
+      const os=detectOS(); const { arch, sure }=await detectArch(os);
       let best=null, bestArch=arch;
-      if(os && groups[os]){
-        let list=groups[os][arch];
-        if(!list){ bestArch=Object.keys(groups[os])[0]; list=groups[os][bestArch]; }
-        if(list && list.length) best=list[0];
-      }
+      if(os && groups[os]){ let list=groups[os][arch]; if(!list){ bestArch=Object.keys(groups[os])[0]; list=groups[os][bestArch]; } if(list&&list.length) best=list[0]; }
+      if(best){ setPrimary(best.url, `Download for ${OS_LABEL[os]}${bestArch&&bestArch!=='apk'?' · '+(ARCH_LABEL[bestArch]||bestArch):''}`); }
+      else{ setPrimary(releasesUrl(), 'View all downloads'); }
 
-      if(best){
-        els.dl.href=best.url;
-        els.label.textContent=`Download for ${OS_LABEL[os]} · ${ARCH_LABEL[bestArch]||bestArch}`;
-      }else{
-        els.dl.href=releasesUrl();
-        els.label.textContent='View all downloads';
-      }
+      if(os){ const chip=document.querySelector(`.pill[data-os="${os}"]`); if(chip) chip.classList.add('on'); }
 
-      // Highlight the detected OS chip up top.
-      if(os){
-        const chip=document.querySelector(`.chip[data-os="${os}"]`);
-        if(chip) chip.classList.add('detected');
-      }
-
-      // ---- render the full grouped list ------------------------------------
       let html='';
-      for(const o of OS_ORDER){
-        if(!groups[o]) continue;
-        const isDetected = (o===os);
-        html+=`<div class="card${isDetected?' detected':''}"><strong>${OS_LABEL[o]}${isDetected?' — your system':''}</strong>`;
-        for(const ar of ARCH_ORDER){
-          const list=groups[o][ar];
-          if(!list || !list.length) continue;
-          const links=list.map(it=>{
-            const sz=fmtSize(it.size);
-            return `<a href="${it.url}">.${it.ext}</a>${sz?` <span class="sz">${sz}</span>`:''}`;
-          }).join(' · ');
-          html+=`<div class="dlrow"><span class="arch">${ARCH_LABEL[ar]||ar}</span> ${links}</div>`;
+      for(const o of OS_ORDER){ if(!groups[o]) continue; const isDet=(o===os);
+        html+=`<div class="dl-card${isDet?' detected':''}"><strong>${OS_LABEL[o]}${isDet?' — your system':''}</strong>`;
+        for(const ar of ARCH_ORDER){ const list=groups[o][ar]; if(!list||!list.length) continue;
+          const links=list.map(it=>{ const sz=fmtSize(it.size); return `<a href="${it.url}">.${it.ext}</a>${sz?` <span class="sz">${sz}</span>`:''}`; }).join(' · ');
+          const arLabel = ar==='apk' ? 'Sideload' : (ARCH_LABEL[ar]||ar);
+          html+=`<div class="dlrow"><span class="arch">${arLabel}</span> ${links}</div>`;
         }
         html+='</div>';
       }
-      els.all.innerHTML = html || `<div class="card"><span>No platform builds found — <a href="${releasesUrl()}" style="color:#4ADE80">see the release page</a>.</span></div>`;
-
-      // Note when the architecture is only a best guess (Safari/Firefox on Mac).
-      if(os==='macos' && !sure){
-        els.note.textContent='macOS chip type can\u2019t be detected in this browser — defaulted to Apple Silicon (ARM64). On an Intel Mac, pick the x64 build above.';
-      }
+      els.all.innerHTML = html || `<div class="dl-card"><span>No platform builds found — <a href="${releasesUrl()}" style="color:var(--green)">see the releases page</a>.</span></div>`;
+      if(os==='macos' && !sure){ els.note.textContent='macOS chip type can’t be detected in this browser — defaulted to Apple Silicon (ARM64). On an Intel Mac, pick the x64 build above.'; }
     }catch(e){
-      els.ver.textContent='unavailable';
-      els.date.textContent='n/a';
-      els.dl.href=releasesUrl();
-      els.label.textContent='View downloads on GitHub';
-      els.all.innerHTML=`<div class="card"><span>Couldn\u2019t load builds right now — <a href="${releasesUrl()}" style="color:#4ADE80">open the latest release</a>.</span></div>`;
+      els.ver.textContent='unavailable'; els.date.textContent='n/a';
+      setPrimary(releasesUrl(), 'View downloads on GitHub');
+      els.all.innerHTML=`<div class="dl-card"><span>Couldn’t load builds right now — <a href="${releasesUrl()}" style="color:var(--green)">open the releases page</a>.</span></div>`;
     }
-
     document.getElementById('year').textContent=new Date().getFullYear();
   })();
   </script>


### PR DESCRIPTION
Rebuilds the GitHub-Pages site (`/docs`) into a proper, professional landing page — still a single self-contained `index.html` (no build step, works as-is on Pages).

**Sections:** sticky nav · hero (with a CSS TV + phone visual and the live latest-version) · **'Now on your phone'** band for the Android app · features grid · **community app catalog** gallery · 3-step how-it-works + the YouTube walkthrough · downloads · FAQ · footer.

**Highlights vs the old single-card page:**
- Reflects the **Android app** everywhere (was Windows/macOS/Linux only).
- Shows the real feature set: sign-in-once cert reuse, Jellyfin server/theme config, show & uninstall installed apps, custom icons, IPTV channels, resilient installs, native `.tpk`.
- **Live downloads** logic preserved and extended to include the **Android `.apk`** + Android detection; the visitor's platform is auto-highlighted.
- Brand palette pulled from the logo (Tizen cyan + Jellyfin gradient).

CNAME + favicon untouched. Deploys to apps2samsung.madebypatrick.nl (and the apps2samsung.com redirect) from `beta/docs` on merge.

Tag-balanced HTML, inline JS syntax-checked. Best previewed on Pages after merge (or I can publish a design-preview).