### PR TITLE
Backup: export/import settings + certificates (PC ↔ Mac ↔ phone) — bump 2.7.2 (#510)

### DIFF
--- a/Apps2Samsung.Core/Portability/BackupService.cs
+++ b/Apps2Samsung.Core/Portability/BackupService.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace Apps2Samsung.Backup
+{
+    /// <summary>What <see cref="BackupService.Import"/> pulled out of a backup archive.</summary>
+    /// <param name="SettingsJson">The raw <c>settings.json</c> content (desktop AppSettings schema), or
+    /// null if the archive had none. Each head decides how to apply it (desktop merges into its
+    /// settings.json; mobile maps the known keys into Preferences).</param>
+    /// <param name="CertificateFilesRestored">How many certificate files were written back.</param>
+    public sealed record BackupImportResult(string? SettingsJson, int CertificateFilesRestored);
+
+    /// <summary>
+    /// Head-agnostic settings + certificate backup. Produces/consumes a single .zip so a config can move
+    /// PC ↔ Mac ↔ mobile (#510). The archive holds:
+    ///   • <c>settings.json</c>  — the settings blob (desktop AppSettings JSON schema; the shared format
+    ///                             both heads read/write, so keys line up across platforms).
+    ///   • <c>Certificate/…</c>  — the generated signing profiles (the folder each head exposes as
+    ///                             <see cref="Apps2Samsung.Configuration.IAppConfig.CertificateStorePath"/>),
+    ///                             so the Samsung login + already-installed apps' signing survive the move.
+    /// Both heads store certs under the same relative <c>Certificate/</c> layout, so that half is uniform;
+    /// only the settings mapping is head-specific and lives in each head.
+    /// </summary>
+    public static class BackupService
+    {
+        public const string SettingsEntryName = "settings.json";
+        private const string CertPrefix = "Certificate/";
+
+        /// <summary>Write <paramref name="settingsJson"/> and the whole <paramref name="certificateStorePath"/>
+        /// tree into <paramref name="zipOutput"/>. The stream is left open for the caller to dispose.</summary>
+        public static void Export(Stream zipOutput, string? settingsJson, string certificateStorePath)
+        {
+            using var zip = new ZipArchive(zipOutput, ZipArchiveMode.Create, leaveOpen: true);
+
+            if (!string.IsNullOrEmpty(settingsJson))
+            {
+                var entry = zip.CreateEntry(SettingsEntryName, CompressionLevel.Optimal);
+                using var writer = new StreamWriter(entry.Open());
+                writer.Write(settingsJson);
+            }
+
+            if (Directory.Exists(certificateStorePath))
+            {
+                foreach (var file in Directory.EnumerateFiles(certificateStorePath, "*", SearchOption.AllDirectories))
+                {
+                    var rel = Path.GetRelativePath(certificateStorePath, file).Replace('\\', '/');
+                    zip.CreateEntryFromFile(file, CertPrefix + rel, CompressionLevel.Optimal);
+                }
+            }
+        }
+
+        /// <summary>Restore certificates into <paramref name="certificateStorePath"/> (overwriting) and
+        /// return the archive's settings.json for the caller to apply.</summary>
+        public static BackupImportResult Import(Stream zipInput, string certificateStorePath)
+        {
+            string? settingsJson = null;
+            int certFiles = 0;
+
+            using var zip = new ZipArchive(zipInput, ZipArchiveMode.Read);
+            var certRoot = Path.GetFullPath(certificateStorePath);
+
+            foreach (var entry in zip.Entries)
+            {
+                if (entry.FullName.Equals(SettingsEntryName, StringComparison.OrdinalIgnoreCase))
+                {
+                    using var reader = new StreamReader(entry.Open());
+                    settingsJson = reader.ReadToEnd();
+                }
+                else if (entry.FullName.StartsWith(CertPrefix, StringComparison.OrdinalIgnoreCase)
+                         && !string.IsNullOrEmpty(entry.Name))
+                {
+                    var rel = entry.FullName.Substring(CertPrefix.Length).Replace('/', Path.DirectorySeparatorChar);
+                    var dest = Path.GetFullPath(Path.Combine(certificateStorePath, rel));
+
+                    // Zip-slip guard: never write outside the certificate store.
+                    if (!dest.StartsWith(certRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                        && !dest.Equals(certRoot, StringComparison.Ordinal))
+                        continue;
+
+                    Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+                    entry.ExtractToFile(dest, overwrite: true);
+                    certFiles++;
+                }
+            }
+
+            return new BackupImportResult(settingsJson, certFiles);
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -35,8 +35,8 @@
 		<ApplicationId>nl.madebypatrick.apps2samsung</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>2.7.0</ApplicationDisplayVersion>
-		<ApplicationVersion>1</ApplicationVersion>
+		<ApplicationDisplayVersion>2.7.2</ApplicationDisplayVersion>
+		<ApplicationVersion>2</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<WindowsPackageType>None</WindowsPackageType>

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -154,6 +154,23 @@
 
                 <BoxView Style="{StaticResource Divider}" />
 
+                <!-- Backup -->
+                <Label Text="Backup" FontAttributes="Bold" FontSize="14" />
+                <Label Style="{StaticResource Hint}"
+                       Text="Save your settings and signing certificates to a .zip you can move to another device, or restore from one. Certificates are restored immediately; restart the app to apply imported settings." />
+                <Button Text="📦 Export backup" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="14,8"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                        Clicked="OnExportBackupClicked" />
+                <Button Text="📥 Import backup" HorizontalOptions="Start"
+                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="14,8"
+                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                        Clicked="OnImportBackupClicked" />
+
+                <BoxView Style="{StaticResource Divider}" />
+
                 <!-- Diagnostics -->
                 <Label Text="Diagnostics" FontAttributes="Bold" FontSize="14" />
                 <Label Style="{StaticResource Hint}"

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Text.Json.Nodes;
+using Apps2Samsung.Backup;
 using Apps2Samsung.Mobile.Services;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
 using Microsoft.Maui.Storage;
@@ -74,6 +76,142 @@ public partial class SettingsPage : ContentPage
 		{
 			await DisplayAlert("Debug log", $"Couldn't share the log: {ex.Message}", "OK");
 		}
+	}
+
+	// ---- Backup (export/import of settings + signing certificates) ----
+	// Uses the head-agnostic Apps2Samsung.Backup.BackupService: the archive holds a settings.json
+	// (desktop AppSettings schema, so configs move PC ↔ Mac ↔ mobile) plus the whole Certificate/ tree.
+
+	private static string CertStorePath => new MobileAppConfig().CertificateStorePath;
+
+	// Serialize the mobile settings into the shared desktop AppSettings JSON schema.
+	private static string BuildSettingsJson()
+	{
+		var obj = new JsonObject
+		{
+			["DeletePreviousInstall"] = MobileSettings.DeletePreviousInstall,
+			["OpenAfterInstall"] = MobileSettings.OpenAfterInstall,
+			["KeepWGTFile"] = MobileSettings.KeepWgtFile,
+			["ShowAllJellyfinVersions"] = MobileSettings.ShowAllJellyfinVersions,
+			["ForceSamsungLogin"] = MobileSettings.ForceSamsungLogin,
+			["TryOverwrite"] = MobileSettings.TryOverwrite,
+			["PartnerSigning"] = MobileSettings.PartnerSigning,
+			["ManualDuids"] = MobileSettings.ManualDuids,
+			["GitHubToken"] = MobileSettings.GitHubToken,
+			["JellyfinIP"] = MobileSettings.JellyfinServerUrl,
+			["JellyfinUserId"] = MobileSettings.JellyfinUserId,
+			["JellyfinServerId"] = MobileSettings.JellyfinServerId,
+			["JellyfinServerName"] = MobileSettings.JellyfinServerName,
+			["JellyfinServerLocalAddress"] = MobileSettings.JellyfinServerLocalAddress,
+			["CustomCss"] = MobileSettings.JellyfinCustomCss,
+			["PatchYoutubePlugin"] = MobileSettings.JellyfinPatchYoutube,
+			["JellyfinAccessToken"] = MobileSettings.JellyfinAccessToken,
+			["TvAppChannelsJson"] = MobileSettings.TvAppChannelsJson,
+			["CustomAppIconsJson"] = MobileSettings.CustomAppIconsJson,
+		};
+		return obj.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+	}
+
+	private async void OnExportBackupClicked(object? sender, EventArgs e)
+	{
+		try
+		{
+			var path = Path.Combine(FileSystem.CacheDirectory, "apps2samsung-backup.zip");
+			using (var stream = File.Create(path))
+				BackupService.Export(stream, BuildSettingsJson(), CertStorePath);
+
+			await Share.Default.RequestAsync(new ShareFileRequest("Apps2Samsung backup", new ShareFile(path)));
+		}
+		catch (Exception ex)
+		{
+			await DisplayAlert("Export backup", $"Couldn't export the backup: {ex.Message}", "OK");
+		}
+	}
+
+	private async void OnImportBackupClicked(object? sender, EventArgs e)
+	{
+		try
+		{
+			// Accept .zip archives. FilePickerFileType is per-platform; on Android match by MIME + extension.
+			var zipTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
+			{
+				[DevicePlatform.Android] = new[] { "application/zip", "application/octet-stream" },
+				[DevicePlatform.iOS] = new[] { "public.zip-archive" },
+				[DevicePlatform.MacCatalyst] = new[] { "public.zip-archive" },
+				[DevicePlatform.WinUI] = new[] { ".zip" },
+			});
+
+			var result = await FilePicker.Default.PickAsync(new PickOptions
+			{
+				PickerTitle = "Select an Apps2Samsung backup (.zip)",
+				FileTypes = zipTypes,
+			});
+			if (result is null)
+				return;
+
+			BackupImportResult import;
+			using (var stream = await result.OpenReadAsync())
+				import = BackupService.Import(stream, CertStorePath);
+
+			if (!string.IsNullOrEmpty(import.SettingsJson))
+				await ApplySettingsJsonAsync(import.SettingsJson!);
+
+			// Refresh visible controls from the newly-applied settings.
+			OnAppearing();
+
+			await DisplayAlert(
+				"Import backup",
+				$"Imported settings + {import.CertificateFilesRestored} certificate file(s). Certificates are already restored. Restart the app to fully apply the imported settings.",
+				"OK");
+		}
+		catch (Exception ex)
+		{
+			await DisplayAlert("Import backup", $"Couldn't import the backup: {ex.Message}", "OK");
+		}
+	}
+
+	// Map the shared AppSettings JSON keys back onto MobileSettings. Missing keys are left untouched.
+	private static async Task ApplySettingsJsonAsync(string json)
+	{
+		JsonNode? root;
+		try { root = JsonNode.Parse(json); }
+		catch { return; }
+		if (root is not JsonObject o)
+			return;
+
+		bool? GetBool(string key)
+		{
+			try { return o[key]?.GetValue<bool>(); }
+			catch { return null; }
+		}
+		string? GetString(string key)
+		{
+			try { return o[key]?.GetValue<string>(); }
+			catch { return null; }
+		}
+
+		if (GetBool("DeletePreviousInstall") is { } deletePrev) MobileSettings.DeletePreviousInstall = deletePrev;
+		if (GetBool("OpenAfterInstall") is { } openAfter) MobileSettings.OpenAfterInstall = openAfter;
+		if (GetBool("KeepWGTFile") is { } keepWgt) MobileSettings.KeepWgtFile = keepWgt;
+		if (GetBool("ShowAllJellyfinVersions") is { } showAll) MobileSettings.ShowAllJellyfinVersions = showAll;
+		if (GetBool("ForceSamsungLogin") is { } forceLogin) MobileSettings.ForceSamsungLogin = forceLogin;
+		if (GetBool("TryOverwrite") is { } tryOverwrite) MobileSettings.TryOverwrite = tryOverwrite;
+		if (GetBool("PartnerSigning") is { } partner) MobileSettings.PartnerSigning = partner;
+		if (GetBool("PatchYoutubePlugin") is { } patchYt) MobileSettings.JellyfinPatchYoutube = patchYt;
+
+		if (GetString("ManualDuids") is { } duids) MobileSettings.ManualDuids = duids;
+		if (GetString("JellyfinIP") is { } jfIp) MobileSettings.JellyfinServerUrl = jfIp;
+		if (GetString("JellyfinUserId") is { } jfUser) MobileSettings.JellyfinUserId = jfUser;
+		if (GetString("JellyfinServerId") is { } jfServer) MobileSettings.JellyfinServerId = jfServer;
+		if (GetString("JellyfinServerName") is { } jfName) MobileSettings.JellyfinServerName = jfName;
+		if (GetString("JellyfinServerLocalAddress") is { } jfLocal) MobileSettings.JellyfinServerLocalAddress = jfLocal;
+		if (GetString("CustomCss") is { } css) MobileSettings.JellyfinCustomCss = css;
+		if (GetString("TvAppChannelsJson") is { } channels) MobileSettings.TvAppChannelsJson = channels;
+		if (GetString("CustomAppIconsJson") is { } icons) MobileSettings.CustomAppIconsJson = icons;
+
+		// Secrets go through the async SecureStorage-backed setters.
+		if (GetString("GitHubToken") is { } token) await MobileSettings.SetGitHubTokenAsync(token);
+		if (GetString("JellyfinAccessToken") is { } accessToken) await MobileSettings.SetJellyfinAccessTokenAsync(accessToken);
 	}
 
 	private void OnToggleTokenVisibility(object? sender, EventArgs e)

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -153,7 +153,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.7.1";
+        public string AppVersion { get; set; } = "v2.7.2";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
@@ -1,3 +1,6 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -11,6 +14,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 
 namespace Apps2Samsung.ViewModels
 {
@@ -268,6 +274,117 @@ namespace Apps2Samsung.ViewModels
             {
                 return code;
             }
+        }
+
+        [ObservableProperty]
+        private string backupStatus = string.Empty;
+
+        // Export settings.json + the generated signing certificates to a single .zip the user can copy
+        // to another computer or phone (#510). Uses the shared Core BackupService so the archive format
+        // matches the mobile head.
+        [RelayCommand]
+        private async Task ExportBackup()
+        {
+            try
+            {
+                var storage = GetActiveStorageProvider();
+                if (storage is null)
+                    return;
+
+                var file = await storage.SaveFilePickerAsync(new FilePickerSaveOptions
+                {
+                    Title = "Export backup",
+                    SuggestedFileName = "apps2samsung-backup.zip",
+                    DefaultExtension = "zip",
+                    FileTypeChoices = new[]
+                    {
+                        new FilePickerFileType("Apps2Samsung backup") { Patterns = new[] { "*.zip" } }
+                    }
+                });
+                if (file is null)
+                    return;
+
+                var settingsJson = JsonSerializer.Serialize(AppSettings.Default,
+                    new JsonSerializerOptions { WriteIndented = true });
+
+                await using (var stream = await file.OpenWriteAsync())
+                    Apps2Samsung.Backup.BackupService.Export(stream, settingsJson, AppSettings.CertificatePath);
+
+                BackupStatus = "Backup exported.";
+            }
+            catch (Exception ex)
+            {
+                BackupStatus = $"Export failed: {ex.Message}";
+                Trace.WriteLine($"[Backup] export failed: {ex}");
+            }
+        }
+
+        // Import a backup .zip: restore the certificates and merge the settings. Settings take effect on
+        // next launch.
+        [RelayCommand]
+        private async Task ImportBackup()
+        {
+            try
+            {
+                var storage = GetActiveStorageProvider();
+                if (storage is null)
+                    return;
+
+                var files = await storage.OpenFilePickerAsync(new FilePickerOpenOptions
+                {
+                    Title = "Import backup",
+                    AllowMultiple = false,
+                    FileTypeFilter = new[]
+                    {
+                        new FilePickerFileType("Apps2Samsung backup") { Patterns = new[] { "*.zip" } }
+                    }
+                });
+                var file = files.FirstOrDefault();
+                if (file is null)
+                    return;
+
+                Apps2Samsung.Backup.BackupImportResult result;
+                await using (var stream = await file.OpenReadAsync())
+                    result = Apps2Samsung.Backup.BackupService.Import(stream, AppSettings.CertificatePath);
+
+                if (!string.IsNullOrEmpty(result.SettingsJson))
+                    MergeImportedSettings(result.SettingsJson!);
+
+                BackupStatus = $"Imported settings + {result.CertificateFilesRestored} certificate file(s). Restart the app to apply.";
+            }
+            catch (Exception ex)
+            {
+                BackupStatus = $"Import failed: {ex.Message}";
+                Trace.WriteLine($"[Backup] import failed: {ex}");
+            }
+        }
+
+        // Merge the imported settings.json into the current settings.json: imported keys win, and keys the
+        // backup doesn't contain (e.g. desktop-only fields absent from a mobile export) keep their current
+        // value, so importing never silently resets unrelated settings. Applied on next Load().
+        private static void MergeImportedSettings(string importedJson)
+        {
+            var current = JsonNode.Parse(JsonSerializer.Serialize(AppSettings.Default))?.AsObject() ?? new JsonObject();
+            var imported = JsonNode.Parse(importedJson)?.AsObject();
+            if (imported is not null)
+            {
+                foreach (var kv in imported)
+                    current[kv.Key] = kv.Value?.DeepClone();
+            }
+
+            var dir = Path.GetDirectoryName(AppSettings.FilePath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(AppSettings.FilePath,
+                current.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        private static IStorageProvider? GetActiveStorageProvider()
+        {
+            if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+                return (desktop.Windows.FirstOrDefault(w => w.IsActive) ?? desktop.MainWindow)?.StorageProvider;
+
+            return null;
         }
 
         [RelayCommand]

--- a/Jellyfin2Samsung-CrossOS/Views/AppSettingsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/AppSettingsView.axaml
@@ -249,6 +249,26 @@
 				</Grid>
 			</StackPanel>
 
+			<Border Height="1" Background="{DynamicResource SystemControlForegroundBaseMediumLowBrush}" Margin="0,4"/>
+
+			<!-- Backup Section -->
+			<StackPanel Spacing="8">
+				<TextBlock Text="Backup &amp; restore" Classes="label" FontWeight="SemiBold"/>
+				<TextBlock Text="Save your settings and signing certificates to a file, or restore them — to move between this PC, a Mac, or your phone."
+						   Classes="label" Opacity="0.7" TextWrapping="Wrap"/>
+				<Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+					<Button Grid.Column="0" Classes="secondary" HorizontalAlignment="Stretch"
+							HorizontalContentAlignment="Center" Padding="10,6"
+							Content="Export backup"
+							Command="{Binding ExportBackupCommand}"/>
+					<Button Grid.Column="1" Classes="secondary" HorizontalAlignment="Stretch"
+							HorizontalContentAlignment="Center" Padding="10,6"
+							Content="Import backup"
+							Command="{Binding ImportBackupCommand}"/>
+				</Grid>
+				<TextBlock Text="{Binding BackupStatus}" Classes="label" Opacity="0.8" TextWrapping="Wrap"/>
+			</StackPanel>
+
 		<!-- bottom slack: ScrollViewer under-measures wrapping content, so guarantee the last row clears the fold -->
 			<Border Height="40"/>
 		</StackPanel>


### PR DESCRIPTION
Implements #510 — move your setup between PC, Mac and phone.

## What
A single **`.zip`** backup that holds **`settings.json` + the generated signing certificates**. Restoring on another device carries over both your settings *and* the signing identity — so you don't re-do the Samsung login, and already-installed apps stay overwrite-able (no "same id, different certificate").

- **`Apps2Samsung.Core/Portability/BackupService.cs`** — head-agnostic `Export`/`Import` over a zip (`settings.json` + the `Certificate/` tree, zip-slip guarded). The certificate half is uniform because both heads expose the same `CertificateStorePath` layout.
- **Desktop** (`AppSettingsViewModel` + `AppSettingsView`) — Export/Import buttons in a new **Backup** section. Export serialises `AppSettings`; import restores certs and **merges** the settings.json — imported keys win, and keys the backup *doesn't* contain (e.g. desktop-only fields absent from a mobile export) keep their current value, so importing never silently resets unrelated settings. Applied on next launch.
- **Mobile** (`SettingsPage`) — Export builds the same `settings.json` schema from `MobileSettings`, writes the zip to the cache and shares it; Import file-picks a `.zip`, restores certs, and maps the known keys back into Preferences/SecureStorage.

The shared `settings.json` schema = the desktop `AppSettings` JSON keys, so **PC / Mac / phone all line up**.

## Version
Bumped to **v2.7.2** (`AppSettings.AppVersion` + mobile `ApplicationDisplayVersion` 2.7.2 / `ApplicationVersion` 2) for the next beta.

## Build
Both heads compile clean, 0 errors (desktop `Apps2Samsung.csproj`, mobile `Apps2Samsung.Mobile.csproj -f net10.0-android`).

Note: the backup contains cert private keys and stored Jellyfin/GitHub tokens — it's a personal-config file, intended to be kept private.