### PR TITLE
Fix misleading [118, -4] message + robust device enrichment (#481)

### DIFF
--- a/Apps2Samsung.Core/Sdb/TizenInstallDiagnostics.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstallDiagnostics.cs
@@ -28,8 +28,10 @@ namespace Apps2Samsung.Sdb
             Has(output, Constants.TizenErrorCodes.InstallFailed118012) ||
             Has(output, Constants.TizenErrorCodes.InstallFailed118Minus12);
 
-        /// <summary>The package targets a newer Tizen API level than the TV supports ([118, -4]) —
-        /// re-signing/overwriting can't help.</summary>
+        /// <summary>The TV refused the package with [118, -4] ("operation not allowed" / "load archive
+        /// info fail"). Ambiguous: usually the package targets a newer Tizen than the TV, OR it needs
+        /// Partner signing / a privilege the certificate doesn't grant — so don't present it as a flat
+        /// "TV too old" (misleading when other apps install fine). Retrying/overwriting won't help.</summary>
         public static bool IsApiVersionMismatch(string? output) =>
             Has(output, Constants.TizenErrorCodes.InstallFailed118Minus4);
 

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -137,11 +137,12 @@ public sealed class WgtInstaller
 			throw new InvalidOperationException(
 				"Connection to the TV was interrupted. Check Wi-Fi (and that the TV is awake), then try again.");
 
-		// API-version mismatch: the app targets a newer Tizen than this TV supports — a different build
-		// is needed, not a retry.
+		// [118, -4] "operation not allowed": the TV refused the package. Ambiguous — could be the app
+		// targeting a newer Tizen than this TV, OR the package needing Partner signing / a privilege the
+		// certificate doesn't grant. Don't assert "TV too old" (it misleads when other apps install fine).
 		if (TizenInstallDiagnostics.IsApiVersionMismatch(output))
 			throw new InvalidOperationException(
-				"This TV's Tizen version is too old for this app (API-version mismatch [118, -4]). Try an older build if one is available.");
+				"The TV refused this package ([118, -4]). Either the app needs a newer Tizen than this TV, or it needs Partner signing / a privilege your certificate doesn't allow. If other apps install fine, turn on Partner signing in Settings and retry, or try an older build.");
 
 		bool certMismatch = TizenInstallDiagnostics.IsCertificateMismatch(output);
 		bool outOfSpace = TizenInstallDiagnostics.IsInsufficientSpace(output);

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -114,7 +114,7 @@
   "lblKeepWGTFile": "Preserve WGT file",
   "AuthorMismatch": "Author Certificate mismatch, please re-sign the package with correct certificate.",
   "certificateMismatch": "{0} is already installed with a different signing certificate, so your TV won't replace it in place — and this TV doesn't allow removing apps remotely over the network connection. Please delete {0} on the TV manually (open the Apps list, press and hold {0}, choose Remove), then install it again.",
-  "apiVersionMismatch": "Your TV can't run this app: it was built for a newer Tizen version than your TV has (an API-version mismatch — install error [118, -4]). This is not a certificate or sign-in problem, so re-signing won't help. You need a build of this app made for your TV's Tizen version; check for an older or compatible release, or this app may not support your TV model.",
+  "apiVersionMismatch": "Your TV refused this package (install error [118, -4], \"operation not allowed\"). This usually means one of two things: the app was built for a newer Tizen version than your TV, or the package needs Partner signing / a privilege your certificate doesn't grant. If other apps (for example Jellyfin) install on this TV just fine, it's this package — try turning on Partner signing in Settings and installing again, or use an older/compatible build of the app.",
   "FixYouTube153": "Fix YouTube Plugin (Error 153)",
   "lblBasePath": "Base Path",
   "lblJellyfinUsername": "Username",

