### PR TITLE
TV storage cleanup: app sizes, remove-leftover, auto-clean partials

### DIFF
--- a/Apps2Samsung.Core/Models/InstalledApp.cs
+++ b/Apps2Samsung.Core/Models/InstalledApp.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Apps2Samsung.Models
 {
     /// <summary>
@@ -9,9 +11,30 @@ namespace Apps2Samsung.Models
         string TizenId,
         string Version,
         string InstallDate,
-        bool IsRemovable)
+        bool IsRemovable,
+        long SizeBytes = 0)
     {
         /// <summary>Title if the TV reported one, otherwise the Tizen id — never empty.</summary>
         public string DisplayName => string.IsNullOrWhiteSpace(Title) ? TizenId : Title;
+
+        /// <summary>Human-readable install size for this app ("—" when unknown/0).</summary>
+        public string SizeDisplay => FormatSize(SizeBytes);
+
+        /// <summary>
+        /// Formats a byte count as a human-readable size ("—" when 0 or negative, else one decimal
+        /// KB/MB/GB, e.g. "12.6 MB"). Invariant so the decimal separator is always a dot. Shared for
+        /// per-app sizes and for the per-TV total used space.
+        /// </summary>
+        public static string FormatSize(long bytes)
+        {
+            if (bytes <= 0)
+                return "—";
+
+            const double kb = 1024, mb = kb * 1024, gb = mb * 1024;
+            var c = CultureInfo.InvariantCulture;
+            if (bytes < mb) return string.Format(c, "{0:0.0} KB", bytes / kb);
+            if (bytes < gb) return string.Format(c, "{0:0.0} MB", bytes / mb);
+            return string.Format(c, "{0:0.0} GB", bytes / gb);
+        }
     }
 }

--- a/Apps2Samsung.Core/Sdb/TizenInstalledApps.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstalledApps.cs
@@ -25,8 +25,9 @@ namespace Apps2Samsung.Sdb
         private static bool IsSeparator(string line) =>
             !line.Contains('=') && line.Contains("----") && line.Replace("-", "").Trim().Length == 0;
 
-        /// <summary>Parse the applist output. Returns the apps sorted by display name (case-insensitive);
-        /// empty when the output is blank or an error/"no listing" response.</summary>
+        /// <summary>Parse the applist output. Returns the apps sorted by install size (largest first,
+        /// so the biggest space users are on top), then display name (case-insensitive); empty when the
+        /// output is blank or an error/"no listing" response.</summary>
         public static IReadOnlyList<InstalledApp> Parse(string? output)
         {
             var apps = new List<InstalledApp>();
@@ -39,12 +40,14 @@ namespace Apps2Samsung.Sdb
             {
                 if (current.TryGetValue("app_tizen_id", out var id) && !string.IsNullOrWhiteSpace(id))
                 {
+                    long.TryParse(current.GetValueOrDefault("app_size", string.Empty).Trim(), out var size);
                     apps.Add(new InstalledApp(
                         Title: current.GetValueOrDefault("app_title", string.Empty),
                         TizenId: id.Trim(),
                         Version: current.GetValueOrDefault("app_version", string.Empty),
                         InstallDate: current.GetValueOrDefault("install_date", string.Empty),
-                        IsRemovable: current.GetValueOrDefault("is_removable", string.Empty) == "1"));
+                        IsRemovable: current.GetValueOrDefault("is_removable", string.Empty) == "1",
+                        SizeBytes: size));
                 }
                 current.Clear();
             }
@@ -66,7 +69,8 @@ namespace Apps2Samsung.Sdb
             return apps
                 .GroupBy(a => a.TizenId, StringComparer.OrdinalIgnoreCase)
                 .Select(g => g.First())
-                .OrderBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(a => a.SizeBytes)
+                .ThenBy(a => a.DisplayName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
         }
     }

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
@@ -10,13 +10,16 @@
 
         <!-- Header banner with a back affordance -->
         <Border Grid.Row="0" BackgroundColor="#2C3E50" Padding="12,18" StrokeThickness="0" StrokeShape="RoundRectangle 8">
-            <Grid ColumnDefinitions="44,*,44" VerticalOptions="Center">
+            <Grid ColumnDefinitions="44,*,Auto,44" ColumnSpacing="4" VerticalOptions="Center">
                 <Button Grid.Column="0" Text="‹" FontSize="26" TextColor="White"
                         BackgroundColor="Transparent" BorderWidth="0" Padding="0"
                         WidthRequest="44" HeightRequest="44" Clicked="OnBackClicked" />
                 <Label Grid.Column="1" Text="Installed apps" TextColor="White" FontAttributes="Bold"
                        VerticalOptions="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
