### PR TITLE
Relocate remaining runtime bundle-writes off macOS — finishes #498

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -25,7 +25,16 @@ namespace Apps2Samsung.Helpers
 
         // Pre-2.5.1 location: next to the binary. Used once to migrate existing users' settings.
         private static readonly string LegacyFilePath = Path.Combine(FolderPath, FileName);
-        public static readonly string TizenSdbPath = Path.Combine(FolderPath, "Assets", "TizenSDB");
+
+        // Read-only Tizen SDB binary shipped inside the install folder/bundle.
+        public static readonly string BundledTizenSdbPath = Path.Combine(FolderPath, "Assets", "TizenSDB");
+        // Working dir the SDB binary actually runs from. The auto-updater replaces the binary here, so
+        // on macOS it must live OUTSIDE the .app bundle (writing there breaks the code signature and the
+        // TCC Local Network prompt, #498); it's seeded from BundledTizenSdbPath on first use. Windows/
+        // Linux run straight from the bundled copy, unchanged.
+        public static readonly string TizenSdbPath = OperatingSystem.IsMacOS()
+            ? Path.Combine(DataFolderPath, "TizenSDB")
+            : BundledTizenSdbPath;
 
         // Generated signing certificates live in the per-user data dir so they survive app/bundle
         // updates. A macOS .dmg (or an installer) replaces the whole install folder/bundle; if the

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/ProcessHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/ProcessHelper.cs
@@ -62,15 +62,15 @@ namespace Apps2Samsung.Helpers.Core
                 WorkingDirectory = workingDirectory ?? ""
             };
 
-            // Build log file path (next to app .exe)
-            string exeDir = AppContext.BaseDirectory;
+            // Build log file path. Shares FileLog's directory so it stays OUT of the .app bundle on
+            // macOS — writing next to the binary mutates the signed bundle and breaks TCC (issue #498).
             string timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss-fff");
             string firstTwoArgs = GetFirstArguments(arguments);
             string sanitizedArguments = new(firstTwoArgs.Where(c => char.IsLetterOrDigit(c) || c == '_' || c == '-').ToArray());
             if (string.IsNullOrEmpty(sanitizedArguments))
                 sanitizedArguments = "unknown";
 
-            string logFolder = Path.Combine(exeDir, "Logs");
+            string logFolder = Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory;
             string logFilePath = Path.Combine(logFolder, $"process_{sanitizedArguments}_{timestamp}.log");
 
             try
@@ -102,7 +102,7 @@ namespace Apps2Samsung.Helpers.Core
                 // Always write everything to a log file
                 try
                 {
-                    Directory.CreateDirectory(exeDir);
+                    Directory.CreateDirectory(logFolder);
                     await File.WriteAllTextAsync(logFilePath, result.Output);
                     result.Output += $"\n[Log written to: {logFilePath}]";
                 }

--- a/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
@@ -20,8 +20,13 @@ namespace Apps2Samsung.Services
         private static readonly Uri BundledUri =
             new("avares://Apps2Samsung/Assets/third-party-apps.json");
 
-        private static readonly string CachePath =
-            Path.Combine(AppSettings.FolderPath, "third-party-apps.cache.json");
+        // The remote-manifest cache. On macOS this must NOT live next to the binary: writing it into
+        // the .app bundle mutates it and breaks the code signature / TCC Local Network prompt (#498).
+        private static readonly string CachePath = OperatingSystem.IsMacOS()
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library", "Caches", "Apps2Samsung", "third-party-apps.cache.json")
+            : Path.Combine(AppSettings.FolderPath, "third-party-apps.cache.json");
 
         private readonly HttpClient _httpClient;
 
