### PR TITLE
Release v2.7.1 (beta → master)

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -283,6 +283,8 @@ jobs:
             <key>CFBundlePackageType</key><string>APPL</string>
             <key>LSMinimumSystemVersion</key><string>11.0</string>
           
+            <key>NSLocalNetworkUsageDescription</key>
+            <string>Apps2Samsung scans your local network to find Samsung TVs in Developer Mode.</string>
             <key>CFBundleIconFile</key><string>jellyfin.icns</string>
           </dict>
           </plist>
@@ -331,6 +333,8 @@ jobs:
             <key>CFBundlePackageType</key><string>APPL</string>
             <key>LSMinimumSystemVersion</key><string>11.0</string>
           
+            <key>NSLocalNetworkUsageDescription</key>
+            <string>Apps2Samsung scans your local network to find Samsung TVs in Developer Mode.</string>
             <key>CFBundleIconFile</key><string>jellyfin.icns</string>
           </dict>
           </plist>

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -331,6 +331,8 @@ jobs:
             <key>CFBundlePackageType</key><string>APPL</string>
             <key>LSMinimumSystemVersion</key><string>11.0</string>
 
+            <key>NSLocalNetworkUsageDescription</key>
+            <string>Apps2Samsung scans your local network to find Samsung TVs in Developer Mode.</string>
             <key>CFBundleIconFile</key><string>jellyfin.icns</string>
           </dict>
           </plist>
@@ -379,6 +381,8 @@ jobs:
             <key>CFBundlePackageType</key><string>APPL</string>
             <key>LSMinimumSystemVersion</key><string>11.0</string>
 
+            <key>NSLocalNetworkUsageDescription</key>
+            <string>Apps2Samsung scans your local network to find Samsung TVs in Developer Mode.</string>
             <key>CFBundleIconFile</key><string>jellyfin.icns</string>
           </dict>
           </plist>

--- a/Apps2Samsung.Core/Core/Constants.cs
+++ b/Apps2Samsung.Core/Core/Constants.cs
@@ -74,7 +74,7 @@ namespace Apps2Samsung.Helpers.Core
         {
             public const int TizenDevPort = 26101;
             public const int SamsungTvApiPort = 8001;
-            public const int SamsungLoginCallbackPort = 4794;
+            // Samsung login callback port lives in Apps2Samsung.Samsung.SamsungOAuth.CallbackPort.
         }
 
         /// <summary>