-                <Button Grid.Column="2" x:Name="RefreshBtn" Text="⟳" FontSize="18" TextColor="White"
+                <Button Grid.Column="2" x:Name="RemoveLeftoverBtn" Text="Remove leftover…" FontSize="12"
+                        TextColor="White" BackgroundColor="Transparent" BorderWidth="0" Padding="6,0"
+                        VerticalOptions="Center" Clicked="OnRemoveLeftoverClicked" />
+                <Button Grid.Column="3" x:Name="RefreshBtn" Text="⟳" FontSize="18" TextColor="White"
                         BackgroundColor="Transparent" BorderWidth="0" Padding="0"
                         WidthRequest="44" HeightRequest="44" Clicked="OnRefreshClicked" />
             </Grid>
@@ -42,7 +45,10 @@
                                        LineBreakMode="TailTruncation" />
                                 <Label Text="{Binding TizenId}" FontSize="11" Opacity="0.55"
                                        LineBreakMode="TailTruncation" />
-                                <Label Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55" />
+                                <HorizontalStackLayout Spacing="10">
+                                    <Label Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55" />
+                                    <Label Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.55" />
+                                </HorizontalStackLayout>
                             </VerticalStackLayout>
                             <Button Grid.Column="1" Text="Uninstall" Clicked="OnUninstallClicked"
                                     IsVisible="{Binding IsRemovable}" VerticalOptions="Center"

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
@@ -36,6 +36,50 @@ public partial class InstalledAppsPage : ContentPage
 
 	private async void OnRefreshClicked(object? sender, EventArgs e) => await LoadAsync();
 
+	// A partial/failed install can leave a package dir that vd_applist never shows, so it can't be
+	// removed from the list above. vd_appuninstall <packageId> still reclaims it, so offer a manual
+	// escape hatch: type the package id and force-remove it.
+	private async void OnRemoveLeftoverClicked(object? sender, EventArgs e)
+	{
+		var id = await DisplayPromptAsync(
+			"Remove leftover",
+			"Enter the package id of a leftover/partial install to remove:",
+			"Remove", "Cancel", placeholder: "e.g. HarborTV");
+		if (string.IsNullOrWhiteSpace(id))
+			return;
+		id = id.Trim();
+
+		var confirm = await DisplayAlert(
+			"Remove leftover",
+			$"Force-remove package \"{id}\" from {_tvLabel}?", "Remove", "Cancel");
+		if (!confirm)
+			return;
+
+		SetBusy(true, $"Removing {id}…");
+		try
+		{
+			var result = await _sdb.UninstallAsync(_tvIp, id);
+			// Exit 0, or "failed[132]" (not installed / already gone) — both mean the leftover is cleared.
+			var ok = result.ExitCode == 0 ||
+					 (result.Output?.Contains("failed[132]", StringComparison.OrdinalIgnoreCase) ?? false);
+			if (!ok)
+			{
+				SetBusy(false);
+				await DisplayAlert("Remove failed",
+					string.IsNullOrWhiteSpace(result.Error) ? result.Output?.Trim() : result.Error, "OK");
+				return;
+			}
+		}
+		catch (Exception ex)
+		{
+			SetBusy(false);
+			await DisplayAlert("Remove failed", ex.Message, "OK");
+			return;
+		}
+
+		await LoadAsync();
+	}
+
 	private async Task LoadAsync()
 	{
 		SetBusy(true, "Reading installed apps…");
@@ -53,7 +97,8 @@ public partial class InstalledAppsPage : ContentPage
 			else
 			{
 				var removable = apps.Count(a => a.IsRemovable);
-				CountLabel.Text = $"{apps.Count} apps on {_tvLabel} · {removable} removable";
+				var totalUsed = InstalledApp.FormatSize(apps.Sum(a => a.SizeBytes));
+				CountLabel.Text = $"{apps.Count} apps · {totalUsed} used on {_tvLabel} · {removable} removable";
 			}
 		}
 		catch (Exception ex)

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -65,6 +65,19 @@ public sealed class WgtInstaller
 		// version before install and/or launch the app afterwards.
 		var (appId, packageId) = ReadPackageIds(wgtPath);
 
