### PR TITLE
Fix LiteFin install "needs a new app id" — generalize package-id regex (#400)

### DIFF
--- a/Apps2Samsung.Core/Core/RegexPatterns.cs
+++ b/Apps2Samsung.Core/Core/RegexPatterns.cs
@@ -124,20 +124,34 @@ namespace Apps2Samsung.Helpers.Core
                 @"<tizen:application\s+id=""(?<pkg>[A-Za-z0-9]+)\.Jellyfin""\s+package=""\k<pkg>""";
 
             /// <summary>
-            /// Pre-compiled regex for Tizen application ID extraction.
+            /// Pre-compiled regex for Tizen application ID extraction. Jellyfin-specific — matches
+            /// only <c>&lt;pkg&gt;.Jellyfin</c> ids. Keep this for the Jellyfin-only patches (e.g.
+            /// FixYouTube) that must never touch non-Jellyfin packages.
             /// </summary>
             public static readonly Regex TizenApplicationId = new(
                 TizenApplicationIdPattern,
                 RegexOptions.Compiled | RegexOptions.Multiline);
 
             /// <summary>
-            /// Creates a pattern to match and replace a specific package ID in config.xml.
+            /// Generic package-id matcher: any <c>&lt;pkg&gt;.&lt;AppName&gt;</c> id whose
+            /// <c>package</c> attribute equals <c>&lt;pkg&gt;</c>. Used to read/rewrite the package id
+            /// for ANY app. Jellyfin variants such as LiteFin use <c>LitefinApp.Litefin</c> (not
+            /// <c>.Jellyfin</c>), so the pattern above silently misses them — which made the [118]
+            /// package-id-conflict retry a no-op and failed the install with "needs a new app id" (#400).
+            /// </summary>
+            public static readonly Regex TizenPackageIdAny = new(
+                @"<tizen:application\s+id=""(?<pkg>[A-Za-z0-9]+)\.[A-Za-z0-9]+""\s+package=""\k<pkg>""",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+            /// <summary>
+            /// Creates a pattern to match a specific package's Tizen application element (any app-name
+            /// suffix, not just <c>.Jellyfin</c>), so the id can be rewritten for any variant.
             /// </summary>
             /// <param name="packageId">The package ID to match.</param>
             /// <returns>The pattern string.</returns>
             public static string CreatePackageIdReplacePattern(string packageId)
             {
-                return $@"<tizen:application\s+id=""{packageId}\.Jellyfin""\s+package=""{packageId}""";
+                return $@"<tizen:application\s+id=""{packageId}\.[A-Za-z0-9]+""\s+package=""{packageId}""";
             }
         }
 

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -108,7 +108,7 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
             using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
                 configContent = await reader.ReadToEndAsync();
 
-            var match = RegexPatterns.WgtConfig.TizenApplicationId.Match(configContent);
+            var match = RegexPatterns.WgtConfig.TizenPackageIdAny.Match(configContent);
             return match.Success ? match.Groups["pkg"].Value : null;
         }
         public static async Task<string?> ReadExtractedWgtPackageId(string workspaceRoot)
@@ -118,7 +118,7 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
                 return null;
 
             var configContent = await File.ReadAllTextAsync(configPath, Encoding.UTF8);
-            var match = RegexPatterns.WgtConfig.TizenApplicationId.Match(configContent);
+            var match = RegexPatterns.WgtConfig.TizenPackageIdAny.Match(configContent);
             return match.Success ? match.Groups["pkg"].Value : null;
         }
         public static async Task<bool> ModifyWgtPackageId(string wgtPath)

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -1028,8 +1028,12 @@ namespace Apps2Samsung.Services
                 if (_appSettings.TryOverwrite)
                 {
                     _appSettings.TryOverwrite = false;
-                    await FileHelper.ModifyWgtPackageId(packageUrl);
-                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
+                    // Give the package a fresh random id and retry. Only retry if the id was actually
+                    // rewritten — if the config couldn't be read/modified (previously silent for any
+                    // non-".Jellyfin" variant like LiteFin, #400), retrying would hit the identical
+                    // [118] conflict, so fall through to a clear failure instead.
+                    if (await FileHelper.ModifyWgtPackageId(packageUrl))
+                        return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
                 }
 
                 _appSettings.TryOverwrite = false;


### PR DESCRIPTION
Fixes #400. LiteFin fails with **"Jellyfin app needs a new app id!"** while Jellyfin / Moonfin / Jellyfin-AVPlay install fine on the same TV.

## Root cause (confirmed against the real package)
The `[118]` package-id-conflict handler calls `ModifyWgtPackageId` to randomise the id and retry. But the read/rewrite regex was hardcoded to a `.Jellyfin` app-id suffix:

```
<tizen:application id="(?<pkg>[A-Za-z0-9]+)\.Jellyfin" package="\k<pkg>"
```

LiteFin's `config.xml` is `id="LitefinApp.Litefin" package="LitefinApp"` → **no match** → `ReadWgtPackageId` returns null → `ModifyWgtPackageId` no-ops (its `false` return was ignored) → the retry installs the **unchanged** package → identical `[118]` → falls through to "needs a new app id." The `.Jellyfin` variants match, which is exactly why only LiteFin broke.

## Fix
- Add `RegexPatterns.WgtConfig.TizenPackageIdAny` — generic `<pkg>.<AppName>` matcher.
- Point the generic readers (`ReadWgtPackageId`, `ReadExtractedWgtPackageId`) and `CreatePackageIdReplacePattern` at it. The `.Jellyfin`-specific regex is **kept** solely for the Jellyfin-only patches (`FixYouTube`), so their behaviour is unchanged.
- Only retry after `ModifyWgtPackageId` actually rewrote the id; otherwise fail clearly instead of a pointless retry into the same conflict.

## Verified
Against the real `Litefin-1.3.0.wgt` **and** the ultra-legacy build:
- old `.Jellyfin` regex → no match;
- new regex → rewrites `id="LitefinApp.Litefin" package="LitefinApp"` → a fresh random package id, suffix + `required_version` preserved.

ultra-legacy `required_version="2.3"` (OK for Tizen 2.4) and only standard privileges — no cert/version blocker.

Build: `Apps2Samsung.csproj` (+ Core) clean, 0 errors.

Note: this clears the specific "needs a new app id" dead-end. The reporters' Tizen 2.4 logs also show old-firmware SDB flakiness (`uninstall failed[132]`, "Remote closed channel before sending OKAY") which is TV-side and out of scope here.