### PR TITLE
Strip Partner-only privileges for public installs on old TVs (LiteFin #400)

### DIFF
--- a/Apps2Samsung.Core/Packaging/WgtPrivileges.cs
+++ b/Apps2Samsung.Core/Packaging/WgtPrivileges.cs
@@ -18,6 +18,19 @@ namespace Apps2Samsung.Packaging
             "http://tizen.org/privilege/vpnservice",
         };
 
+        // Partner-only / Samsung-restricted privileges that a PUBLIC-signed package must not declare on
+        // old firmware: pre-Tizen-4 TVs reject the whole install with a generic install failed[118]
+        // when a public cert requests one (#400 — LiteFin declares SmartHub 'preview'). Newer TVs just
+        // ignore an ungranted privilege, and Partner-signed installs are entitled to them, so these are
+        // only stripped for a public install on an old TV — never when Partner signing is in effect.
+        // Deliberately NOT in PartnerPrivileges: adding them there would force Partner signing, which
+        // retail TVs/individual accounts often can't obtain — the point is to install *public*.
+        public static readonly IReadOnlyCollection<string> PublicIncompatiblePrivileges =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "http://developer.samsung.com/privilege/preview",
+        };
+
         // .wgt / config.xml: <tizen:privilege name="http://tizen.org/privilege/..."/>
         private static readonly Regex WebPrivilege = new(
             @"<tizen:privilege\b[^>]*\bname\s*=\s*""(?<name>[^""]+)""",

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -264,6 +264,63 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
         /// background-service components. Returns true if anything was removed (the wgt must be
         /// re-signed afterwards — the caller re-enters the install flow which re-signs).
         /// </summary>
+        /// <summary>
+        /// Removes Partner-only <c>&lt;tizen:privilege&gt;</c> declarations (see
+        /// <see cref="Apps2Samsung.Packaging.WgtPrivileges.PublicIncompatiblePrivileges"/>) from the
+        /// package's config.xml so a public-signed package installs on old TVs that otherwise reject it
+        /// with a generic <c>install failed[118]</c> (#400). Returns true if anything was removed (the
+        /// wgt must be re-signed afterwards — the caller re-enters the install flow which re-signs).
+        /// </summary>
+        public static async Task<bool> StripWgtIncompatiblePrivileges(string wgtPath)
+        {
+            if (!File.Exists(wgtPath))
+                return false;
+
+            var toStrip = Apps2Samsung.Packaging.WgtPrivileges.PublicIncompatiblePrivileges;
+            if (toStrip.Count == 0)
+                return false;
+
+            using var memoryStream = new MemoryStream();
+            using (var originalStream = File.OpenRead(wgtPath))
+                await originalStream.CopyToAsync(memoryStream);
+
+            memoryStream.Position = 0;
+
+            bool changed = false;
+            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Update, true))
+            {
+                var configEntry = archive.GetEntry("config.xml");
+                if (configEntry == null)
+                    return false;
+
+                string configContent;
+                using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
+                    configContent = await reader.ReadToEndAsync();
+
+                var newConfig = configContent;
+                foreach (var priv in toStrip)
+                {
+                    // Drop the whole <tizen:privilege ... name="<priv>" .../> element (any attribute order).
+                    var pattern = $@"[ \t]*<tizen:privilege\b[^>]*\bname\s*=\s*""{Regex.Escape(priv)}""[^>]*/>\s*\r?\n?";
+                    newConfig = Regex.Replace(newConfig, pattern, string.Empty, RegexOptions.IgnoreCase);
+                }
+
+                if (newConfig == configContent)
+                    return false;
+
+                changed = true;
+                configEntry.Delete();
+                var newEntry = archive.CreateEntry("config.xml");
+                using var writer = new StreamWriter(newEntry.Open(), Encoding.UTF8);
+                await writer.WriteAsync(newConfig);
+            }
+
+            if (changed)
+                await File.WriteAllBytesAsync(wgtPath, memoryStream.ToArray());
+
+            return changed;
+        }
+
         public static async Task<bool> StripWgtServiceComponent(string wgtPath)
         {
             if (!File.Exists(wgtPath))

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -392,6 +392,19 @@ namespace Apps2Samsung.Services
                         Trace.WriteLine($"Device Tizen {deviceInfo.TizenVersion} < {serviceSupport}: removed bundled background service so the package can install");
                 }
 