+		// Was this package already on the TV before we started? Needed so the failure-cleanup below
+		// only clears a partial from a FRESH install and never removes a pre-existing working app.
+		bool wasInstalledBefore = false;
+		if (!string.IsNullOrWhiteSpace(packageId))
+		{
+			try
+			{
+				var listed = await _sdb.AppsAsync(tvIp);
+				wasInstalledBefore = listed?.Output?.Contains(packageId!, StringComparison.OrdinalIgnoreCase) ?? false;
+			}
+			catch { /* best-effort; if we can't tell, treat as fresh (cleanup guard still needs packageId) */ }
+		}
+
 		if (MobileSettings.DeletePreviousInstall && !string.IsNullOrWhiteSpace(packageId))
 		{
 			progress?.Invoke("Removing old version…");
@@ -109,7 +122,7 @@ public sealed class WgtInstaller
 		progress?.Invoke("Installing on TV…");
 		var install = await _sdb.InstallAsync(tvIp, wgtPath, sdkToolPath);
 		if (install.ExitCode != 0)
-			install = await RecoverInstallAsync(tvIp, wgtPath, sdkToolPath, packageId, install, progress);
+			install = await RecoverInstallAsync(tvIp, wgtPath, sdkToolPath, packageId, install, progress, wasInstalledBefore);
 
 		if (MobileSettings.OpenAfterInstall && !string.IsNullOrWhiteSpace(appId))
 		{
@@ -128,9 +141,22 @@ public sealed class WgtInstaller
 	// mirroring the desktop head's error-code handling. Returns the successful result or throws with an
 	// actionable message.
 	private async Task<ProcessResult> RecoverInstallAsync(
-		string tvIp, string wgtPath, string sdkToolPath, string? packageId, ProcessResult failed, Action<string>? progress)
+		string tvIp, string wgtPath, string sdkToolPath, string? packageId, ProcessResult failed, Action<string>? progress,
+		bool wasInstalledBefore)
 	{
 		var output = failed.Output ?? string.Empty;
+
+		// Fresh-install cleanup guard: a failed install of an app that was NOT already on the TV can
+		// leave a partial package dir wasting storage. Best-effort clear it before we throw — but ONLY
+		// when it was a fresh install (never remove a pre-existing working app on a failed reinstall).
+		// Not called on the transport-lost / [118,-4] / cert-mismatch paths (those throw earlier).
+		async Task ClearPartialIfFresh()
+		{
+			if (!wasInstalledBefore && !string.IsNullOrWhiteSpace(packageId))
+			{
+				try { await _sdb.UninstallAsync(tvIp, packageId!); } catch { /* best-effort */ }
+			}
+		}
 
 		// Environmental — a broken route to the TV. Retrying the same push can't help.
 		if (TizenInstallDiagnostics.IsTransportLost(output))
@@ -167,6 +193,7 @@ public sealed class WgtInstaller
 				throw new InvalidOperationException(
 					"The TV already has this app signed with a different certificate. Remove it on the TV (Apps → delete), then install again.");
 
+			await ClearPartialIfFresh();
 			throw new InvalidOperationException($"Install failed: {Detail(retry.Error, retry.Output)}");
 		}
 
@@ -178,6 +205,7 @@ public sealed class WgtInstaller
 			throw new InvalidOperationException(
 				"Not enough free space on the TV [116]. Remove some apps and try again, or enable \"Override existing app\" in Settings.");
 
+		await ClearPartialIfFresh();
 		throw new InvalidOperationException($"Install failed: {Detail(failed.Error, failed.Output)}");
 	}
 

--- a/Jellyfin2Samsung-CrossOS/Interfaces/IDialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/IDialogService.cs
@@ -10,5 +10,7 @@ namespace Apps2Samsung.Interfaces
         Task<bool> ShowConfirmationAsync(string title, string message, string yes, string no, Window? owner = null);
         Task<string?> PromptForIpAsync();
 
+        /// <summary>Prompts for a free-form line of text. Returns the entered text, or null if cancelled.</summary>
+        Task<string?> PromptForTextAsync(string title, string message, string placeholder);
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
@@ -18,7 +18,7 @@ namespace Apps2Samsung.Interfaces
         Task<string> GetTvNameAsync(string tvIpAddress);
         Task<string> EnsureTizenSdbAvailable();
         Task<string> DownloadPackageAsync(string downloadUrl, bool validateWgt = false);
