### PR TITLE
ci: skip beta release build for docs/ and .github/ changes

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -5,6 +5,8 @@ on:
     branches: [beta]
     paths-ignore:
       - 'README.md'
+      - 'docs/**'      # website (GitHub Pages) — deploys on its own, shouldn't trigger an app release
+      - '.github/**'   # workflow / repo-meta changes shouldn't trigger an app release
   # Allow running the beta release manually (e.g. when a merge didn't fire the push trigger).
   workflow_dispatch:
 


### PR DESCRIPTION
Adds `docs/**` and `.github/**` to the Beta Pre-Release `paths-ignore`.

Website edits (Pages deploys `docs/` independently) and workflow/repo-meta changes no longer trigger a full app build — which also stops them from **regenerating the release notes** each time. Pushes that touch app code still build as normal.