### PR TITLE
Bump Avalonia 11.3.6 → 11.3.12 (macOS accessibility crash #501)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -68,13 +68,13 @@
   </ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
+    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.6">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Addresses #501 — "Application Crashes Randomly and Often" on macOS 26.5.2 (arm64 beta).

## Diagnosis
The Apple crash report is a main-thread `EXC_BAD_ACCESS` (Data Abort / byte-read translation fault) inside `libAvaloniaNative`:

```
-[AvnWindow automationPeer]                                    (libAvaloniaNative)
-[AvnView accessibilityHitTest:]
-[NSWindow(NSWindowAccessibility) accessibilityHitTest:]
_accessibilityParentAdjustedHitTestElement:atLocation:
```

macOS's accessibility system hit-tests the window (this fires constantly during normal mouse movement, and whenever any accessibility client is active) and dereferences a bad/stale Avalonia **automation peer**. That matches the "random and often" report. It's a **framework-level bug in Avalonia's macOS native layer**, not our code — the same family as the long-standing macOS native teardown crashes ([#8879](https://github.com/AvaloniaUI/Avalonia/issues/8879), [#4923](https://github.com/AvaloniaUI/Avalonia/issues/4923), [#16799](https://github.com/AvaloniaUI/Avalonia/issues/16799)).

## Change
We're pinned to **11.3.6**; this bumps to **11.3.12** (latest 11.3.x — same minor, API-compatible). That range includes several macOS + accessibility fixes ([11.3.12 notes](https://github.com/AvaloniaUI/Avalonia/discussions/20673)): release-mouse-capture-on-focus-lost (#20574), render-target ≥1×1 (#20610), ScrollBar a11y (#20483), title-bar-in-a11y-tree (#20485).

## Honest caveat
The 11.3.7–11.3.12 changelogs **do not explicitly list a fix for this exact `automationPeer` hit-test path**, so this is the low-risk first attempt, not a confirmed fix. It needs on-device confirmation from the reporter. If it persists, next steps are an upstream Avalonia report with this crash log and/or a targeted workaround.

Build: `Apps2Samsung.csproj` (+ Core) compiles clean, 0 errors.