--- a/Jellyfin2Samsung-CrossOS/Helpers/Tizen/Devices/DeviceHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Tizen/Devices/DeviceHelper.cs
@@ -33,34 +33,36 @@ namespace Apps2Samsung.Helpers.Tizen.Devices
                 // Check for cancellation before processing each device
                 cancellationToken.ThrowIfCancellationRequested();
 
+                // Enrich any TV that answers on the REST API (8001) with its friendly model/name —
+                // for ready (debug-open) TVs as well as not-ready ones. But never drop a TV we found:
+                // if REST is unavailable or returns no name, keep the base entry and fall back to the
+                // SDB-resolved name / IP so an installable TV always stays in the list.
                 if (await _networkService.IsPortOpenAsync(device.IpAddress, 8001, cancellationToken))
                 {
                     try
                     {
                         var samsungDevice = await _tizenApiClient.GetDeveloperInfoAsync(device);
-                        // GetDeveloperInfoAsync returns a fresh object, so carry over whether the
-                        // debug port was reachable (i.e. whether the TV is actually installable).
+                        // GetDeveloperInfoAsync returns a fresh object, so carry over the debug-port
+                        // state (installable?) and the SDB name when REST didn't supply its own.
                         samsungDevice.DebugPortOpen = device.DebugPortOpen;
-                        if (!string.IsNullOrEmpty(samsungDevice.DeviceName))
-                            devices.Add(samsungDevice);
+                        if (string.IsNullOrEmpty(samsungDevice.DeviceName))
+                            samsungDevice.DeviceName = device.DeviceName;
+                        if (string.IsNullOrEmpty(samsungDevice.Manufacturer))
+                            samsungDevice.Manufacturer = device.Manufacturer;
+                        devices.Add(samsungDevice);
                     }
                     catch
                     {
-                        Trace.WriteLine($"Failed to get developer info for device at {device.IpAddress}.");
+                        Trace.WriteLine($"Failed to get developer info for device at {device.IpAddress}; keeping base entry.");
+                        devices.Add(device);
                     }
                 }
                 else
                 {
-                    try
-                    {
-                        device.ModelName = device.ModelName;
-                        device.Manufacturer = device.Manufacturer;
-                        device.DeveloperMode = "1";
-                        device.DeveloperIP = string.Empty;
-
-                        devices.Add(device);
-                    }
-                    catch { }
+                    // No REST API — a debug-open TV reachable only over SDB. Keep it as-is (its SDB
+                    // name/IP is what identifies it); Developer Mode is on since the debug port answered.
+                    device.DeveloperMode = "1";
+                    devices.Add(device);
                 }
             }
 


### PR DESCRIPTION
Follow-ups from the #481 investigation (Harbor failed with `[118, -4]` on a **Tizen-9** TV where Jellyfin installs fine, but the tool told the user *"your TV is too old"*).

**1. Reworded the `[118, -4]` message** (`en.json` source + mobile `WgtInstaller` string + Core doc-comment). It no longer asserts the TV is too old or that it "isn't a certificate problem." `[118, -4]` ("operation not allowed" / "load archive info fail") is ambiguous — could be a newer-Tizen requirement **or** the package needing **Partner signing** / a privilege the cert doesn't grant. New copy says as much and adds the useful tell: *"if other apps (e.g. Jellyfin) install fine, it's this package — try Partner signing."* (Other 27 language files are pipeline-translated from the `en.json` source.)

**2. `DeviceHelper.ScanForDevicesAsync` robustness:**
- Enriches **every** TV that answers on the REST API (8001) with its friendly model/name — ready TVs too, not only not-ready ones.
- **Never drops a found TV**: on REST failure or an empty REST name, keeps the base entry and **falls back to the SDB name / IP** (previously an installable TV could be omitted entirely, and its SDB name discarded).

Note (from the dig): there was **no** name/IP cross-wiring bug — the scan is per-IP correct; the user simply had two TVs (installable 85″ over SDB, not-ready 75″ over REST). Desktop + mobile build **0 errors**.