### PR TITLE
Default the manual package picker to WGT/TPK (not WGT-only)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -41,8 +41,14 @@ namespace Apps2Samsung.Helpers.Core
 
 public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
 {
+    // The first entry is the picker's default-selected filter — keep the combined WGT/TPK
+    // filter first so both package types are shown by default (was defaulting to WGT-only).
     var fileTypes = new List<FilePickerFileType>
     {
+        new("WGT / TPK Files")
+        {
+            Patterns = allItem
+        },
         new("WGT Files")
         {
             Patterns = wgtItem
@@ -50,10 +56,6 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
         new("TPK Files")
         {
             Patterns = tpkItem
-        },
-        new("All Supported Files")
-        {
-            Patterns = allItem
         }
     };
 


### PR DESCRIPTION
The desktop **Select WGT/TPK File** dialog listed the WGT-only filter first, so the picker opened defaulting to WGT and `.tpk` packages were hidden until the user manually switched the filter dropdown.

Reorder the filters so a combined **WGT / TPK Files** entry is first — the picker's default-selected filter — so both package types are shown by default.

One file, `Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs`.