### PR TITLE
Mobile Samsung login via Custom Tab (fix Google sign-in) + OAuth dedup/state validation

### DIFF
--- a/Apps2Samsung.Core/Core/Constants.cs
+++ b/Apps2Samsung.Core/Core/Constants.cs
@@ -74,7 +74,7 @@ namespace Apps2Samsung.Helpers.Core
         {
             public const int TizenDevPort = 26101;
             public const int SamsungTvApiPort = 8001;
-            public const int SamsungLoginCallbackPort = 4794;
+            // Samsung login callback port lives in Apps2Samsung.Samsung.SamsungOAuth.CallbackPort.
         }
 
         /// <summary>
@@ -134,11 +134,8 @@ namespace Apps2Samsung.Helpers.Core
         public static class Samsung
         {
             public const string LoopbackHost = "localhost";
-            public const string CallbackPath = "/signin/callback";
-            public const string OAuthClientId = "v285zxnl3h";
-            public const string OAuthState = "accountcheckdogeneratedstatetext";
-            public const string TokenType = "TOKEN";
-            public const string SignInGateUrl = "https://account.samsung.com/accounts/be1dce529476c1a6d407c4c7578c31bd/signInGate";
+            // OAuth endpoint + parameters (SignInGate URL, client id, state, token type, callback
+            // path) are the single source of truth in Apps2Samsung.Samsung.SamsungOAuth.
             public const string PlatformVd = "VD";
             public const string PrivilegeLevelPublic = "Public";
             public const string DeveloperTypeIndividual = "Individual";

--- a/Apps2Samsung.Core/Samsung/SamsungOAuth.cs
+++ b/Apps2Samsung.Core/Samsung/SamsungOAuth.cs
@@ -24,5 +24,13 @@ namespace Apps2Samsung.Samsung
             $"{SignInGateUrl}?locale=&clientId={ClientId}" +
             $"&redirect_uri={Uri.EscapeDataString(redirectUri)}" +
             $"&state={State}&tokenType={TokenType}";
+
+        /// <summary>
+        /// True when the <c>state</c> returned on the callback matches the value we sent in
+        /// <see cref="BuildAuthorizeUrl"/>. The single implementation both heads use to reject a
+        /// callback whose state doesn't round-trip (CSRF / stray callback protection).
+        /// </summary>
+        public static bool IsValidState(string? state) =>
+            string.Equals(state, State, StringComparison.Ordinal);
     }
 }

--- a/Apps2Samsung.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/Apps2Samsung.Mobile/Platforms/Android/AndroidManifest.xml
@@ -3,4 +3,15 @@
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:networkSecurityConfig="@xml/network_security_config"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<!-- Android 11+ package visibility: without this, Custom Tabs provider resolution and the
+	     ActionView browser fallback both fail silently. -->
+	<queries>
+		<intent>
+			<action android:name="android.support.customtabs.action.CustomTabsService" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="https" />
+		</intent>
+	</queries>
 </manifest>

--- a/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
@@ -1,60 +1,108 @@
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using Android.Webkit;
+using AndroidX.Browser.CustomTabs;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using Apps2Samsung.Samsung;
+using AndroidIntent = Android.Content.Intent;
 using AndroidUri = Android.Net.Uri;
-using AndroidWebView = Android.Webkit.WebView;
 
 namespace Apps2Samsung.Mobile.Platforms.Android;
 