-        Task<InstallResult> InstallPackageAsync(string packageUrl, string tvIpAddress, CancellationToken cancellationToken, ProgressCallback? progress = null, Action? onSamsungLoginStarted = null);
+        Task<InstallResult> InstallPackageAsync(string packageUrl, string tvIpAddress, CancellationToken cancellationToken, ProgressCallback? progress = null, Action? onSamsungLoginStarted = null, bool? wasAlreadyInstalled = null);
 
         /// <summary>Lists the apps installed on the TV (ensures the SDB binary, queries, parses).</summary>
         Task<IReadOnlyList<Apps2Samsung.Models.InstalledApp>> GetInstalledAppsAsync(string tvIpAddress);

--- a/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
@@ -311,5 +311,43 @@ namespace Apps2Samsung.Services
 
             return null;
         }
+
+        public async Task<string?> PromptForTextAsync(string title, string message, string placeholder)
+        {
+            var window = GetMainWindow();
+            if (window == null)
+                return null;
+
+            var isDarkMode = AppSettings.Default.DarkMode;
+            var foregroundBrush = GetThemeBrush("SystemControlForegroundBaseHighBrush", isDarkMode);
+
+            var textBox = new TextBox
+            {
+                Watermark = placeholder,
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(8),
+                FontSize = 14
+            };
+
+            var panel = new StackPanel { Spacing = 10 };
+            panel.Children.Add(new TextBlock
+            {
+                Text = message,
+                TextWrapping = TextWrapping.Wrap,
+                Foreground = foregroundBrush,
+                FontSize = 14,
+                Margin = new Thickness(0, 5, 0, 0)
+            });
+            panel.Children.Add(textBox);
+
+            // Reuse the app's styled dialog chrome (same Fluent look as the confirmation/IP prompts),
+            // wiring OK/Cancel through a bool TCS and returning the entered text only on OK.
+            var tcs = new TaskCompletionSource<bool>();
+            var dialog = CreateStyledDialog(title, panel, showButtons: true, tcs: tcs, yesText: "Remove", noText: "Cancel");
+
+            await dialog.ShowDialog(window);
+
+            return await tcs.Task ? textBox.Text : null;
+        }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -299,7 +299,8 @@ namespace Apps2Samsung.Services
             string tvIpAddress,
             CancellationToken cancellationToken,
             ProgressCallback? progress = null,
-            Action? onSamsungLoginStarted = null)
+            Action? onSamsungLoginStarted = null,
+            bool? wasAlreadyInstalled = null)
         {
             if (TizenSdbPath is null)
             {
@@ -312,7 +313,25 @@ namespace Apps2Samsung.Services
                     return InstallResult.FailureResult(Constants.LocalizationKeys.InstallTizenSdb.Localized());
                 }
             }
-        
+
+            // Record whether the app was already on the TV BEFORE this run (once, on the outer call;
+            // recursive retries carry the original value forward). This gates the fresh-install partial
+            // cleanup in HandleInstallationResultAsync: we only clear a partial for an app that wasn't
+            // there to begin with, never a pre-existing working app. If we can't tell, assume installed
+            // (fail safe — never uninstall).
+            if (wasAlreadyInstalled is null)
+            {
+                try
+                {
+                    var (existing, _) = await CheckForInstalledApp(tvIpAddress, packageUrl);
+                    wasAlreadyInstalled = existing;
+                }
+                catch
+                {
+                    wasAlreadyInstalled = true;
+                }
+            }
+
             try
             {
                 // Step 1: Prepare device and check for existing installations
@@ -404,7 +423,8 @@ namespace Apps2Samsung.Services
                     deviceInfo.SdkToolPath,
                     progress,
                     cancellationToken,
-                    onSamsungLoginStarted);
+                    onSamsungLoginStarted,
+                    wasAlreadyInstalled.Value);
             }
             catch (Exception ex)
             {
@@ -891,8 +911,25 @@ namespace Apps2Samsung.Services
             string sdkToolPath,
             ProgressCallback? progress,
             CancellationToken cancellationToken,
-            Action? onSamsungLoginStarted)
+            Action? onSamsungLoginStarted,
+            bool wasAlreadyInstalled)
         {
+            // Best-effort cleanup of a partial left behind by a FRESH failed install. Guarded on
+            // wasAlreadyInstalled: only clear a package that wasn't on the TV before this run — never
+            // uninstall a pre-existing working app on a failed reinstall. Swallows all errors.
+            async Task ClearPartialIfFresh()
+            {
+                if (wasAlreadyInstalled)
+                    return;
+                try
+                {
+                    var pkgId = await FileHelper.ReadWgtPackageId(packageUrl);
+                    if (!string.IsNullOrWhiteSpace(pkgId))
+                        await _sdb.UninstallAsync(tvIpAddress, pkgId!);
+                }
+                catch { /* best-effort */ }
+            }
+
             var installResults = await InstallPackageOnDeviceAsync(tvIpAddress, packageUrl, sdkToolPath);
 
             // Transport / connection failure (e.g. "Unable to read data from the transport
@@ -917,7 +954,7 @@ namespace Apps2Samsung.Services
                 {
                     Trace.WriteLine("Installation failed, insufficient space! retrying with remove previous version");
                     _appSettings.TryOverwrite = false;
-                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
+                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
                 }
 
                 _appSettings.TryOverwrite = false;
@@ -937,7 +974,7 @@ namespace Apps2Samsung.Services
                     _appSettings.TryOverwrite = false;
                     _appSettings.ForceSamsungLogin = true;
                     _appSettings.DeletePreviousInstall = true;
-                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
+                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
                 }
 
                 // Overwrite can't help and the TV can't remove it over USB -> tell the user to delete it manually.
