### PR TITLE
Stop writing into the .app bundle at runtime (macOS discovery, #498)

### DIFF
--- a/Apps2Samsung.Core/Diagnostics/FileLog.cs
+++ b/Apps2Samsung.Core/Diagnostics/FileLog.cs
@@ -25,6 +25,23 @@ namespace Apps2Samsung.Diagnostics
         /// <summary>The debug log file created by <see cref="Initialize"/> (null until initialized).</summary>
         public static string? CurrentLogFile { get; private set; }
 
+        /// <summary>
+        /// The platform-appropriate log directory shared by every desktop log writer (Program startup
+        /// and the "Open logs folder" buttons), so they can never drift apart.
+        ///
+        /// On macOS this deliberately lives OUTSIDE the .app bundle, in <c>~/Library/Logs/Apps2Samsung</c>:
+        /// creating a <c>Logs/</c> dir inside the ad-hoc-signed bundle mutates it and breaks static
+        /// signature validation (issue #498). Windows/Linux keep logs next to the binary — unchanged, so
+        /// existing users' log paths stay put. The mobile head uses <c>FileSystem.AppDataDirectory</c>
+        /// directly and never touches this.
+        /// </summary>
+        public static string DefaultLogDirectory =>
+            OperatingSystem.IsMacOS()
+                ? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Library", "Logs", "Apps2Samsung")
+                : Path.Combine(AppContext.BaseDirectory, "Logs");
+
         /// <summary>Adds a file trace listener under <paramref name="logDirectory"/>, tees Console into
         /// it, and logs unhandled exceptions. Idempotent and never throws — logging must not take down
         /// startup.</summary>

--- a/Jellyfin2Samsung-CrossOS/Helpers/API/TizenApiClient.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/API/TizenApiClient.cs
@@ -48,10 +48,6 @@ namespace Apps2Samsung.Helpers.API
 
                 var jsonObject = JsonNode.Parse(jsonContent);
 
-                var logFilePath = Path.Combine(AppContext.BaseDirectory, "Logs", $"debug_tv_api_{DateTime.Now:yyyy-MM-dd_HH-mm-ss-fff}.log");
-                await File.WriteAllTextAsync(logFilePath, jsonContent);
-
-
                 var deviceNode = jsonObject?["device"];
                 if (deviceNode == null)
                 {

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -37,7 +37,15 @@ namespace Apps2Samsung.Helpers
 
         public static readonly string ProfilePath = Path.Combine(FolderPath, "Assets", "TizenProfile");
         public static readonly string EsbuildPath = Path.Combine(FolderPath, "Assets", "esbuild");
-        public static readonly string DownloadPath = Path.Combine(FolderPath, "Downloads");
+
+        // Downloaded-package (.wgt) cache. On macOS this must NOT live inside the .app bundle: writing
+        // there mutates the ad-hoc-signed bundle and breaks static signature validation (issue #498).
+        // Use ~/Library/Caches; Windows/Linux keep it next to the binary (unchanged).
+        public static readonly string DownloadPath = OperatingSystem.IsMacOS()
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library", "Caches", "Apps2Samsung", "Downloads")
+            : Path.Combine(FolderPath, "Downloads");
 
         private static AppSettings? _instance;
 

--- a/Jellyfin2Samsung-CrossOS/Program.cs
+++ b/Jellyfin2Samsung-CrossOS/Program.cs
@@ -12,7 +12,8 @@ namespace Apps2Samsung
         public static void Main(string[] args)
         {
             // Route Trace to a file BEFORE Avalonia starts (shared with the mobile head via Core).
-            Apps2Samsung.Diagnostics.FileLog.Initialize(Path.Combine(AppContext.BaseDirectory, "Logs"));
+            // DefaultLogDirectory keeps logs OUT of the .app bundle on macOS (see FileLog / issue #498).
+            Apps2Samsung.Diagnostics.FileLog.Initialize(Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory);
 
 
             BuildAvaloniaApp()

--- a/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
@@ -222,7 +222,7 @@ namespace Apps2Samsung.Services
                 {
                     try
                     {
-                        var logFolder = Path.Combine(AppContext.BaseDirectory, "Logs");
+                        var logFolder = Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory;
                         Directory.CreateDirectory(logFolder);
 
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
@@ -275,7 +275,7 @@ namespace Apps2Samsung.ViewModels
         {
             try
             {
-                var logFolder = Path.Combine(AppContext.BaseDirectory, "Logs");
+                var logFolder = Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory;
                 Directory.CreateDirectory(logFolder);
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
## Why

On macOS the app is **ad-hoc signed** (`codesign --sign -` in both release workflows). Creating files *inside* the signed bundle at runtime mutates it and breaks **static** signature validation — the leading suspect for the silent TV-discovery failure in #498:

- app never prompts for Local Network permission,
- never appears under **System Settings → Privacy & Security → Local Network**,
- scan returns `Found 0 device(s)` because every LAN-connect denial is swallowed by `NetworkService`'s `catch { /* Ignore scan failures */ }` (line 147) and `IsPortOpenAsync`'s `catch { return false; }`.

The first thing the app does at startup is create `Logs/` **inside** the bundle (`AppContext.BaseDirectory` = `Apps2Samsung.app/Contents/MacOS/`), so the bundle is already mutated before the first scan runs.

## What

Move every runtime write out of the bundle **on macOS only**; Windows/Linux behaviour is unchanged so existing users' paths stay put.

| Write | Before (in bundle) | After (macOS) |
|---|---|---|
| Debug logs | `<bundle>/Contents/MacOS/Logs` | `~/Library/Logs/Apps2Samsung` |
| `.wgt` download cache | `<bundle>/…/Downloads` | `~/Library/Caches/Apps2Samsung/Downloads` |
| Per-scan TV-API JSON dump | `<bundle>/…/Logs/debug_tv_api_*.log` | **removed** (debug leftover) |

- New `FileLog.DefaultLogDirectory` is the single source of truth, used by `Program` startup **and** both "Open logs folder" buttons (`AppSettingsViewModel`, `DialogService`) so they can't drift apart.
- The `TizenApiClient` write dumped raw TV JSON into the bundle on **every** scan and didn't even create the dir first — removed.

Build: `Apps2Samsung.csproj` (+ Core) compiles clean, 0 errors.

## Important caveats

- **This is necessary hygiene but may not be sufficient.** Ad-hoc signing has no stable identity for TCC to register a Local Network grant against, especially on the reporter's **macOS 27 developer beta**. If the `codesign -vv --strict` / `log stream --predicate 'subsystem == "com.apple.TCC"'` output requested on #498 shows the signature is valid but TCC still won't prompt, the real fix is **Developer ID + notarization** (tracked separately).
- **Follow-up bundle write not addressed here:** `TizenInstallerService.EnsureTizenSdbAvailable()` moves an updated SDB binary into `Assets/TizenSDB` (bundle) when a newer version is available. It's install-time (not discovery-time) and a larger change, so it's left for a separate PR.
- `NSLocalNetworkUsageDescription` (already added in 58e9e43) is kept — required, just not sufficient.