### PR TITLE
Log unexpected scan connect failures instead of swallowing them (#498 diagnostic)

### DIFF
--- a/Apps2Samsung.Core/Network/NetworkService.cs
+++ b/Apps2Samsung.Core/Network/NetworkService.cs
@@ -144,7 +144,12 @@ namespace Apps2Samsung.Services
                                 }
                             }
                         }
-                        catch { /* Ignore scan failures */ }
+                        catch (Exception ex)
+                        {
+                            // Don't let one host's failure abort the sweep, but no longer swallow it
+                            // silently — log so a systematic failure (e.g. an OS-level block) is visible.
+                            Trace.WriteLine($"[Scan] host probe failed: {ex.GetType().Name} — {ex.Message}");
+                        }
                     })));
 
             Trace.WriteLine($"Scan complete! Found {foundDevices.Count} device(s) (debug port {TizenDevPort} or REST API {SamsungTvApiPort}).");
@@ -199,8 +204,25 @@ namespace Apps2Samsung.Services
                 await client.ConnectAsync(ip, port, ct);
                 return true;
             }
-            catch
+            catch (OperationCanceledException)
             {
+                return false; // normal: per-probe timeout / linked-CTS cancellation
+            }
+            catch (Exception ex)
+            {
+                // A subnet sweep expects most probes to fail with refused/timeout/unreachable, so keep
+                // those quiet. Anything else is surfaced instead of silently swallowed — notably macOS
+                // Local Network privacy, which blocks the connect with "Operation not permitted"
+                // (SocketError.AccessDenied). That log line is what tells us a connect was denied by
+                // the OS rather than the host simply being absent (see #498).
+                var normal = ex is SocketException se && se.SocketErrorCode is
+                    SocketError.ConnectionRefused or SocketError.TimedOut or
+                    SocketError.HostUnreachable or SocketError.NetworkUnreachable;
+                if (!normal)
+                {
+                    var code = (ex as SocketException)?.SocketErrorCode.ToString() ?? ex.GetType().Name;
+                    Trace.WriteLine($"[Scan] connect {ip}:{port} failed unexpectedly ({code}): {ex.Message}");
+                }
                 return false;
             }
         }


### PR DESCRIPTION
Diagnostic aid for #498. Manual IP entry fails too, so the macOS problem is at the **connect layer**, not discovery — but `NetworkService` swallowed the real error, so we can't see *why*.

- `IsPortOpenAsync`: `catch { return false; }`
- scan loop: `catch { /* Ignore scan failures */ }`

A macOS Local Network denial was therefore indistinguishable from "host absent" and only ever produced `Found 0 device(s)`.

## Change
The connect catch now logs anything **outside** the expected closed-host set (`ConnectionRefused` / `TimedOut` / `HostUnreachable` / `NetworkUnreachable`) — most importantly a Local Network privacy block, which surfaces as **"Operation not permitted"** (`SocketError.AccessDenied`). Normal sweep misses stay quiet (no 254-host spam); cancellations are treated as normal timeouts. The per-host catch logs instead of silently ignoring.

## Why it matters for #498
With this, alihandrox's debug log (`~/Library/Logs/Apps2Samsung/`) will show the exact socket error on the failed connect — distinguishing **"macOS is blocking the app"** (`AccessDenied` / Operation not permitted → signing/Local-Network) from **"network/routing problem"** (unreachable). Pairs with the `nc` probe requested on the issue.

Build: `Apps2Samsung.Core` compiles clean, 0 errors.