-// Hosts the Samsung SignInGate in a WebView and captures the token it POSTs to the redirect_uri.
-// A WebView URL-intercept can't read a POST body, so we run a tiny in-app loopback listener on
-// :4794 (same role as the desktop Kestrel callback) and point the redirect at it. Proven on-device
-// by the tizen-sdb Probe; this is that recipe wrapped behind SamsungLoginService.
-[Activity(Label = "Samsung Login", ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+// Runs the Samsung SignInGate in the system browser (Chrome Custom Tab) and captures the token it
+// POSTs to the redirect_uri via an in-app loopback listener on :4794 — the same contract the desktop
+// head fulfils with Kestrel. An embedded WebView cannot be used here: accounts.google.com rejects
+// embedded user agents (disallowed_useragent), which kills SignInGate's "Sign in with Google" path.
+[Activity(Label = "Samsung Login",
+          LaunchMode = LaunchMode.SingleTask,
+          ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
 public class SamsungLoginActivity : Activity
 {
     // Single-flight bridge to SamsungLoginService: it sets this before launching, the activity
     // completes it with the raw token JSON (or faults/cancels it).
     internal static TaskCompletionSource<string>? Pending;
 
+    private const string StateTabLaunched = "tab_launched";
+
     private TcpListener? _listener;
     private readonly CancellationTokenSource _cts = new();
+    private bool _tabLaunched;
+    private volatile bool _settled;
 
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
         ActionBar?.Hide();
 
-        var web = new AndroidWebView(this);
-        web.Settings.JavaScriptEnabled = true;   // SignInGate needs JS
-        web.Settings.DomStorageEnabled = true;
-        web.Settings.DatabaseEnabled = true;
-        web.Settings.JavaScriptCanOpenWindowsAutomatically = true;
-        web.Settings.SetSupportMultipleWindows(true);
-        // The final redirect goes to http://localhost from an https page — allow it.
-        web.Settings.MixedContentMode = MixedContentHandling.AlwaysAllow;
-        // Samsung's account pages behave badly under the default "; wv" WebView UA.
-        web.Settings.UserAgentString =
-            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/126.0.0.0 Mobile Safari/537.36";
-
-        // Cross-domain login needs cookies, including third-party.
-        CookieManager.Instance!.SetAcceptCookie(true);
-        CookieManager.Instance.SetAcceptThirdPartyCookies(web, true);
-
-        web.SetWebViewClient(new LoggingClient(msg => Fault(new InvalidOperationException(msg))));
-
-        SetContentView(web);
+        _tabLaunched = savedInstanceState?.GetBoolean(StateTabLaunched) ?? false;
 
         _ = Task.Run(() => ListenForCallbackAsync(_cts.Token));
+    }
 
+    protected override void OnSaveInstanceState(Bundle outState)
+    {
+        outState.PutBoolean(StateTabLaunched, _tabLaunched);
+        base.OnSaveInstanceState(outState);
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+
+        // Already resolved (token or error): the CLEAR_TOP intent dismissed the tab and brought
+        // us back, so all that's left is to tear down.
+        if (_settled)
+        {
+            Finish();
+            return;
+        }
+
+        if (!_tabLaunched)
+        {
+            _tabLaunched = true;
+            LaunchTab();
+            return;
+        }
+
+        // Foreground again with nothing captured: the user dismissed the browser tab.
+        Pending?.TrySetCanceled();
+        Pending = null;
+        Finish();
+    }
+
+    private void LaunchTab()
+    {
         var redirect = $"http://localhost:{SamsungOAuth.CallbackPort}{SamsungOAuth.CallbackPath}";
-        web.LoadUrl(SamsungOAuth.BuildAuthorizeUrl(redirect));
+        var url = AndroidUri.Parse(SamsungOAuth.BuildAuthorizeUrl(redirect));
+
+        if (url is null)
+        {
+            Fault(new InvalidOperationException("Could not build the SignInGate authorize URL."));
+            return;
+        }
+
+        try
+        {
+            new CustomTabsIntent.Builder()
+                .SetShowTitle(true)
+                .Build()
+                .LaunchUrl(this, url);
+        }
+        catch (global::Android.Content.ActivityNotFoundException)
+        {
+            // No Custom Tabs provider — fall back to whatever browser is installed.
+            try
+            {
+                StartActivity(new AndroidIntent(AndroidIntent.ActionView, url));
+            }
+            catch (global::Android.Content.ActivityNotFoundException ex)
+            {
+                Fault(new InvalidOperationException(
+                    "No browser is available to complete the Samsung login.", ex));
+            }
+        }
     }
 
     private async Task ListenForCallbackAsync(CancellationToken ct)
@@ -71,24 +119,32 @@ public class SamsungLoginActivity : Activity
 
                 var (method, path, body) = await ReadRequestAsync(stream, ct);
 
-                const string page = "Login captured — return to the app.";
-                var resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n" +
-                           $"Content-Length: {Encoding.UTF8.GetByteCount(page)}\r\nConnection: close\r\n\r\n{page}";
+                // Briefly visible in the browser tab before CLEAR_TOP dismisses it.
+                const string page =
+                    "<!doctype html><meta name=viewport content=\"width=device-width,initial-scale=1\">" +
+                    "<body style=\"font:16px system-ui;padding:2rem\">" +
+                    "Login captured — returning to Apps2Samsung…</body>";
+                var resp = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n" +
+                           $"Content-Length: {Encoding.UTF8.GetByteCount(page)}\r\n" +
+                           "Connection: close\r\n\r\n" + page;
                 await stream.WriteAsync(Encoding.UTF8.GetBytes(resp), ct);
                 await stream.FlushAsync(ct);
 
                 if (method == "POST" && path.StartsWith(SamsungOAuth.CallbackPath, StringComparison.Ordinal))
                 {
+                    // Reject a callback whose state doesn't round-trip (CSRF / stray callback).
+                    var state = ParseFormField(body, "state");
+                    if (!SamsungOAuth.IsValidState(state is null ? null : Uri.UnescapeDataString(state)))
+                    {
+                        Fault(new InvalidOperationException("Samsung login state mismatch — aborting."));
+                        return;
+                    }
+
                     var code = ParseFormField(body, "code");
                     if (!string.IsNullOrWhiteSpace(code))
                     {
                         var tokenJson = Uri.UnescapeDataString(code);
-                        RunOnUiThread(() =>
-                        {
-                            Pending?.TrySetResult(tokenJson);
-                            Pending = null;
-                            Finish();
-                        });
+                        RunOnUiThread(() => Complete(tokenJson));
                         return;
                     }
                 }
@@ -105,12 +161,44 @@ public class SamsungLoginActivity : Activity
         }
     }
 
+    private void Complete(string tokenJson)
+    {
+        _settled = true;
+        Pending?.TrySetResult(tokenJson);
+        Pending = null;
+        BringToFront();
+    }
+
     private void Fault(Exception ex) => RunOnUiThread(() =>
     {
+        _settled = true;
         Pending?.TrySetException(ex);
         Pending = null;
-        Finish();
+        BringToFront();
     });
+
+    // Pops the browser tab off this task and re-enters OnResume, which finishes the activity.
+    // Needed because the tab lives in our task and there is no redirect Intent to close it —
+    // the callback arrives over a socket, not an intent filter.
+    private void BringToFront() =>
+        StartActivity(new AndroidIntent(this, typeof(SamsungLoginActivity))
+            .AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop));
+
+    protected override void OnDestroy()
+    {
+        _cts.Cancel();
+        try { _listener?.Stop(); } catch { /* ignore */ }
+
+        // Only unblock the awaiter if we're leaving without having resolved it.
+        if (!_settled)
+        {
+            Pending?.TrySetCanceled();
+            Pending = null;
+        }
+
+        _cts.Dispose();
+        base.OnDestroy();
+    }
 
     // Minimal HTTP/1.1 request reader: request line + headers, then the Content-Length body.
     private static async Task<(string method, string path, string body)> ReadRequestAsync(
@@ -160,30 +248,5 @@ public class SamsungLoginActivity : Activity
                 return kv[1];
         }
         return null;
-    }
-
-    protected override void OnDestroy()
-    {
-        _cts.Cancel();
-        try { _listener?.Stop(); } catch { /* ignore */ }
-        // If we're leaving without a captured token (user backed out), unblock the awaiter.
-        Pending?.TrySetCanceled();
-        Pending = null;
-        base.OnDestroy();
-    }
-
-    // Keeps navigation inside the WebView and surfaces main-frame load failures (so a failed page
-    // gives the real reason rather than a generic error screen).
-    private sealed class LoggingClient(Action<string> log) : WebViewClient
-    {
-        public override bool ShouldOverrideUrlLoading(AndroidWebView? view, IWebResourceRequest? request)
-            => false; // let the WebView handle every navigation (incl. the localhost POST)
-
-        public override void OnReceivedError(AndroidWebView? view, IWebResourceRequest? request, WebResourceError? error)
-        {
-            if (request?.IsForMainFrame == true)
-                log($"load error {(int?)error?.ErrorCode}: {error?.Description} @ {request?.Url}");
-            base.OnReceivedError(view, request, error);
-        }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/SamsungLoginService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/SamsungLoginService.cs
@@ -1,6 +1,7 @@
 using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
+using Apps2Samsung.Samsung;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -11,7 +12,6 @@ using System.Net;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace Apps2Samsung.Services
 {
@@ -20,7 +20,7 @@ namespace Apps2Samsung.Services
         private IWebHost? _callbackServer;
 
         private string CallbackUrl =>
-            $"http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}{Constants.Samsung.CallbackPath}";
+            $"http://{Constants.Samsung.LoopbackHost}:{SamsungOAuth.CallbackPort}{SamsungOAuth.CallbackPath}";
 
         public Action<SamsungAuth>? CallbackReceived;
 
@@ -56,12 +56,7 @@ namespace Apps2Samsung.Services
 
             await service.StartCallbackServer();
 
-            string loginUrl =
-                $"{Constants.Samsung.SignInGateUrl}" +
-                $"?locale=&clientId={Constants.Samsung.OAuthClientId}" +
-                $"&redirect_uri={HttpUtility.UrlEncode(service.CallbackUrl)}" +
-                $"&state={Constants.Samsung.OAuthState}" +
-                $"&tokenType={Constants.Samsung.TokenType}";
+            string loginUrl = SamsungOAuth.BuildAuthorizeUrl(service.CallbackUrl);
 
             try
             {
@@ -91,12 +86,12 @@ namespace Apps2Samsung.Services
         {
             _callbackServer = new WebHostBuilder()
                 .UseKestrel()
-                .UseUrls($"http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}")
+                .UseUrls($"http://{Constants.Samsung.LoopbackHost}:{SamsungOAuth.CallbackPort}")
                 .Configure(app =>
                 {
                     app.Run(async context =>
                     {
-                        if (context.Request.Path == Constants.Samsung.CallbackPath &&
+                        if (context.Request.Path == SamsungOAuth.CallbackPath &&
                             context.Request.Method == "POST")
                         {
                             string body = await new StreamReader(context.Request.Body).ReadToEndAsync();
@@ -116,6 +111,14 @@ namespace Apps2Samsung.Services
 
                                 if (kv[0] == "code")
                                     codeEncoded = Uri.UnescapeDataString(kv[1]);
+                            }
+
+                            // Reject a callback whose state doesn't round-trip (CSRF / stray callback).
+                            if (!SamsungOAuth.IsValidState(state))
+                            {
+                                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                                await context.Response.WriteAsync("Invalid login response (state mismatch).");
+                                return;
                             }
 
                             if (string.IsNullOrWhiteSpace(codeEncoded))
@@ -163,7 +166,7 @@ namespace Apps2Samsung.Services
             await _callbackServer.StartAsync();
 
             Trace.WriteLine(
-                $"[SamsungLoginService] Bound to http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}");
+                $"[SamsungLoginService] Bound to http://{Constants.Samsung.LoopbackHost}:{SamsungOAuth.CallbackPort}");
         }
 
         public async Task StopCallbackServer()


### PR DESCRIPTION
Fixes **"Sign in with Google" doing nothing** in the mobile Samsung login, and folds in the OAuth cleanups the change surfaced. From `samsung-login-google-signin-fix.md`.

### Phase 1 — Android head (`Apps2Samsung.Mobile`)
Root cause: the login ran in a WebView, but `accounts.google.com` rejects embedded WebViews (`disallowed_useragent`), so SignInGate's Google popup went nowhere.

- **Replaced the WebView with a Chrome Custom Tab.** Not Chrome-specific — it uses the device's default browser (Chrome, **Samsung Internet**, Edge, Firefox…), degrades to a normal browser tab if the default has no Custom-Tabs support, and to an `ACTION_VIEW` fallback / clear error if no browser exists. The in-app loopback listener on `:4794` is unchanged, so this now mirrors the desktop head (system browser + loopback POST capture).
- **`AndroidManifest`**: added `<queries>` (CustomTabsService + VIEW/https) for Android 11+ package visibility — without it, provider resolution and the fallback fail silently.
- Removed the spoofed UA, `MixedContentMode`, third-party cookies, and `LoggingClient`. `ReadRequestAsync`/`ParseFormField` kept verbatim.

### Phase 2 — Core/desktop
- **De-duplicated OAuth constants** into the single source of truth `Apps2Samsung.Samsung.SamsungOAuth` (SignInGate URL, client id, state, token type, callback path/port). Desktop's `PerformSamsungLoginAsync` now calls `SamsungOAuth.BuildAuthorizeUrl(...)` instead of inline interpolation.
- **`state` is now validated** on both heads against `SamsungOAuth.State` (one Core impl: `SamsungOAuth.IsValidState`), rejecting a callback whose state doesn't round-trip.

### Build status
- ✅ **Core + desktop** build clean (net10.0, 0 errors).
- ⚠️ **Mobile** (`net10.0-android`) was **not** built — the CI/dev machine has the `maui-android` workload; this environment does not.

### Pre-merge checklist (needs the maui-android machine)
1. Confirm `AndroidX.Browser` is available (I did **not** touch the csproj to avoid guessing a version):
   ```
   dotnet list Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj package --include-transitive | grep -i browser
   ```
   If absent, add `Xamarin.AndroidX.Browser` pinned to the resolved AndroidX version.
2. Build + deploy the Android head.
3. On-device verify: Samsung ID/password (regression), **Google path now shows the real account chooser**, user-cancel completes as cancelled (no hang), immediate re-login (port `4794` re-bind), and — given the audience — **Samsung Internet as default browser**.
4. Desktop login still works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
