### PR TITLE
Fix mobile Samsung login hanging on signInComplete (dual-stack loopback)

### DIFF
--- a/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
@@ -109,8 +109,13 @@ public class SamsungLoginActivity : Activity
     {
         try
         {
-            _listener = new TcpListener(IPAddress.Loopback, SamsungOAuth.CallbackPort);
+            // Bind dual-stack: Android's Chrome often resolves the redirect's "localhost" to the IPv6
+            // loopback (::1), so an IPv4-only (127.0.0.1) listener never receives the callback POST and
+            // the login tab hangs on signInComplete. Accepting both ::1 and 127.0.0.1 fixes it.
+            _listener = new TcpListener(IPAddress.IPv6Any, SamsungOAuth.CallbackPort);
+            _listener.Server.DualMode = true;
             _listener.Start();
+            System.Diagnostics.Trace.WriteLine($"[SamsungLogin] callback listener up on :{SamsungOAuth.CallbackPort} (dual-stack)");
 
             while (!ct.IsCancellationRequested)
             {
@@ -118,6 +123,7 @@ public class SamsungLoginActivity : Activity
                 using var stream = client.GetStream();
 
                 var (method, path, body) = await ReadRequestAsync(stream, ct);
+                System.Diagnostics.Trace.WriteLine($"[SamsungLogin] callback request: {method} {path}");
 
                 // Briefly visible in the browser tab before CLEAR_TOP dismisses it.
                 const string page =


### PR DESCRIPTION
Since the mobile head moved from an embedded WebView to a Chrome Custom Tab, the Samsung login hangs: after the password step the tab lands on `account.samsung.com/.../signInComplete` and stays **blank**, and the app never returns.

## Cause
`signInComplete` POSTs the token to the redirect_uri (`http://localhost:4794/signin/callback`), which the app catches with an in-app `TcpListener`. But it bound **IPv4 loopback only**:

```csharp
_listener = new TcpListener(IPAddress.Loopback, …); // 127.0.0.1 only
```

Android's Chrome frequently resolves `localhost` to the **IPv6 loopback `::1`**, so the POST goes to `[::1]:4794` — nothing listening → connection refused → the tab hangs. The **desktop is fine** because Kestrel binds `localhost` **dual-stack**. This also explains why it broke on the WebView→browser switch: the old WebView never made a real loopback network hop; Chrome does, and picks IPv6.

## Fix
Bind the listener **dual-stack** so it catches the callback whether Chrome uses `::1` or `127.0.0.1`:

```csharp
_listener = new TcpListener(IPAddress.IPv6Any, SamsungOAuth.CallbackPort);
_listener.Server.DualMode = true;
_listener.Start();
```

Also logs each callback request (`[SamsungLogin] callback request: …`) so we can confirm on-device — if the tab still hangs, the log tells us whether *anything* now reaches the listener.

Android head builds clean, 0 errors. **No version bump** (stays v2.7.3 — appending to the current beta notes). Needs an on-device confirm.