@@ -973,7 +1010,7 @@ namespace Apps2Samsung.Services
                 {
                     _appSettings.TryOverwrite = false;
                     await FileHelper.ModifyWgtPackageId(packageUrl);
-                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
+                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
                 }
 
                 _appSettings.TryOverwrite = false;
@@ -988,10 +1025,12 @@ namespace Apps2Samsung.Services
                 if (_appSettings.TryOverwrite)
                 {
                     _appSettings.TryOverwrite = false;
-                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
+                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
                 }
 
                 _appSettings.TryOverwrite = false;
+                // Retries exhausted on a generic failure — clear any partial left by a fresh install.
+                await ClearPartialIfFresh();
                 return InstallResult.FailureResult($"Installation failed: {installResults.Output}");
             }
 
@@ -1018,10 +1057,12 @@ namespace Apps2Samsung.Services
             if (_appSettings.TryOverwrite)
             {
                 _appSettings.TryOverwrite = false;
-                return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted);
+                return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
             }
 
             _appSettings.TryOverwrite = false;
+            // Retries exhausted on an unknown result — clear any partial left by a fresh install.
+            await ClearPartialIfFresh();
             return InstallResult.FailureResult($"Installation failed: {installResults.Output}");
         }
 

--- a/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
@@ -56,9 +56,10 @@ namespace Apps2Samsung.ViewModels
                         Apps.Add(a);
                 });
                 var removable = apps.Count(a => a.IsRemovable);
+                var totalUsed = InstalledApp.FormatSize(apps.Sum(a => a.SizeBytes));
                 StatusText = apps.Count == 0
                     ? "Couldn't read the app list from this TV."