@@ -134,11 +134,8 @@ namespace Apps2Samsung.Helpers.Core
         public static class Samsung
         {
             public const string LoopbackHost = "localhost";
-            public const string CallbackPath = "/signin/callback";
-            public const string OAuthClientId = "v285zxnl3h";
-            public const string OAuthState = "accountcheckdogeneratedstatetext";
-            public const string TokenType = "TOKEN";
-            public const string SignInGateUrl = "https://account.samsung.com/accounts/be1dce529476c1a6d407c4c7578c31bd/signInGate";
+            // OAuth endpoint + parameters (SignInGate URL, client id, state, token type, callback
+            // path) are the single source of truth in Apps2Samsung.Samsung.SamsungOAuth.
             public const string PlatformVd = "VD";
             public const string PrivilegeLevelPublic = "Public";
             public const string DeveloperTypeIndividual = "Individual";

--- a/Apps2Samsung.Core/Core/RegexPatterns.cs
+++ b/Apps2Samsung.Core/Core/RegexPatterns.cs
@@ -124,20 +124,34 @@ namespace Apps2Samsung.Helpers.Core
                 @"<tizen:application\s+id=""(?<pkg>[A-Za-z0-9]+)\.Jellyfin""\s+package=""\k<pkg>""";
 
             /// <summary>
-            /// Pre-compiled regex for Tizen application ID extraction.
+            /// Pre-compiled regex for Tizen application ID extraction. Jellyfin-specific — matches
+            /// only <c>&lt;pkg&gt;.Jellyfin</c> ids. Keep this for the Jellyfin-only patches (e.g.
+            /// FixYouTube) that must never touch non-Jellyfin packages.
             /// </summary>
             public static readonly Regex TizenApplicationId = new(
                 TizenApplicationIdPattern,
                 RegexOptions.Compiled | RegexOptions.Multiline);
 
             /// <summary>
-            /// Creates a pattern to match and replace a specific package ID in config.xml.
+            /// Generic package-id matcher: any <c>&lt;pkg&gt;.&lt;AppName&gt;</c> id whose
+            /// <c>package</c> attribute equals <c>&lt;pkg&gt;</c>. Used to read/rewrite the package id
+            /// for ANY app. Jellyfin variants such as LiteFin use <c>LitefinApp.Litefin</c> (not
+            /// <c>.Jellyfin</c>), so the pattern above silently misses them — which made the [118]
+            /// package-id-conflict retry a no-op and failed the install with "needs a new app id" (#400).
+            /// </summary>
+            public static readonly Regex TizenPackageIdAny = new(
+                @"<tizen:application\s+id=""(?<pkg>[A-Za-z0-9]+)\.[A-Za-z0-9]+""\s+package=""\k<pkg>""",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+            /// <summary>
+            /// Creates a pattern to match a specific package's Tizen application element (any app-name
+            /// suffix, not just <c>.Jellyfin</c>), so the id can be rewritten for any variant.
             /// </summary>
             /// <param name="packageId">The package ID to match.</param>
             /// <returns>The pattern string.</returns>
             public static string CreatePackageIdReplacePattern(string packageId)
             {
-                return $@"<tizen:application\s+id=""{packageId}\.Jellyfin""\s+package=""{packageId}""";
+                return $@"<tizen:application\s+id=""{packageId}\.[A-Za-z0-9]+""\s+package=""{packageId}""";
             }
         }
 

--- a/Apps2Samsung.Core/Diagnostics/FileLog.cs
+++ b/Apps2Samsung.Core/Diagnostics/FileLog.cs
@@ -25,6 +25,23 @@ namespace Apps2Samsung.Diagnostics
         /// <summary>The debug log file created by <see cref="Initialize"/> (null until initialized).</summary>
         public static string? CurrentLogFile { get; private set; }
 
+        /// <summary>
+        /// The platform-appropriate log directory shared by every desktop log writer (Program startup
+        /// and the "Open logs folder" buttons), so they can never drift apart.
+        ///
+        /// On macOS this deliberately lives OUTSIDE the .app bundle, in <c>~/Library/Logs/Apps2Samsung</c>:
+        /// creating a <c>Logs/</c> dir inside the ad-hoc-signed bundle mutates it and breaks static
+        /// signature validation (issue #498). Windows/Linux keep logs next to the binary — unchanged, so
+        /// existing users' log paths stay put. The mobile head uses <c>FileSystem.AppDataDirectory</c>
+        /// directly and never touches this.
+        /// </summary>
+        public static string DefaultLogDirectory =>
+            OperatingSystem.IsMacOS()
+                ? Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    "Library", "Logs", "Apps2Samsung")
+                : Path.Combine(AppContext.BaseDirectory, "Logs");
+
         /// <summary>Adds a file trace listener under <paramref name="logDirectory"/>, tees Console into
         /// it, and logs unhandled exceptions. Idempotent and never throws — logging must not take down
         /// startup.</summary>

--- a/Apps2Samsung.Core/Network/NetworkService.cs
+++ b/Apps2Samsung.Core/Network/NetworkService.cs
@@ -144,7 +144,12 @@ namespace Apps2Samsung.Services
                                 }
                             }
                         }
-                        catch { /* Ignore scan failures */ }
+                        catch (Exception ex)
+                        {
+                            // Don't let one host's failure abort the sweep, but no longer swallow it
+                            // silently — log so a systematic failure (e.g. an OS-level block) is visible.
+                            Trace.WriteLine($"[Scan] host probe failed: {ex.GetType().Name} — {ex.Message}");
+                        }
                     })));
 
             Trace.WriteLine($"Scan complete! Found {foundDevices.Count} device(s) (debug port {TizenDevPort} or REST API {SamsungTvApiPort}).");
@@ -199,8 +204,25 @@ namespace Apps2Samsung.Services
                 await client.ConnectAsync(ip, port, ct);
                 return true;
             }
-            catch
+            catch (OperationCanceledException)
             {
+                return false; // normal: per-probe timeout / linked-CTS cancellation
+            }
+            catch (Exception ex)
+            {
+                // A subnet sweep expects most probes to fail with refused/timeout/unreachable, so keep
+                // those quiet. Anything else is surfaced instead of silently swallowed — notably macOS
+                // Local Network privacy, which blocks the connect with "Operation not permitted"
+                // (SocketError.AccessDenied). That log line is what tells us a connect was denied by
+                // the OS rather than the host simply being absent (see #498).
+                var normal = ex is SocketException se && se.SocketErrorCode is
+                    SocketError.ConnectionRefused or SocketError.TimedOut or
+                    SocketError.HostUnreachable or SocketError.NetworkUnreachable;
+                if (!normal)
+                {
+                    var code = (ex as SocketException)?.SocketErrorCode.ToString() ?? ex.GetType().Name;
+                    Trace.WriteLine($"[Scan] connect {ip}:{port} failed unexpectedly ({code}): {ex.Message}");
+                }
                 return false;
             }
         }

