### PR TITLE
#523: accept manual TV IP on the SDB port alone (match the scan)

### DIFF
--- a/Apps2Samsung.Core/Network/NetworkService.cs
+++ b/Apps2Samsung.Core/Network/NetworkService.cs
@@ -58,23 +58,25 @@ namespace Apps2Samsung.Services
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
                     cts.Token, cancellationToken);
 
+                // Accept a TV on the SDB debug port (26101) alone — the same bar the network scan
+                // uses (see FindTizenTvsAsync). Manual entry previously ALSO required the 8001 REST
+                // API to be open, so a TV that's reachable and developer-ready on 26101 but whose
+                // 8001 is closed/firewalled/slow (the two probes shared one 1s budget) was wrongly
+                // rejected as "Invalid device IP" — even though the exact same TV would have been
+                // accepted by the scan. Match the scan so the manual and discovered paths agree (#523).
                 if (await IsPortOpenAsync(ip, TizenDevPort, linkedCts.Token))
                 {
-                    if (await IsPortOpenAsync(ip, SamsungTvApiPort, linkedCts.Token))
+                    var manufacturer = await GetManufacturerFromIp(ip);
+                    var device = new NetworkDevice
                     {
-                        var manufacturer = await GetManufacturerFromIp(ip);
-                        var device = new NetworkDevice
-                        {
-                            IpAddress = ip,
-                            Manufacturer = manufacturer
-                        };
+                        IpAddress = ip,
+                        Manufacturer = manufacturer
+                    };
 
-                        if (manufacturer?.Contains("Samsung", StringComparison.OrdinalIgnoreCase) == true)
-                            device.DeviceName = await GetTvNameAsync(ip);
+                    if (manufacturer?.Contains("Samsung", StringComparison.OrdinalIgnoreCase) == true)
+                        device.DeviceName = await GetTvNameAsync(ip);
 
-                        return device;
-                    }
-                    return null;
+                    return device;
                 }
 
                 return null;


### PR DESCRIPTION
Fixes #523.

## The report
v2.7.3 rejects a valid, reachable TV IP with **"Invalid device IP"** when entered manually. The reporter confirmed the TV is reachable (`nc … 26101`).

## Root cause — the manual path was stricter than the scan
`NetworkService.ValidateManualTizenAddress` required **both** the SDB debug port (26101) **and** the 8001 REST API to be open. The network scan (`FindTizenTvsAsync`) accepts a TV on **26101 alone**. So a TV that is reachable and developer-ready on 26101, but whose 8001 is closed/firewalled/slow (both probes shared a single 1 s budget), was **rejected by manual entry but would have been found by the scan** — the exact asymmetry in the report.

This strictness has existed since v1.7.5, so it is not a v2.7.3-specific code change; but it is a real inconsistency and the cheapest, safest thing to correct.

## Fix
Drop the extra 8001 requirement from the manual path so it uses the same bar as the scan: **26101 open ⇒ accept**. One file, `Apps2Samsung.Core/Network/NetworkService.cs`.

## Note for the reporter (macOS)
If 26101 itself is genuinely reachable from the shell but the app still can't connect, the remaining suspect is the **macOS Local-Network privacy block** (same family as #498): the GUI app's `TcpClient.ConnectAsync` gets `AccessDenied` while Terminal's `nc` is separately permitted. That is an OS-permission issue this change can't fix; the app's Trace log (`AccessDenied` on 26101) would confirm it.