@@ -103,6 +108,7 @@ namespace Apps2Samsung.Services
         {
             try
             {
+                Directory.CreateDirectory(Path.GetDirectoryName(CachePath)!);
                 File.WriteAllText(CachePath, json);
             }
             catch (Exception ex)

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -60,6 +60,25 @@ namespace Apps2Samsung.Services
         public async Task<string> EnsureTizenSdbAvailable()
         {
             string tizenSdbPath = AppSettings.TizenSdbPath;
+
+            // On macOS the SDB runs from a writable per-user dir (see AppSettings.TizenSdbPath): the
+            // updater rewrites the binary and doing that inside the signed .app bundle breaks TCC
+            // (#498). Seed it from the read-only bundled copy on first use.
+            if (OperatingSystem.IsMacOS() && tizenSdbPath != AppSettings.BundledTizenSdbPath)
+            {
+                Directory.CreateDirectory(tizenSdbPath);
+                if (!Directory.EnumerateFileSystemEntries(tizenSdbPath).Any()
+                    && Directory.Exists(AppSettings.BundledTizenSdbPath))
+                {
+                    foreach (var src in Directory.GetFiles(AppSettings.BundledTizenSdbPath))
+                    {
+                        var dest = Path.Combine(tizenSdbPath, Path.GetFileName(src));
+                        File.Copy(src, dest, overwrite: true);
+                        await _processHelper.MakeExecutableAsync(dest);
+                    }
+                }
+            }
+
             if (!Directory.Exists(tizenSdbPath))
             {
                 throw new InvalidOperationException(


### PR DESCRIPTION
Follow-up to #499. The reporter's `codesign`/TCC output on #498 **confirmed the mechanism** and revealed #499 only fixed one of four writers.

## The confirmation
`sudo log stream --predicate 'subsystem == "com.apple.TCC"'` during a scan shows, for every request:

```
tccd: SecStaticCodeCheckValidity() static code from org.madebypatrick.apps2samsung : anchor apple; status: -67050
tccd: promptPolicy = 0; isApplePlatformBinary = 0
```

`-67050` = `errSecCSResourcesInvalid` — the broken seal. TCC validates the **on-disk bundle** before deciding whether to prompt; because runtime writes have added files, the check fails and `promptPolicy = 0`, so the Local Network prompt never appears and the scan silently returns 0 devices.

`codesign -vv --strict --deep` named the added files:
```
file added: .../Contents/MacOS/third-party-apps.cache.json
file added: .../Contents/MacOS/Logs/process_x_*.log
file added: .../Contents/MacOS/Logs/debug_*.log
file added: .../Contents/MacOS/Assets/TizenSDB/TizenSdb_v1.1.1_macos-arm64
```

## What this PR does (Windows/Linux unchanged)
| Writer | Before | After (macOS) |
|---|---|---|
| `ProcessHelper` `process_*.log` | `<bundle>/Logs` | `FileLog.DefaultLogDirectory` (`~/Library/Logs`) |
| `ProviderManifestService` catalog cache | `<bundle>/third-party-apps.cache.json` | `~/Library/Caches/Apps2Samsung/` |
| Tizen SDB binary (+ auto-update) | `<bundle>/Assets/TizenSDB` | `~/.config/Apps2Samsung/TizenSDB`, seeded from the bundled copy on first use |

- The manifest cache wrote at **startup** (before the first scan), so on its own it was enough to break the seal for discovery.
- `debug_*.log` was already handled by #499.
- Also fixes a latent `ProcessHelper` bug: it created `exeDir` instead of the log folder.

## SDB approach
Rather than swap desktop to the in-process engine (the mobile/android head's `InProcessSdbEngine`), which would be a large, regression-prone change to the install/uninstall/permit/resign paths, this keeps `ExeSdbEngine` but runs the binary from a writable per-user dir seeded from the bundle. Migrating desktop to the in-process engine remains a worthwhile **separate** cleanup that would remove the native binary (and this whole class of problem) entirely.

## Expected result
With #499 + this, a **freshly installed** build performs zero runtime writes into the bundle, so the seal stays valid, `SecStaticCodeCheckValidity` passes, and TCC can finally prompt for Local Network. Needs a from-scratch install to verify (an already-mutated bundle stays broken until reinstalled).

Build: `Apps2Samsung.csproj` (+ Core) compiles clean, 0 errors.