--- a/Apps2Samsung.Core/Samsung/SamsungOAuth.cs
+++ b/Apps2Samsung.Core/Samsung/SamsungOAuth.cs
@@ -24,5 +24,13 @@ namespace Apps2Samsung.Samsung
             $"{SignInGateUrl}?locale=&clientId={ClientId}" +
             $"&redirect_uri={Uri.EscapeDataString(redirectUri)}" +
             $"&state={State}&tokenType={TokenType}";
+
+        /// <summary>
+        /// True when the <c>state</c> returned on the callback matches the value we sent in
+        /// <see cref="BuildAuthorizeUrl"/>. The single implementation both heads use to reject a
+        /// callback whose state doesn't round-trip (CSRF / stray callback protection).
+        /// </summary>
+        public static bool IsValidState(string? state) =>
+            string.Equals(state, State, StringComparison.Ordinal);
     }
 }

--- a/Apps2Samsung.Mobile/Platforms/Android/AndroidManifest.xml
+++ b/Apps2Samsung.Mobile/Platforms/Android/AndroidManifest.xml
@@ -3,4 +3,15 @@
 	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true" android:networkSecurityConfig="@xml/network_security_config"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
+	<!-- Android 11+ package visibility: without this, Custom Tabs provider resolution and the
+	     ActionView browser fallback both fail silently. -->
+	<queries>
+		<intent>
+			<action android:name="android.support.customtabs.action.CustomTabsService" />
+		</intent>
+		<intent>
+			<action android:name="android.intent.action.VIEW" />
+			<data android:scheme="https" />
+		</intent>
+	</queries>
 </manifest>

