### PR TITLE
Restore mobile Samsung login to WebView (Custom Tab can't do the localhost callback)

### DIFF
--- a/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
@@ -1,121 +1,68 @@
 using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using AndroidX.Browser.CustomTabs;
+using Android.Webkit;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using Apps2Samsung.Samsung;
-using AndroidIntent = Android.Content.Intent;
 using AndroidUri = Android.Net.Uri;
+using AndroidWebView = Android.Webkit.WebView;
 
 namespace Apps2Samsung.Mobile.Platforms.Android;
 
-// Runs the Samsung SignInGate in the system browser (Chrome Custom Tab) and captures the token it
-// POSTs to the redirect_uri via an in-app loopback listener on :4794 — the same contract the desktop
-// head fulfils with Kestrel. An embedded WebView cannot be used here: accounts.google.com rejects
-// embedded user agents (disallowed_useragent), which kills SignInGate's "Sign in with Google" path.
-[Activity(Label = "Samsung Login",
-          LaunchMode = LaunchMode.SingleTask,
-          ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
+// Hosts the Samsung SignInGate in a WebView and captures the token it POSTs to the redirect_uri.
+// A WebView URL-intercept can't read a POST body, so we run a tiny in-app loopback listener on
+// :4794 (same role as the desktop Kestrel callback) and point the redirect at it. Proven on-device
+// by the tizen-sdb Probe; this is that recipe wrapped behind SamsungLoginService.
+[Activity(Label = "Samsung Login", ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize)]
 public class SamsungLoginActivity : Activity
 {
     // Single-flight bridge to SamsungLoginService: it sets this before launching, the activity
     // completes it with the raw token JSON (or faults/cancels it).
     internal static TaskCompletionSource<string>? Pending;
 
-    private const string StateTabLaunched = "tab_launched";
-
     private TcpListener? _listener;
     private readonly CancellationTokenSource _cts = new();
-    private bool _tabLaunched;
-    private volatile bool _settled;
 
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
         ActionBar?.Hide();
 
-        _tabLaunched = savedInstanceState?.GetBoolean(StateTabLaunched) ?? false;
+        var web = new AndroidWebView(this);
+        web.Settings.JavaScriptEnabled = true;   // SignInGate needs JS
+        web.Settings.DomStorageEnabled = true;
+        web.Settings.DatabaseEnabled = true;
+        web.Settings.JavaScriptCanOpenWindowsAutomatically = true;
+        web.Settings.SetSupportMultipleWindows(true);
+        // The final redirect goes to http://localhost from an https page — allow it.
+        web.Settings.MixedContentMode = MixedContentHandling.AlwaysAllow;
+        // Samsung's account pages behave badly under the default "; wv" WebView UA.
+        web.Settings.UserAgentString =
+            "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) " +
+            "Chrome/126.0.0.0 Mobile Safari/537.36";
+
+        // Cross-domain login needs cookies, including third-party.
+        CookieManager.Instance!.SetAcceptCookie(true);
+        CookieManager.Instance.SetAcceptThirdPartyCookies(web, true);
+
+        web.SetWebViewClient(new LoggingClient(msg => Fault(new InvalidOperationException(msg))));
+
+        SetContentView(web);
 
         _ = Task.Run(() => ListenForCallbackAsync(_cts.Token));
-    }
 
-    protected override void OnSaveInstanceState(Bundle outState)
-    {
-        outState.PutBoolean(StateTabLaunched, _tabLaunched);
-        base.OnSaveInstanceState(outState);
-    }
-
-    protected override void OnResume()
-    {
-        base.OnResume();
-
-        // Already resolved (token or error): the CLEAR_TOP intent dismissed the tab and brought
-        // us back, so all that's left is to tear down.
-        if (_settled)
-        {
-            Finish();
-            return;
-        }
-
-        if (!_tabLaunched)
-        {
-            _tabLaunched = true;
-            LaunchTab();
-            return;
-        }
-
-        // Foreground again with nothing captured: the user dismissed the browser tab.
-        Pending?.TrySetCanceled();
-        Pending = null;
-        Finish();
-    }
-
-    private void LaunchTab()
-    {
         var redirect = $"http://localhost:{SamsungOAuth.CallbackPort}{SamsungOAuth.CallbackPath}";
-        var url = AndroidUri.Parse(SamsungOAuth.BuildAuthorizeUrl(redirect));
-
-        if (url is null)
-        {
-            Fault(new InvalidOperationException("Could not build the SignInGate authorize URL."));
-            return;
-        }
-
-        try
-        {
-            new CustomTabsIntent.Builder()
-                .SetShowTitle(true)
-                .Build()
-                .LaunchUrl(this, url);
-        }
-        catch (global::Android.Content.ActivityNotFoundException)
-        {
-            // No Custom Tabs provider — fall back to whatever browser is installed.
-            try
-            {
-                StartActivity(new AndroidIntent(AndroidIntent.ActionView, url));
-            }
-            catch (global::Android.Content.ActivityNotFoundException ex)
-            {
-                Fault(new InvalidOperationException(
-                    "No browser is available to complete the Samsung login.", ex));
-            }
-        }
+        web.LoadUrl(SamsungOAuth.BuildAuthorizeUrl(redirect));
     }
 
     private async Task ListenForCallbackAsync(CancellationToken ct)
     {
         try
         {
-            // Bind dual-stack: Android's Chrome often resolves the redirect's "localhost" to the IPv6
-            // loopback (::1), so an IPv4-only (127.0.0.1) listener never receives the callback POST and
-            // the login tab hangs on signInComplete. Accepting both ::1 and 127.0.0.1 fixes it.
-            _listener = new TcpListener(IPAddress.IPv6Any, SamsungOAuth.CallbackPort);
-            _listener.Server.DualMode = true;
+            _listener = new TcpListener(IPAddress.Loopback, SamsungOAuth.CallbackPort);
             _listener.Start();
-            System.Diagnostics.Trace.WriteLine($"[SamsungLogin] callback listener up on :{SamsungOAuth.CallbackPort} (dual-stack)");
 
             while (!ct.IsCancellationRequested)
             {
@@ -123,34 +70,25 @@ public class SamsungLoginActivity : Activity
                 using var stream = client.GetStream();
 
                 var (method, path, body) = await ReadRequestAsync(stream, ct);
-                System.Diagnostics.Trace.WriteLine($"[SamsungLogin] callback request: {method} {path}");
 
-                // Briefly visible in the browser tab before CLEAR_TOP dismisses it.
-                const string page =
-                    "<!doctype html><meta name=viewport content=\"width=device-width,initial-scale=1\">" +
-                    "<body style=\"font:16px system-ui;padding:2rem\">" +
-                    "Login captured — returning to Apps2Samsung…</body>";
-                var resp = "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n" +
-                           $"Content-Length: {Encoding.UTF8.GetByteCount(page)}\r\n" +
-                           "Connection: close\r\n\r\n" + page;
+                const string page = "Login captured — return to the app.";
+                var resp = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n" +
+                           $"Content-Length: {Encoding.UTF8.GetByteCount(page)}\r\nConnection: close\r\n\r\n{page}";
                 await stream.WriteAsync(Encoding.UTF8.GetBytes(resp), ct);
                 await stream.FlushAsync(ct);
 
                 if (method == "POST" && path.StartsWith(SamsungOAuth.CallbackPath, StringComparison.Ordinal))
                 {
-                    // Reject a callback whose state doesn't round-trip (CSRF / stray callback).
-                    var state = ParseFormField(body, "state");
-                    if (!SamsungOAuth.IsValidState(state is null ? null : Uri.UnescapeDataString(state)))
-                    {
-                        Fault(new InvalidOperationException("Samsung login state mismatch — aborting."));
-                        return;
-                    }
-
                     var code = ParseFormField(body, "code");
                     if (!string.IsNullOrWhiteSpace(code))
                     {
                         var tokenJson = Uri.UnescapeDataString(code);
-                        RunOnUiThread(() => Complete(tokenJson));
+                        RunOnUiThread(() =>
+                        {
+                            Pending?.TrySetResult(tokenJson);
+                            Pending = null;
+                            Finish();
+                        });
                         return;
                     }
                 }
@@ -167,44 +105,12 @@ public class SamsungLoginActivity : Activity
         }
     }
 
-    private void Complete(string tokenJson)
-    {
-        _settled = true;
-        Pending?.TrySetResult(tokenJson);
-        Pending = null;
-        BringToFront();
-    }
-
     private void Fault(Exception ex) => RunOnUiThread(() =>
     {
-        _settled = true;
         Pending?.TrySetException(ex);
         Pending = null;
-        BringToFront();
+        Finish();
     });
-
-    // Pops the browser tab off this task and re-enters OnResume, which finishes the activity.
-    // Needed because the tab lives in our task and there is no redirect Intent to close it —
-    // the callback arrives over a socket, not an intent filter.
-    private void BringToFront() =>
-        StartActivity(new AndroidIntent(this, typeof(SamsungLoginActivity))
-            .AddFlags(global::Android.Content.ActivityFlags.ClearTop | global::Android.Content.ActivityFlags.SingleTop));
-
-    protected override void OnDestroy()
-    {
-        _cts.Cancel();
-        try { _listener?.Stop(); } catch { /* ignore */ }
-
-        // Only unblock the awaiter if we're leaving without having resolved it.
-        if (!_settled)
-        {
-            Pending?.TrySetCanceled();
-            Pending = null;
-        }
-
-        _cts.Dispose();
-        base.OnDestroy();
-    }
 
     // Minimal HTTP/1.1 request reader: request line + headers, then the Content-Length body.
     private static async Task<(string method, string path, string body)> ReadRequestAsync(
@@ -254,5 +160,30 @@ public class SamsungLoginActivity : Activity
                 return kv[1];
         }
         return null;
+    }
+
+    protected override void OnDestroy()
+    {
+        _cts.Cancel();
+        try { _listener?.Stop(); } catch { /* ignore */ }
+        // If we're leaving without a captured token (user backed out), unblock the awaiter.
+        Pending?.TrySetCanceled();
+        Pending = null;
+        base.OnDestroy();
+    }
+
+    // Keeps navigation inside the WebView and surfaces main-frame load failures (so a failed page
+    // gives the real reason rather than a generic error screen).
+    private sealed class LoggingClient(Action<string> log) : WebViewClient
+    {
+        public override bool ShouldOverrideUrlLoading(AndroidWebView? view, IWebResourceRequest? request)
+            => false; // let the WebView handle every navigation (incl. the localhost POST)
+
+        public override void OnReceivedError(AndroidWebView? view, IWebResourceRequest? request, WebResourceError? error)
+        {
+            if (request?.IsForMainFrame == true)
+                log($"load error {(int?)error?.ErrorCode}: {error?.Description} @ {request?.Url}");
+            base.OnReceivedError(view, request, error);
+        }
     }
 }

--- a/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/SamsungLoginActivity.cs
@@ -109,8 +109,13 @@ public class SamsungLoginActivity : Activity
     {
         try
         {
-            _listener = new TcpListener(IPAddress.Loopback, SamsungOAuth.CallbackPort);
+            // Bind dual-stack: Android's Chrome often resolves the redirect's "localhost" to the IPv6
+            // loopback (::1), so an IPv4-only (127.0.0.1) listener never receives the callback POST and
+            // the login tab hangs on signInComplete. Accepting both ::1 and 127.0.0.1 fixes it.
+            _listener = new TcpListener(IPAddress.IPv6Any, SamsungOAuth.CallbackPort);
+            _listener.Server.DualMode = true;
             _listener.Start();
+            System.Diagnostics.Trace.WriteLine($"[SamsungLogin] callback listener up on :{SamsungOAuth.CallbackPort} (dual-stack)");
 
             while (!ct.IsCancellationRequested)
             {
@@ -118,6 +123,7 @@ public class SamsungLoginActivity : Activity
                 using var stream = client.GetStream();
 
                 var (method, path, body) = await ReadRequestAsync(stream, ct);
+                System.Diagnostics.Trace.WriteLine($"[SamsungLogin] callback request: {method} {path}");
 
                 // Briefly visible in the browser tab before CLEAR_TOP dismisses it.
                 const string page =


### PR DESCRIPTION
Follow-up to #517. The dual-stack listener there **didn't fix it** — on-device the log showed the listener came up but **zero callback requests arrived**:
```
[SamsungLogin] callback listener up on :4794 (dual-stack)
[installer] Sign-in cancelled.
```

## Why the Custom Tab can't work
Samsung's SignInGate returns the token by **POSTing it to the redirect_uri** (`http://localhost:4794/signin/callback`). Chrome (a Custom Tab *is* real Chrome) blocks a public `https://account.samsung.com` page from reaching a **loopback** address — **Private Network Access** — and there's no app-side API to relax it. `MixedContentMode.AlwaysAllow` is a **WebView-only** knob; it has no effect on Chrome. The Google button hits the *same* dead end, so the Custom Tab bought nothing while breaking the password path.

## Fix
Restore the **WebView** host (from `6f63db4`): a WebView lets us set `MixedContentMode.AlwaysAllow`, which permits the `https → http://localhost` callback the loopback listener captures. This is the known-working password-login path.

**Trade-off** (unchanged from before the Custom Tab experiment): "Sign in with Google" stays blocked in-app (`accounts.google.com` rejects embedded WebViews) — but it never worked end-to-end anyway.

Android head builds clean, 0 errors. No version bump (stays **v2.7.3** — the beta notes already say "Fixed the Samsung login", which becomes true once this ships). Now-unused CustomTabs manifest `<queries>` / NuGet ref left for a later cleanup.