### PR TITLE
SDB: retry read commands on transient transport reset (fixes spurious TV Name not found #524)

### DIFF
--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -35,7 +35,7 @@
 		<ApplicationId>nl.madebypatrick.apps2samsung</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>2.7.3</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>2.7.4</ApplicationDisplayVersion>
 		<ApplicationVersion>3</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->

--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.7.0</CFBundleVersion>
+	<CFBundleVersion>2.7.4</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -153,7 +153,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.7.3";
+        public string AppVersion { get; set; } = "v2.7.4";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Info.plist
+++ b/Jellyfin2Samsung-CrossOS/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.madebypatrick.apps2samsung</string>
     <key>CFBundleVersion</key>
-    <string>2.5.4</string>
+    <string>2.7.4</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleSignature</key>

--- a/Jellyfin2Samsung-CrossOS/Services/ExeSdbEngine.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/ExeSdbEngine.cs
@@ -31,17 +31,47 @@ namespace Apps2Samsung.Services
 
         private Task<ProcessResult> Run(string arguments) => _processHelper.RunCommandAsync(SdbPath, arguments);
 
-        public Task<ProcessResult> DevicesAsync(string tvIpAddress) => Run($"devices {tvIpAddress}");
+        // Transient SDB transport hiccups: the TV drops the connection mid-read ("...forcibly closed by
+        // the remote host", "Remote closed stream while reading"). These are races on the SDB link, not
+        // real failures — a quick retry almost always succeeds. This is why a single reset on the
+        // device-info read produced a spurious "TV Name could not be found" even though the TV was just
+        // discovered (#524). Applied ONLY to idempotent read/query commands — never to
+        // install/uninstall/resign, which aren't safe to blindly repeat.
+        private static readonly string[] TransientTransportErrors =
+        {
+            "forcibly closed by the remote host",
+            "Remote closed stream while reading",
+            "Unable to read data from the transport connection",
+            "Connection reset by peer",
+        };
+
+        private static bool IsTransientTransportError(ProcessResult result) =>
+            !string.IsNullOrEmpty(result.Output) &&
+            Array.Exists(TransientTransportErrors,
+                marker => result.Output.Contains(marker, StringComparison.OrdinalIgnoreCase));
+
+        private async Task<ProcessResult> RunWithRetry(string arguments, int attempts = 3)
+        {
+            var result = await _processHelper.RunCommandAsync(SdbPath, arguments);
+            for (int i = 1; i < attempts && IsTransientTransportError(result); i++)
+            {
+                await Task.Delay(400 * i); // brief backoff before retrying the reset
+                result = await _processHelper.RunCommandAsync(SdbPath, arguments);
+            }
+            return result;
+        }
+
+        public Task<ProcessResult> DevicesAsync(string tvIpAddress) => RunWithRetry($"devices {tvIpAddress}");
 
         public Task<ProcessResult> DisconnectAsync(string tvIpAddress) => Run($"disconnect {tvIpAddress}");
 
-        public Task<ProcessResult> CapabilityAsync(string tvIpAddress) => Run($"capability {tvIpAddress}");
+        public Task<ProcessResult> CapabilityAsync(string tvIpAddress) => RunWithRetry($"capability {tvIpAddress}");
 
-        public Task<ProcessResult> DuidAsync(string tvIpAddress) => Run($"duid {tvIpAddress}");
+        public Task<ProcessResult> DuidAsync(string tvIpAddress) => RunWithRetry($"duid {tvIpAddress}");
 
-        public Task<ProcessResult> DiagnoseAsync(string tvIpAddress) => Run($"diagnose {tvIpAddress}");
+        public Task<ProcessResult> DiagnoseAsync(string tvIpAddress) => RunWithRetry($"diagnose {tvIpAddress}");
 
-        public Task<ProcessResult> AppsAsync(string tvIpAddress) => Run($"apps {tvIpAddress}");
+        public Task<ProcessResult> AppsAsync(string tvIpAddress) => RunWithRetry($"apps {tvIpAddress}");
 
         public Task<ProcessResult> LaunchAsync(string tvIpAddress, string appId) => Run($"launch {tvIpAddress} \"{appId}\"");
 


### PR DESCRIPTION
Fixes #524. On a normal TV (not a firmware thing), the SDB link sometimes drops a read mid-stream:
```
process_devices → "Remote closed stream while reading"
process_duid    → "...An existing connection was forcibly closed by the remote host"
```
Each SDB query is a one-shot `TizenSdb.exe` call, so a single reset made `GetTvNameAsync` return empty → the install bailed with **"TV Name could not be found"** — even though the TV had just been discovered.

## Fix
`ExeSdbEngine` now **retries the idempotent read commands** (`devices`, `capability`, `duid`, `diagnose`, `apps`) up to 3× with a short backoff when the output matches a transient transport-reset marker (`forcibly closed by the remote host`, `Remote closed stream while reading`, `Unable to read data from the transport connection`, `Connection reset by peer`). Since the reset is a race, a retry almost always succeeds.

**Write commands (install/uninstall/resign/permit) are never retried** — they aren't safe to blindly repeat.

Builds clean, 0 errors.

Note: this makes the *read* robust. If you also want a belt-and-suspenders fallback — when the name read still fails after retries, use the name captured during the scan instead of hard-failing — that's a small follow-up (plumbing the scanned name into `GetDeviceInfoAsync`); left out here to keep it focused.