--- a/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
@@ -182,7 +182,7 @@ public class SamsungLoginActivity : Activity
     // the callback arrives over a socket, not an intent filter.
     private void BringToFront() =>
         StartActivity(new AndroidIntent(this, typeof(SamsungLoginActivity))
-            .AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop));
+            .AddFlags(global::Android.Content.ActivityFlags.ClearTop | global::Android.Content.ActivityFlags.SingleTop));
 
     protected override void OnDestroy()
     {

--- a/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
@@ -1,60 +1,108 @@
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using Android.Webkit;
+using AndroidX.Browser.CustomTabs;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using Apps2Samsung.Samsung;
+using AndroidIntent = Android.Content.Intent;
 using AndroidUri = Android.Net.Uri;
-using AndroidWebView = Android.Webkit.WebView;
 
 namespace Apps2Samsung.Mobile.Platforms.Android;
 
-// Hosts the Samsung SignInGate in a WebView and captures the token it POSTs to the redirect_uri.
-// A WebView URL-intercept can't read a POST body, so we run a tiny in-app loopback listener on
-// :4794 (same role as the desktop Kestrel callback) and point the redirect at it. Proven on-device
-// by the tizen-sdb Probe; this is that recipe wrapped behind SamsungLoginService.
-[Activity(Label = "Samsung Login", ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+// Runs the Samsung SignInGate in the system browser (Chrome Custom Tab) and captures the token it
+// POSTs to the redirect_uri via an in-app loopback listener on :4794 — the same contract the desktop
+// head fulfils with Kestrel. An embedded WebView cannot be used here: accounts.google.com rejects
+// embedded user agents (disallowed_useragent), which kills SignInGate's "Sign in with Google" path.
+[Activity(Label = "Samsung Login",
+          LaunchMode = LaunchMode.SingleTask,
+          ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
 public class SamsungLoginActivity : Activity
 {
     // Single-flight bridge to SamsungLoginService: it sets this before launching, the activity
     // completes it with the raw token JSON (or faults/cancels it).
     internal static TaskCompletionSource<string>? Pending;
 
+    private const string StateTabLaunched = "tab_launched";
+
     private TcpListener? _listener;
     private readonly CancellationTokenSource _cts = new();
+    private bool _tabLaunched;
+    private volatile bool _settled;
 
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
         ActionBar?.Hide();
 
-        var web = new AndroidWebView(this);
-        web.Settings.JavaScriptEnabled = true;   // SignInGate needs JS
-        web.Settings.DomStorageEnabled = true;
-        web.Settings.DatabaseEnabled = true;
-        web.Settings.JavaScriptCanOpenWindowsAutomatically = true;
-        web.Settings.SetSupportMultipleWindows(true);
-        // The final redirect goes to http://localhost from an https page — allow it.
-        web.Settings.MixedContentMode = MixedContentHandling.AlwaysAllow;
-        // Samsung's account pages behave badly under the default "; wv" WebView UA.
-        web.Settings.UserAgentString =
-            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/126.0.0.0 Mobile Safari/537.36";
-
-        // Cross-domain login needs cookies, including third-party.
-        CookieManager.Instance!.SetAcceptCookie(true);
-        CookieManager.Instance.SetAcceptThirdPartyCookies(web, true);
-
-        web.SetWebViewClient(new LoggingClient(msg => Fault(new InvalidOperationException(msg))));
-
-        SetContentView(web);
+        _tabLaunched = savedInstanceState?.GetBoolean(StateTabLaunched) ?? false;
 
         _ = Task.Run(() => ListenForCallbackAsync(_cts.Token));
+    }
 
+    protected override void OnSaveInstanceState(Bundle outState)
+    {
+        outState.PutBoolean(StateTabLaunched, _tabLaunched);
+        base.OnSaveInstanceState(outState);
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+
+        // Already resolved (token or error): the CLEAR_TOP intent dismissed the tab and brought
+        // us back, so all that's left is to tear down.
+        if (_settled)
+        {
+            Finish();
+            return;
+        }
+
+        if (!_tabLaunched)
+        {
+            _tabLaunched = true;
+            LaunchTab();
+            return;
+        }
+
+        // Foreground again with nothing captured: the user dismissed the browser tab.
+        Pending?.TrySetCanceled();
+        Pending = null;
+        Finish();
+    }
+
+    private void LaunchTab()
+    {
         var redirect = $"http://localhost:{SamsungOAuth.CallbackPort}{SamsungOAuth.CallbackPath}";
-        web.LoadUrl(SamsungOAuth.BuildAuthorizeUrl(redirect));
+        var url = AndroidUri.Parse(SamsungOAuth.BuildAuthorizeUrl(redirect));
+
+        if (url is null)
+        {
+            Fault(new InvalidOperationException("Could not build the SignInGate authorize URL."));
+            return;
+        }
+
+        try
+        {
+            new CustomTabsIntent.Builder()
+                .SetShowTitle(true)
+                .Build()
+                .LaunchUrl(this, url);
+        }
+        catch (global::Android.Content.ActivityNotFoundException)
+        {
+            // No Custom Tabs provider — fall back to whatever browser is installed.
+            try
+            {
+                StartActivity(new AndroidIntent(AndroidIntent.ActionView, url));
+            }
+            catch (global::Android.Content.ActivityNotFoundException ex)
+            {
+                Fault(new InvalidOperationException(
+                    "No browser is available to complete the Samsung login.", ex));
+            }
+        }
     }
 
     private async Task ListenForCallbackAsync(CancellationToken ct)
@@ -71,24 +119,32 @@ public class SamsungLoginActivity : Activity
 
                 var (method, path, body) = await ReadRequestAsync(stream, ct);
 
-                const string page = "Login captured — return to the app.";
-                var resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n" +
-                           $"Content-Length: {Encoding.UTF8.GetByteCount(page)}\r\nConnection: close\r\n\r\n{page}";
+                // Briefly visible in the browser tab before CLEAR_TOP dismisses it.
+                const string page =
+                    "<!doctype html><meta name=viewport content=\"width=device-width,initial-scale=1\">" +
+                    "<body style=\"font:16px system-ui;padding:2rem\">" +
+                    "Login captured — returning to Apps2Samsung…</body>";
+                var resp = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n" +
+                           $"Content-Length: {Encoding.UTF8.GetByteCount(page)}\r\n" +
+                           "Connection: close\r\n\r\n" + page;
                 await stream.WriteAsync(Encoding.UTF8.GetBytes(resp), ct);
                 await stream.FlushAsync(ct);
 
                 if (method == "POST" && path.StartsWith(SamsungOAuth.CallbackPath, StringComparison.Ordinal))
                 {
+                    // Reject a callback whose state doesn't round-trip (CSRF / stray callback).
+                    var state = ParseFormField(body, "state");
+                    if (!SamsungOAuth.IsValidState(state is null ? null : Uri.UnescapeDataString(state)))
+                    {
+                        Fault(new InvalidOperationException("Samsung login state mismatch — aborting."));
+                        return;
+                    }
+
                     var code = ParseFormField(body, "code");
                     if (!string.IsNullOrWhiteSpace(code))
                     {
                         var tokenJson = Uri.UnescapeDataString(code);
-                        RunOnUiThread(() =>
-                        {
-                            Pending?.TrySetResult(tokenJson);
-                            Pending = null;
-                            Finish();
-                        });
+                        RunOnUiThread(() => Complete(tokenJson));
                         return;
                     }
                 }
@@ -105,12 +161,44 @@ public class SamsungLoginActivity : Activity
         }
     }
 
+    private void Complete(string tokenJson)
+    {
+        _settled = true;
+        Pending?.TrySetResult(tokenJson);
+        Pending = null;
+        BringToFront();
+    }
+
     private void Fault(Exception ex) => RunOnUiThread(() =>
     {
+        _settled = true;
         Pending?.TrySetException(ex);
         Pending = null;
-        Finish();
+        BringToFront();
     });
+
+    // Pops the browser tab off this task and re-enters OnResume, which finishes the activity.
+    // Needed because the tab lives in our task and there is no redirect Intent to close it —
+    // the callback arrives over a socket, not an intent filter.
+    private void BringToFront() =>
+        StartActivity(new AndroidIntent(this, typeof(SamsungLoginActivity))
+            .AddFlags(ActivityFlags.ClearTop | ActivityFlags.SingleTop));
+
+    protected override void OnDestroy()
+    {
+        _cts.Cancel();
+        try { _listener?.Stop(); } catch { /* ignore */ }
+
+        // Only unblock the awaiter if we're leaving without having resolved it.
+        if (!_settled)
+        {
+            Pending?.TrySetCanceled();
+            Pending = null;
+        }
+
+        _cts.Dispose();
+        base.OnDestroy();
+    }
 
     // Minimal HTTP/1.1 request reader: request line + headers, then the Content-Length body.
     private static async Task<(string method, string path, string body)> ReadRequestAsync(
@@ -160,30 +248,5 @@ public class SamsungLoginActivity : Activity
                 return kv[1];
         }
         return null;
-    }
-
-    protected override void OnDestroy()
-    {
-        _cts.Cancel();
-        try { _listener?.Stop(); } catch { /* ignore */ }
-        // If we're leaving without a captured token (user backed out), unblock the awaiter.
-        Pending?.TrySetCanceled();
-        Pending = null;
-        base.OnDestroy();
-    }
-
-    // Keeps navigation inside the WebView and surfaces main-frame load failures (so a failed page
-    // gives the real reason rather than a generic error screen).
-    private sealed class LoggingClient(Action<string> log) : WebViewClient
-    {
-        public override bool ShouldOverrideUrlLoading(AndroidWebView? view, IWebResourceRequest? request)
-            => false; // let the WebView handle every navigation (incl. the localhost POST)
-
-        public override void OnReceivedError(AndroidWebView? view, IWebResourceRequest? request, WebResourceError? error)
-        {
-            if (request?.IsForMainFrame == true)
-                log($"load error {(int?)error?.ErrorCode}: {error?.Description} @ {request?.Url}");
-            base.OnReceivedError(view, request, error);
-        }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -68,13 +68,13 @@
   </ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.6" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.6" />
+    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.6">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>

--- a/Jellyfin2Samsung-CrossOS/Helpers/API/TizenApiClient.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/API/TizenApiClient.cs
@@ -48,10 +48,6 @@ namespace Apps2Samsung.Helpers.API
 
                 var jsonObject = JsonNode.Parse(jsonContent);
 
-                var logFilePath = Path.Combine(AppContext.BaseDirectory, "Logs", $"debug_tv_api_{DateTime.Now:yyyy-MM-dd_HH-mm-ss-fff}.log");
-                await File.WriteAllTextAsync(logFilePath, jsonContent);
-
-
                 var deviceNode = jsonObject?["device"];
                 if (deviceNode == null)
                 {

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -25,7 +25,16 @@ namespace Apps2Samsung.Helpers
 
         // Pre-2.5.1 location: next to the binary. Used once to migrate existing users' settings.
         private static readonly string LegacyFilePath = Path.Combine(FolderPath, FileName);
-        public static readonly string TizenSdbPath = Path.Combine(FolderPath, "Assets", "TizenSDB");
+
+        // Read-only Tizen SDB binary shipped inside the install folder/bundle.
+        public static readonly string BundledTizenSdbPath = Path.Combine(FolderPath, "Assets", "TizenSDB");
+        // Working dir the SDB binary actually runs from. The auto-updater replaces the binary here, so
+        // on macOS it must live OUTSIDE the .app bundle (writing there breaks the code signature and the
+        // TCC Local Network prompt, #498); it's seeded from BundledTizenSdbPath on first use. Windows/
+        // Linux run straight from the bundled copy, unchanged.
+        public static readonly string TizenSdbPath = OperatingSystem.IsMacOS()
+            ? Path.Combine(DataFolderPath, "TizenSDB")
+            : BundledTizenSdbPath;
 
         // Generated signing certificates live in the per-user data dir so they survive app/bundle
         // updates. A macOS .dmg (or an installer) replaces the whole install folder/bundle; if the

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -153,7 +153,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.7.0";
+        public string AppVersion { get; set; } = "v2.7.1";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -37,7 +37,15 @@ namespace Apps2Samsung.Helpers
 
         public static readonly string ProfilePath = Path.Combine(FolderPath, "Assets", "TizenProfile");
         public static readonly string EsbuildPath = Path.Combine(FolderPath, "Assets", "esbuild");
-        public static readonly string DownloadPath = Path.Combine(FolderPath, "Downloads");
+
+        // Downloaded-package (.wgt) cache. On macOS this must NOT live inside the .app bundle: writing
+        // there mutates the ad-hoc-signed bundle and breaks static signature validation (issue #498).
+        // Use ~/Library/Caches; Windows/Linux keep it next to the binary (unchanged).
+        public static readonly string DownloadPath = OperatingSystem.IsMacOS()
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library", "Caches", "Apps2Samsung", "Downloads")
+            : Path.Combine(FolderPath, "Downloads");
 
         private static AppSettings? _instance;
 

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -108,7 +108,7 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
             using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
                 configContent = await reader.ReadToEndAsync();
 
-            var match = RegexPatterns.WgtConfig.TizenApplicationId.Match(configContent);
+            var match = RegexPatterns.WgtConfig.TizenPackageIdAny.Match(configContent);
             return match.Success ? match.Groups["pkg"].Value : null;
         }
         public static async Task<string?> ReadExtractedWgtPackageId(string workspaceRoot)
@@ -118,7 +118,7 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
                 return null;
 
             var configContent = await File.ReadAllTextAsync(configPath, Encoding.UTF8);
-            var match = RegexPatterns.WgtConfig.TizenApplicationId.Match(configContent);
+            var match = RegexPatterns.WgtConfig.TizenPackageIdAny.Match(configContent);
             return match.Success ? match.Groups["pkg"].Value : null;
         }
         public static async Task<bool> ModifyWgtPackageId(string wgtPath)

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/ProcessHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/ProcessHelper.cs
@@ -62,15 +62,15 @@ namespace Apps2Samsung.Helpers.Core
                 WorkingDirectory = workingDirectory ?? ""
             };
 
-            // Build log file path (next to app .exe)
-            string exeDir = AppContext.BaseDirectory;
+            // Build log file path. Shares FileLog's directory so it stays OUT of the .app bundle on
+            // macOS — writing next to the binary mutates the signed bundle and breaks TCC (issue #498).
             string timestamp = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss-fff");
             string firstTwoArgs = GetFirstArguments(arguments);
             string sanitizedArguments = new(firstTwoArgs.Where(c => char.IsLetterOrDigit(c) || c == '_' || c == '-').ToArray());
             if (string.IsNullOrEmpty(sanitizedArguments))
                 sanitizedArguments = "unknown";
 
-            string logFolder = Path.Combine(exeDir, "Logs");
+            string logFolder = Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory;
             string logFilePath = Path.Combine(logFolder, $"process_{sanitizedArguments}_{timestamp}.log");
 
             try
@@ -102,7 +102,7 @@ namespace Apps2Samsung.Helpers.Core
                 // Always write everything to a log file
                 try
                 {
-                    Directory.CreateDirectory(exeDir);
+                    Directory.CreateDirectory(logFolder);
                     await File.WriteAllTextAsync(logFilePath, result.Output);
                     result.Output += $"\n[Log written to: {logFilePath}]";
                 }

--- a/Jellyfin2Samsung-CrossOS/Program.cs
+++ b/Jellyfin2Samsung-CrossOS/Program.cs
@@ -12,7 +12,8 @@ namespace Apps2Samsung
         public static void Main(string[] args)
         {
             // Route Trace to a file BEFORE Avalonia starts (shared with the mobile head via Core).
-            Apps2Samsung.Diagnostics.FileLog.Initialize(Path.Combine(AppContext.BaseDirectory, "Logs"));
+            // DefaultLogDirectory keeps logs OUT of the .app bundle on macOS (see FileLog / issue #498).
+            Apps2Samsung.Diagnostics.FileLog.Initialize(Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory);
 
 
             BuildAvaloniaApp()

--- a/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
@@ -222,7 +222,7 @@ namespace Apps2Samsung.Services
                 {
                     try
                     {
-                        var logFolder = Path.Combine(AppContext.BaseDirectory, "Logs");
+                        var logFolder = Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory;
                         Directory.CreateDirectory(logFolder);
 
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/ProviderManifestService.cs
@@ -20,8 +20,13 @@ namespace Apps2Samsung.Services
         private static readonly Uri BundledUri =
             new("avares://Apps2Samsung/Assets/third-party-apps.json");
 
-        private static readonly string CachePath =
-            Path.Combine(AppSettings.FolderPath, "third-party-apps.cache.json");
+        // The remote-manifest cache. On macOS this must NOT live next to the binary: writing it into
+        // the .app bundle mutates it and breaks the code signature / TCC Local Network prompt (#498).
+        private static readonly string CachePath = OperatingSystem.IsMacOS()
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library", "Caches", "Apps2Samsung", "third-party-apps.cache.json")
+            : Path.Combine(AppSettings.FolderPath, "third-party-apps.cache.json");
 
         private readonly HttpClient _httpClient;
 
@@ -103,6 +108,7 @@ namespace Apps2Samsung.Services
         {
             try
             {
+                Directory.CreateDirectory(Path.GetDirectoryName(CachePath)!);
                 File.WriteAllText(CachePath, json);
             }
             catch (Exception ex)

--- a/Jellyfin2Samsung-CrossOS/Services/SamsungLoginService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/SamsungLoginService.cs
@@ -1,6 +1,7 @@
 using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
+using Apps2Samsung.Samsung;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -11,7 +12,6 @@ using System.Net;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace Apps2Samsung.Services
 {
@@ -20,7 +20,7 @@ namespace Apps2Samsung.Services
         private IWebHost? _callbackServer;
 
         private string CallbackUrl =>
-            $"http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}{Constants.Samsung.CallbackPath}";
+            $"http://{Constants.Samsung.LoopbackHost}:{SamsungOAuth.CallbackPort}{SamsungOAuth.CallbackPath}";
 
         public Action<SamsungAuth>? CallbackReceived;
 
@@ -56,12 +56,7 @@ namespace Apps2Samsung.Services
 
             await service.StartCallbackServer();
 
-            string loginUrl =
-                $"{Constants.Samsung.SignInGateUrl}" +
-                $"?locale=&clientId={Constants.Samsung.OAuthClientId}" +
-                $"&redirect_uri={HttpUtility.UrlEncode(service.CallbackUrl)}" +
-                $"&state={Constants.Samsung.OAuthState}" +
-                $"&tokenType={Constants.Samsung.TokenType}";
+            string loginUrl = SamsungOAuth.BuildAuthorizeUrl(service.CallbackUrl);
 
             try
             {
@@ -91,12 +86,12 @@ namespace Apps2Samsung.Services
         {
             _callbackServer = new WebHostBuilder()
                 .UseKestrel()
-                .UseUrls($"http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}")
+                .UseUrls($"http://{Constants.Samsung.LoopbackHost}:{SamsungOAuth.CallbackPort}")
                 .Configure(app =>
                 {
                     app.Run(async context =>
                     {
-                        if (context.Request.Path == Constants.Samsung.CallbackPath &&
+                        if (context.Request.Path == SamsungOAuth.CallbackPath &&
                             context.Request.Method == "POST")
                         {
                             string body = await new StreamReader(context.Request.Body).ReadToEndAsync();
@@ -116,6 +111,14 @@ namespace Apps2Samsung.Services
 
                                 if (kv[0] == "code")
                                     codeEncoded = Uri.UnescapeDataString(kv[1]);
+                            }
+
+                            // Reject a callback whose state doesn't round-trip (CSRF / stray callback).
+                            if (!SamsungOAuth.IsValidState(state))
+                            {
+                                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                                await context.Response.WriteAsync("Invalid login response (state mismatch).");
+                                return;
                             }
 
                             if (string.IsNullOrWhiteSpace(codeEncoded))
@@ -163,7 +166,7 @@ namespace Apps2Samsung.Services
             await _callbackServer.StartAsync();
 
             Trace.WriteLine(
-                $"[SamsungLoginService] Bound to http://{Constants.Samsung.LoopbackHost}:{Constants.Ports.SamsungLoginCallbackPort}");
+                $"[SamsungLoginService] Bound to http://{Constants.Samsung.LoopbackHost}:{SamsungOAuth.CallbackPort}");
         }
 
         public async Task StopCallbackServer()

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -60,6 +60,25 @@ namespace Apps2Samsung.Services
         public async Task<string> EnsureTizenSdbAvailable()
         {
             string tizenSdbPath = AppSettings.TizenSdbPath;
+
+            // On macOS the SDB runs from a writable per-user dir (see AppSettings.TizenSdbPath): the
+            // updater rewrites the binary and doing that inside the signed .app bundle breaks TCC
+            // (#498). Seed it from the read-only bundled copy on first use.
+            if (OperatingSystem.IsMacOS() && tizenSdbPath != AppSettings.BundledTizenSdbPath)
+            {
+                Directory.CreateDirectory(tizenSdbPath);
+                if (!Directory.EnumerateFileSystemEntries(tizenSdbPath).Any()
+                    && Directory.Exists(AppSettings.BundledTizenSdbPath))
+                {
+                    foreach (var src in Directory.GetFiles(AppSettings.BundledTizenSdbPath))
+                    {
+                        var dest = Path.Combine(tizenSdbPath, Path.GetFileName(src));
+                        File.Copy(src, dest, overwrite: true);
+                        await _processHelper.MakeExecutableAsync(dest);
+                    }
+                }
+            }
+
             if (!Directory.Exists(tizenSdbPath))
             {
                 throw new InvalidOperationException(

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -1028,8 +1028,12 @@ namespace Apps2Samsung.Services
                 if (_appSettings.TryOverwrite)
                 {
                     _appSettings.TryOverwrite = false;
-                    await FileHelper.ModifyWgtPackageId(packageUrl);
-                    return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
+                    // Give the package a fresh random id and retry. Only retry if the id was actually
+                    // rewritten — if the config couldn't be read/modified (previously silent for any
+                    // non-".Jellyfin" variant like LiteFin, #400), retrying would hit the identical
+                    // [118] conflict, so fall through to a clear failure instead.
+                    if (await FileHelper.ModifyWgtPackageId(packageUrl))
+                        return await InstallPackageAsync(packageUrl, tvIpAddress, cancellationToken, progress, onSamsungLoginStarted, wasAlreadyInstalled);
                 }
 
                 _appSettings.TryOverwrite = false;

--- a/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
@@ -275,7 +275,7 @@ namespace Apps2Samsung.ViewModels
         {
             try
             {
-                var logFolder = Path.Combine(AppContext.BaseDirectory, "Logs");
+                var logFolder = Apps2Samsung.Diagnostics.FileLog.DefaultLogDirectory;
                 Directory.CreateDirectory(logFolder);
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | Channel    | Version                                                             | Notes                        |
 |------------|---------------------------------------------------------------------|------------------------------|
 | **Stable** | [v2.7.0](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.7.0)                                        | Recommended for most users   |
-| **Beta**   | [N/A](#)                                            | Includes new features        |
+| **Beta**   | [v2.7.1-beta](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.7.1-beta)                                            | Includes new features        |
 
 <!-- versions:end -->
 


### PR DESCRIPTION
Promotes **beta → master** to publish **v2.7.1** stable.

Follow-up to v2.7.0: this rolls up the Samsung-login and OAuth work plus the version bump.

### 🔏 Samsung login
- **Android: "Sign in with Google" now works** — the mobile login opens in the system browser (Chrome Custom Tab) instead of an embedded WebView, which Google blocks (`disallowed_useragent`). Falls back to any installed browser, then a clear error if none. (#505)
- **Callback `state` is now validated** on both desktop and mobile against the value we sent (one shared `SamsungOAuth.IsValidState`), rejecting a callback that doesn't round-trip.
- OAuth endpoint/parameters de-duplicated into the single `SamsungOAuth` source of truth.

### 🛠️ Fixes
- Android APK build: fully-qualify `Android.Content.ActivityFlags` (was breaking the release build).

Version bumped `v2.7.0` → `v2.7.1`.

**Full Changelog**: https://github.com/Apps2Samsung/Apps2Samsung/compare/v2.7.0...beta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
