### PR TITLE
Drop LiteFin service-strip (3b) and privilege-strip (3c/#507)

### DIFF
--- a/Apps2Samsung.Core/Packaging/WgtPrivileges.cs
+++ b/Apps2Samsung.Core/Packaging/WgtPrivileges.cs
@@ -18,19 +18,6 @@ namespace Apps2Samsung.Packaging
             "http://tizen.org/privilege/vpnservice",
         };
 
-        // Partner-only / Samsung-restricted privileges that a PUBLIC-signed package must not declare on
-        // old firmware: pre-Tizen-4 TVs reject the whole install with a generic install failed[118]
-        // when a public cert requests one (#400 — LiteFin declares SmartHub 'preview'). Newer TVs just
-        // ignore an ungranted privilege, and Partner-signed installs are entitled to them, so these are
-        // only stripped for a public install on an old TV — never when Partner signing is in effect.
-        // Deliberately NOT in PartnerPrivileges: adding them there would force Partner signing, which
-        // retail TVs/individual accounts often can't obtain — the point is to install *public*.
-        public static readonly IReadOnlyCollection<string> PublicIncompatiblePrivileges =
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "http://developer.samsung.com/privilege/preview",
-        };
-
         // .wgt / config.xml: <tizen:privilege name="http://tizen.org/privilege/..."/>
         private static readonly Regex WebPrivilege = new(
             @"<tizen:privilege\b[^>]*\bname\s*=\s*""(?<name>[^""]+)""",

--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -35,8 +35,8 @@
 		<ApplicationId>nl.madebypatrick.apps2samsung</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>2.7.2</ApplicationDisplayVersion>
-		<ApplicationVersion>2</ApplicationVersion>
+		<ApplicationDisplayVersion>2.7.3</ApplicationDisplayVersion>
+		<ApplicationVersion>3</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<WindowsPackageType>None</WindowsPackageType>

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -153,7 +153,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.7.2";
+        public string AppVersion { get; set; } = "v2.7.3";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -264,63 +264,6 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
         /// background-service components. Returns true if anything was removed (the wgt must be
         /// re-signed afterwards — the caller re-enters the install flow which re-signs).
         /// </summary>
-        /// <summary>
-        /// Removes Partner-only <c>&lt;tizen:privilege&gt;</c> declarations (see
-        /// <see cref="Apps2Samsung.Packaging.WgtPrivileges.PublicIncompatiblePrivileges"/>) from the
-        /// package's config.xml so a public-signed package installs on old TVs that otherwise reject it
-        /// with a generic <c>install failed[118]</c> (#400). Returns true if anything was removed (the
-        /// wgt must be re-signed afterwards — the caller re-enters the install flow which re-signs).
-        /// </summary>
-        public static async Task<bool> StripWgtIncompatiblePrivileges(string wgtPath)
-        {
-            if (!File.Exists(wgtPath))
-                return false;
-
-            var toStrip = Apps2Samsung.Packaging.WgtPrivileges.PublicIncompatiblePrivileges;
-            if (toStrip.Count == 0)
-                return false;
-
-            using var memoryStream = new MemoryStream();
-            using (var originalStream = File.OpenRead(wgtPath))
-                await originalStream.CopyToAsync(memoryStream);
-
-            memoryStream.Position = 0;
-
-            bool changed = false;
-            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Update, true))
-            {
-                var configEntry = archive.GetEntry("config.xml");
-                if (configEntry == null)
-                    return false;
-
-                string configContent;
-                using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
-                    configContent = await reader.ReadToEndAsync();
-
-                var newConfig = configContent;
-                foreach (var priv in toStrip)
-                {
-                    // Drop the whole <tizen:privilege ... name="<priv>" .../> element (any attribute order).
-                    var pattern = $@"[ \t]*<tizen:privilege\b[^>]*\bname\s*=\s*""{Regex.Escape(priv)}""[^>]*/>\s*\r?\n?";
-                    newConfig = Regex.Replace(newConfig, pattern, string.Empty, RegexOptions.IgnoreCase);
-                }
-
-                if (newConfig == configContent)
-                    return false;
-
-                changed = true;
-                configEntry.Delete();
-                var newEntry = archive.CreateEntry("config.xml");
-                using var writer = new StreamWriter(newEntry.Open(), Encoding.UTF8);
-                await writer.WriteAsync(newConfig);
-            }
-
-            if (changed)
-                await File.WriteAllBytesAsync(wgtPath, memoryStream.ToArray());
-
-            return changed;
-        }
-
         public static async Task<bool> StripWgtServiceComponent(string wgtPath)
         {
             if (!File.Exists(wgtPath))

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -381,30 +381,6 @@ namespace Apps2Samsung.Services
                     }
                 }
 
-                // Step 3b: Older TVs (below Tizen 4.0) can't install a bundled background
-                // <tizen:service> component — the whole package is rejected with a generic
-                // install failed[118] (see #400). Only on those TVs, strip the service so
-                // the main app still installs. Newer TVs keep the package untouched.
-                var serviceSupport = new Version(Constants.TizenVersions.ServiceComponentSupport);
-                if (deviceInfo.TizenVersion < serviceSupport && await FileHelper.WgtContainsService(packageUrl))
-                {
-                    if (await FileHelper.StripWgtServiceComponent(packageUrl))
-                        Trace.WriteLine($"Device Tizen {deviceInfo.TizenVersion} < {serviceSupport}: removed bundled background service so the package can install");
-                }
-
-                // Step 3c: Old TVs (below Tizen 4.0) reject a PUBLIC-signed package that declares a
-                // Partner-only privilege (e.g. SmartHub 'preview') with the same generic install
-                // failed[118] (#400 — LiteFin). When we're not Partner-signing this package, strip
-                // those privileges so the main app still installs; Partner-signed installs keep them.
-                bool signingPartner = _appSettings.PartnerSigning
-                                      || _appSettings.RequiresPartnerSigning
-                                      || Apps2Samsung.Packaging.WgtPrivileges.RequiresPartner(packageUrl);
-                if (deviceInfo.TizenVersion < serviceSupport && !signingPartner)
-                {
-                    if (await FileHelper.StripWgtIncompatiblePrivileges(packageUrl))
-                        Trace.WriteLine($"Device Tizen {deviceInfo.TizenVersion} < {serviceSupport}: removed Partner-only privilege(s) so the public-signed package can install");
-                }
-
                 // Step 4: Handle certificate selection/generation
                 var certificateResult = await HandleCertificateAsync(
                     tvIpAddress,


### PR DESCRIPTION
Moaz fixed LiteFin upstream (ships **NoService** builds), so our old-TV package workarounds aren't needed — removing them.

- **Step 3b** — removed the `<tizen:service>` strip call.
- **Step 3c (#507)** — removed the Partner-only privilege strip and its supporting code (`FileHelper.StripWgtIncompatiblePrivileges`, `WgtPrivileges.PublicIncompatiblePrivileges`). It never actually fixed the install: OdinK03's NoService build had no service to strip and still `failed[118]`, so this reverts a speculative change with no proven benefit.

Nothing else touched — the id-rewrite (#504) and the rest of the install flow are unchanged. (`StripWgtServiceComponent` / `WgtContainsService` are left in `FileHelper` as now-unused helpers; can be cleaned up separately if wanted.)

−94 lines, builds clean, 0 errors.