### PR TITLE
docs: make apps2samsung.com the primary domain

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-apps2samsung.madebypatrick.nl
+apps2samsung.com

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,13 +7,13 @@
   <title>Apps2Samsung — Install any app on your Samsung TV, from your desktop or phone</title>
   <meta name="description" content="Free, open-source installer that side-loads any app onto Samsung Smart TVs, projectors and smart monitors — Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog. Runs on Windows, macOS, Linux and now Android." />
   <meta name="keywords" content="Samsung TV app installer, install apps Samsung TV, Samsung TV sideload, Jellyfin Samsung TV, Jellyfin Tizen, install Jellyfin, Moonlight Samsung TV, Moonfin, Litefin, AVPlay, Tizen community apps, install apps from phone, Apps2Samsung, Jellyfin2Samsung, Patrick Stel" />
-  <link rel="canonical" href="https://apps2samsung.madebypatrick.nl/" />
+  <link rel="canonical" href="https://apps2samsung.com/" />
 
   <!-- Open Graph -->
   <meta property="og:title" content="Apps2Samsung — Install any app on your Samsung TV" />
   <meta property="og:description" content="Side-load Jellyfin, Moonlight, Moonfin, Litefin and the whole community Tizen catalog onto your Samsung TV. Runs on Windows, macOS, Linux — and now from your Android phone." />
   <meta property="og:image" content="https://github.com/Apps2Samsung/Apps2Samsung/raw/master/.github/jellyfin-tizen-logo.png" />
-  <meta property="og:url" content="https://apps2samsung.madebypatrick.nl/" />
+  <meta property="og:url" content="https://apps2samsung.com/" />
   <meta property="og:type" content="website" />
 
   <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
Switches the GitHub Pages custom domain from the `madebypatrick.nl` subdomain to the apex **apps2samsung.com**.

- `docs/CNAME` → `apps2samsung.com`
- canonical + `og:url` → `https://apps2samsung.com/`

**DNS is already done** (Cloudflare, via API): apex `A` → GitHub Pages `185.199.108–111.153` (DNS-only so GitHub can issue the cert), `www` → `apps2samsung.github.io`; **email MX/SPF preserved**, apex is already resolving to Pages.

**On merge:** Pages serves `apps2samsung.com`; the old subdomain stops serving Pages. After it deploys, wait for the cert then tick **Enforce HTTPS** in Settings → Pages.