-                    : $"{apps.Count} apps · {removable} removable";
+                    : $"{apps.Count} apps · {totalUsed} used · {removable} removable";
             }
             catch (Exception ex)
             {
@@ -96,6 +97,56 @@ namespace Apps2Samsung.ViewModels
                     IsBusy = false;
                     await _dialogService.ShowErrorAsync(
                         string.IsNullOrWhiteSpace(result.Error) ? result.Output?.Trim() ?? "Uninstall failed." : result.Error);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                IsBusy = false;
+                await _dialogService.ShowErrorAsync(ex.Message);
+                return;
+            }
+
+            await Load();
+        }
+
+        // A partial/failed install can leave a package dir that vd_applist never lists, so it can't be
+        // removed from the list above. vd_appuninstall <packageId> still reclaims it — offer a manual
+        // escape hatch: prompt for the package id and force-remove it.
+        [RelayCommand]
+        private async Task RemoveLeftover()
+        {
+            if (IsBusy)
+                return;
+
+            var id = await _dialogService.PromptForTextAsync(
+                "Remove leftover",
+                "Enter the package id of a leftover/partial install to remove:",
+                "e.g. HarborTV");
+            if (string.IsNullOrWhiteSpace(id))
+                return;
+            id = id.Trim();
+
+            var confirm = await _dialogService.ShowConfirmationAsync(
+                "Remove leftover",
+                $"Force-remove package \"{id}\" from {TvLabel}?",
+                "Remove", "Cancel");
+            if (!confirm)
+                return;
+
+            IsBusy = true;
+            StatusText = $"Removing {id}…";
+            try
+            {
+                var result = await _installer.UninstallAppAsync(_tvIp, id);
+                // "failed[132]" = not installed — already gone, treat as success.
+                var ok = result.ExitCode == 0 ||
+                         (result.Output?.Contains("failed[132]", StringComparison.OrdinalIgnoreCase) ?? false);
+                if (!ok)
+                {
+                    IsBusy = false;
+                    await _dialogService.ShowErrorAsync(
+                        string.IsNullOrWhiteSpace(result.Error) ? result.Output?.Trim() ?? "Remove failed." : result.Error);
                     return;
                 }
             }

--- a/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
@@ -27,6 +27,8 @@
                     <TextBlock Text="{Binding TvLabel}" FontSize="12" Opacity="0.6"/>
                 </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
+                    <Button Content="Remove leftover…" Command="{Binding RemoveLeftoverCommand}"
+                            ToolTip.Tip="Force-remove a leftover/partial install by package id"/>
                     <Button Content="↻" Command="{Binding LoadCommand}" ToolTip.Tip="Refresh"/>
                     <Button Content="✕" Command="{Binding CloseCommand}"/>
                 </StackPanel>
@@ -53,7 +55,10 @@
                                                    TextTrimming="CharacterEllipsis"/>
                                         <TextBlock Text="{Binding TizenId}" FontSize="11" Opacity="0.55"
                                                    TextTrimming="CharacterEllipsis"/>
-                                        <TextBlock Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55"/>
+                                        <StackPanel Orientation="Horizontal" Spacing="10">
+                                            <TextBlock Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55"/>
+                                            <TextBlock Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.55"/>
+                                        </StackPanel>
                                     </StackPanel>
                                     <Button Grid.Column="1" Content="Uninstall" VerticalAlignment="Center"
                                             IsVisible="{Binding IsRemovable}"


### PR DESCRIPTION
## Why

A retail Samsung TV's SDB shell is locked down — there's no `df`, no `ls`, and no file browser, so there's no direct way to see or free up storage. The only levers we actually have are the per-app sizes reported by `vd_applist` and removal via `vd_appuninstall`. This PR turns those two levers into three concrete ways to reclaim space, on both the Avalonia desktop head and the MAUI Android head.

## Feature 1 — show app sizes in the installed-apps view
- `InstalledApp` gains a `long SizeBytes` and a computed human-readable `SizeDisplay` ("—" when unknown, else one-decimal KB/MB/GB), plus a shared static `FormatSize` helper.
- `TizenInstalledApps.Parse` reads the `app_size = <bytes>` field and now orders **biggest-first**, then by name, so the top space users are on top.
- Both heads show the size per app, and the count/status line now includes total used space on the TV (e.g. `32 apps · 1.9 GB used on <TV> · 12 removable`).

## Feature 2 — force-remove a leftover by package id
A partial/failed install can leave a package dir that `vd_applist` never lists, so it can't be removed from the list — but `vd_appuninstall <packageId>` still reclaims it. Both heads get a **"Remove leftover…"** action next to refresh: prompt for a package id, confirm, then uninstall. Exit 0 **or** output containing `failed[132]` ("not installed / already gone") counts as success.
- Desktop: added `IDialogService.PromptForTextAsync(title, message, placeholder)` (implemented as a lightweight prompt reusing the existing Fluent-styled dialog chrome) and a `RemoveLeftover` relay command.

## Feature 3 — best-effort auto-clean a partial after a FRESH failed install
When a **fresh** install (app was NOT already on the TV) fails after retries are exhausted, best-effort `vd_appuninstall` the package id to clear the partial before surfacing the error. It never uninstalls a pre-existing working app, and is skipped on transport-lost, `[118,-4]` API-version and cert-mismatch paths.

**"Was already installed" guard, per head:**
- **Mobile (`WgtInstaller`):** queries `AppsAsync` once at the start of `InstallAsync` and checks whether the package id appears in the raw output → `wasInstalledBefore`, passed into `RecoverInstallAsync`; cleanup runs only before the two generic terminal throws.
- **Desktop (`TizenInstallerService`):** `wasAlreadyInstalled` is derived once on the outer `InstallPackageAsync` call via the existing `CheckForInstalledApp`, threaded through the recursive retries and into `HandleInstallationResultAsync`. If it can't be determined, it defaults to "already installed" (fail-safe — never uninstall). Cleanup runs in the generic-failure and unknown-result final branches.

## Build
Both heads build with **0 errors** (desktop Debug; mobile Release net10.0-android).