+                // Step 3c: Old TVs (below Tizen 4.0) reject a PUBLIC-signed package that declares a
+                // Partner-only privilege (e.g. SmartHub 'preview') with the same generic install
+                // failed[118] (#400 — LiteFin). When we're not Partner-signing this package, strip
+                // those privileges so the main app still installs; Partner-signed installs keep them.
+                bool signingPartner = _appSettings.PartnerSigning
+                                      || _appSettings.RequiresPartnerSigning
+                                      || Apps2Samsung.Packaging.WgtPrivileges.RequiresPartner(packageUrl);
+                if (deviceInfo.TizenVersion < serviceSupport && !signingPartner)
+                {
+                    if (await FileHelper.StripWgtIncompatiblePrivileges(packageUrl))
+                        Trace.WriteLine($"Device Tizen {deviceInfo.TizenVersion} < {serviceSupport}: removed Partner-only privilege(s) so the public-signed package can install");
+                }
+
                 // Step 4: Handle certificate selection/generation
                 var certificateResult = await HandleCertificateAsync(
                     tvIpAddress,


### PR DESCRIPTION
Follow-up to #504. #504 fixed a real bug (the id-rewrite was a no-op for non-`.Jellyfin` variants) but **LiteFin still failed** — OdinK03's logs show the id-rewrite now works (`install 9ref5axlbs.Litefin`, `V0vHqCXC9p.Litefin`) yet each attempt still `failed[118]`. So `[118]` was never an id conflict.

## Real root cause (from comparing packages)
Diffing LiteFin's **ultra-legacy** `config.xml` against the variants that install on the same TV:

| privilege | Moonfin | AVPlay | LiteFin |
|---|:-:|:-:|:-:|
| `developer.samsung.com/privilege/preview` (SmartHub — **Partner-level**) | ✗ | ✗ | **✓** |

The auto-Partner detector (`WgtPrivileges.RequiresPartner`) only knows `vpnservice`, so LiteFin is signed **public**, and pre-Tizen-4 firmware rejects a public cert that declares a Partner privilege with a generic `install failed[118]`. This is the exact sibling of the existing **Step 3b**, where a bundled `<tizen:service>` triggers the same `[118]` on old TVs and gets stripped.

## Change
- **`WgtPrivileges.PublicIncompatiblePrivileges`** — Partner-only privileges a public package must not declare on old firmware (currently `preview`). Deliberately **not** added to `PartnerPrivileges`: that would *force* Partner signing, which retail TVs / individual accounts often can't obtain — the goal is to install *public*.
- **`FileHelper.StripWgtIncompatiblePrivileges`** — removes those `<tizen:privilege>` lines (mirrors `StripWgtServiceComponent`).
- **Install flow Step 3c** — on Tizen < 4.0, when **not** Partner-signing, strip them so the public package installs. Newer TVs and Partner-signed installs are untouched.

## Verified (no TV needed for this part)
Against the real `Litefin-1.3.0-ultra-legacy.wgt`: removes **exactly** the `preview` privilege (15 → 14), result is **valid XML**, every other privilege intact. Builds clean, 0 errors.

## ⚠️ Needs on-device confirmation
This is a **candidate fix** — the "public cert + Partner privilege → `[118]` on Tizen 2.4" mechanism is well-evidenced but not yet confirmed on hardware (OdinK03 is back in ~a week). If `[118]` persists after this, the next suspects are the other non-standard privileges LiteFin declares (e.g. the malformed `developer.samsung.com/privilege/network.public`). Complementary upstream angle: LiteFin arguably shouldn't ship `preview`/malformed privileges in a public build (worth raising with MoazSalem).