### PR TITLE
#521: shared icon changer in Core + custom app titles (both heads)

### DIFF
--- a/Apps2Samsung.Core/Catalog/AppCatalog.cs
+++ b/Apps2Samsung.Core/Catalog/AppCatalog.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Apps2Samsung.Helpers.Core; // AddLatestRelease
+using Apps2Samsung.Models;
+using Apps2Samsung.Packaging;
+
+namespace Apps2Samsung.Catalog
+{
+    /// <summary>One installable app offered in the customization editor (icon / title).</summary>
+    /// <param name="DisplayName">Human-readable name shown in the list.</param>
+    /// <param name="Key">Token matched (case-insensitive substring) against the package file name at install.</param>
+    /// <param name="HasOblong">True when this head ships a bundled 16:9 "oblong" launcher tile for this app.</param>
+    public sealed record AppCatalogEntry(string DisplayName, string Key, bool HasOblong);
+
+    /// <summary>
+    /// Builds the shared list of installable apps for the icon/title customization editor, so both heads
+    /// present the same catalog instead of each reimplementing it (#521). The head fetches the
+    /// <see cref="ProviderManifest"/> its own way (desktop <c>ProviderManifestService</c> / mobile
+    /// <c>CatalogService</c>) and passes it in; this class does the shared shaping — expanding the
+    /// community bundle to one entry per .wgt asset, collapsing the Jellyfin variants into one entry, and
+    /// flagging which apps have a bundled oblong tile via <see cref="IOblongIconSource"/>.
+    /// </summary>
+    public sealed class AppCatalog
+    {
+        private readonly AddLatestRelease _releases;
+        private readonly IOblongIconSource _oblong;
+
+        public AppCatalog(AddLatestRelease releases, IOblongIconSource oblong)
+        {
+            _releases = releases;
+            _oblong = oblong;
+        }
+
+        public async Task<IReadOnlyList<AppCatalogEntry>> BuildAsync(ProviderManifest manifest)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var entries = new List<AppCatalogEntry>();
+
+            void Add(string display, string key)
+            {
+                key = key?.Trim() ?? string.Empty;
+                if (string.IsNullOrEmpty(key) || !seen.Add(key))
+                    return;
+
+                entries.Add(new AppCatalogEntry(
+                    DisplayName: string.IsNullOrWhiteSpace(display) ? key : display.Trim(),
+                    Key: key,
+                    HasOblong: _oblong.TryGetOblong(key) != null));
+            }
+
+            foreach (var provider in manifest.Providers)
+            {
+                if (provider.ExpandAssets)
+                {
+                    // Community bundle: one entry per real .wgt asset in the latest release, so every
+                    // community app is offered and the list stays current with the repo (see #462).
+                    // Custom icons/titles only apply to web apps, so skip native .tpk assets. Best-effort:
+                    // a fetch failure just yields no community rows rather than breaking the editor.
+                    if (string.IsNullOrWhiteSpace(provider.Url))
+                        continue;
+                    try
+                    {
+                        var releases = await _releases.GetReleasesAsync(
+                            provider.Url, provider.Prefix, provider.DisplayName, provider.Take);
+                        foreach (var r in releases)
+                            foreach (var asset in r.Assets)
+                            {
+                                if (!asset.FileName.EndsWith(".wgt", StringComparison.OrdinalIgnoreCase))
+                                    continue;
+                                var name = Path.GetFileNameWithoutExtension(asset.FileName);
+                                Add(name, name);
+                            }
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.WriteLine($"[AppCatalog] Could not expand community assets from {provider.Url}: {ex.Message}");
+                    }
+                    continue;
+                }
+
+                // All Jellyfin builds share the "Jellyfin" file-name root, so collapse the variants
+                // (AVPlay, Legacy, …) into one entry that matches any of them.
+                if (string.IsNullOrWhiteSpace(provider.DisplayName) ||
+                    provider.DisplayName.StartsWith("Jellyfin", StringComparison.OrdinalIgnoreCase))
+                    Add("Jellyfin", "Jellyfin");
+                else
+                    Add(provider.DisplayName, provider.DisplayName);
+            }
+
+            return entries;
+        }
+    }
+}

--- a/Apps2Samsung.Core/Configuration/IAppConfig.cs
+++ b/Apps2Samsung.Core/Configuration/IAppConfig.cs
@@ -44,6 +44,8 @@ namespace Apps2Samsung.Configuration
         // ---- Package patching ----
         /// <summary>JSON map { appKey -> "oblong" | custom launcher PNG path } applied to a wgt at install.</summary>
         string CustomAppIconsJson { get; set; }
+        /// <summary>JSON map { appKey -> custom app title } written into a wgt's config.xml &lt;name&gt; at install.</summary>
+        string CustomAppTitlesJson { get; set; }
         /// <summary>JSON array of { name, url } TVApp channels injected into a TVApp wgt at install.</summary>
         string TvAppChannelsJson { get; set; }
 

--- a/Apps2Samsung.Core/Packaging/AppTitlePackagePatcher.cs
+++ b/Apps2Samsung.Core/Packaging/AppTitlePackagePatcher.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Apps2Samsung.Configuration;
+using Apps2Samsung.Helpers.Core; // PackageWorkspace
+using Apps2Samsung.Interfaces;    // IPackagePatcher
+using Apps2Samsung.Models;        // InstallResult
+
+namespace Apps2Samsung.Packaging
+{
+    /// <summary>
+    /// App-agnostic launcher-title patcher, shared by both heads. The user's per-app choice lives in
+    /// <see cref="IAppConfig.CustomAppTitlesJson"/> as a map <c>{ appKey -> title }</c>. An entry applies
+    /// when its key is contained in the package file name (case-insensitive). Mirrors
+    /// <see cref="CustomIconPackagePatcher"/>; register alongside it in the patcher pipeline.
+    /// </summary>
+    public sealed class AppTitlePackagePatcher : IPackagePatcher
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+        private readonly IAppConfig _config;
+
+        public AppTitlePackagePatcher(IAppConfig config) => _config = config;
+
+        public bool CanHandle(string packagePath) => Resolve(packagePath) != null;
+
+        public async Task<InstallResult> ApplyAsync(string packagePath)
+        {
+            var title = Resolve(packagePath);
+            if (title == null)
+                return InstallResult.SuccessResult();
+
+            using var ws = PackageWorkspace.Extract(packagePath);
+            await WgtTitlePatcher.SwapAppTitleAsync(ws, title);
+            ws.Repack();
+
+            Trace.WriteLine($"[CustomTitle] Applied title '{title}' to {Path.GetFileName(packagePath)}.");
+            return InstallResult.SuccessResult();
+        }
+
+        // The custom title configured for this package (first map entry whose key matches the file name), or null.
+        private string? Resolve(string packagePath)
+        {
+            var map = LoadMap();
+            if (map.Count == 0)
+                return null;
+
+            var fileName = Path.GetFileName(packagePath);
+            foreach (var (key, value) in map)
+            {
+                if (!string.IsNullOrWhiteSpace(value) &&
+                    fileName.IndexOf(key, StringComparison.OrdinalIgnoreCase) >= 0)
+                    return value.Trim();
+            }
+
+            return null;
+        }
+
+        private Dictionary<string, string> LoadMap()
+        {
+            var json = _config.CustomAppTitlesJson;
+            if (string.IsNullOrWhiteSpace(json))
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                return JsonSerializer.Deserialize<Dictionary<string, string>>(json, JsonOptions) is { } parsed
+                    ? new Dictionary<string, string>(parsed, StringComparer.OrdinalIgnoreCase)
+                    : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[CustomTitle] Failed to parse CustomAppTitlesJson: {ex.Message}");
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+    }
+}

--- a/Apps2Samsung.Core/Packaging/WgtTitlePatcher.cs
+++ b/Apps2Samsung.Core/Packaging/WgtTitlePatcher.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Security;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Apps2Samsung.Helpers.Core; // PackageWorkspace
+
+namespace Apps2Samsung.Packaging
+{
+    /// <summary>
+    /// Swaps a Tizen package's launcher title — the text inside config.xml's <c>&lt;name&gt;</c> element,
+    /// which is what the TV shows under the app icon. Head-agnostic; the package is re-signed after
+    /// patching so editing config.xml in the extracted workspace is enough. Mirrors
+    /// <see cref="WgtIconPatcher"/> (which swaps the icon bytes) for the title.
+    /// </summary>
+    public static class WgtTitlePatcher
+    {
+        // <name ...>title</name> — allow attributes (e.g. xml:lang) and any inner text.
+        private static readonly Regex NameRegex =
+            new(@"(<name\b[^>]*>)(.*?)(</name>)",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+        /// <summary>Sets the app title in the workspace's config.xml (first <c>&lt;name&gt;</c> element).
+        /// No-op if config.xml is missing or has no <c>&lt;name&gt;</c>.</summary>
+        public static async Task SwapAppTitleAsync(PackageWorkspace ws, string newTitle)
+        {
+            if (string.IsNullOrWhiteSpace(newTitle))
+                return;
+
+            var configPath = Path.Combine(ws.Root, "config.xml");
+            if (!File.Exists(configPath))
+                return;
+
+            try
+            {
+                var content = await File.ReadAllTextAsync(configPath);
+                if (!NameRegex.IsMatch(content))
+                {
+                    Trace.WriteLine("[WgtTitle] config.xml has no <name> element; leaving title unchanged.");
+                    return;
+                }
+
+                var escaped = SecurityElement.Escape(newTitle.Trim());
+                var updated = NameRegex.Replace(content,
+                    m => m.Groups[1].Value + escaped + m.Groups[3].Value, 1);
+
+                await File.WriteAllTextAsync(configPath, updated);
+                Trace.WriteLine($"[WgtTitle] Set app title to '{newTitle.Trim()}'.");
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[WgtTitle] Failed to set app title: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Catalog/CatalogService.cs
+++ b/Apps2Samsung.Mobile/Catalog/CatalogService.cs
@@ -97,7 +97,9 @@ public sealed class CatalogService
 		return new CatalogResult(list, failed, providers.Count);
 	}
 
-	private async Task<ProviderManifest> GetManifestAsync()
+	/// <summary>Fetches the provider manifest (remote, else cached, else empty). Public so the
+	/// icon/title editor can feed it to the shared <see cref="Apps2Samsung.Catalog.AppCatalog"/>.</summary>
+	public async Task<ProviderManifest> GetManifestAsync()
 	{
 		var cachePath = Path.Combine(FileSystem.AppDataDirectory, CacheFileName);
 

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -70,6 +70,12 @@ public static class MauiProgram
 		// "oblong" tiles, so a no-op oblong source — only user-supplied custom PNG icons apply here.
 		builder.Services.AddSingleton<IOblongIconSource, NoOblongIconSource>();
 		builder.Services.AddSingleton<IPackagePatcher, CustomIconPackagePatcher>();
+		builder.Services.AddSingleton<IPackagePatcher, AppTitlePackagePatcher>();
+
+		// Shared app catalog for the icon/title editor (same list as desktop).
+		builder.Services.AddSingleton<Apps2Samsung.Catalog.AppCatalog>(sp => new Apps2Samsung.Catalog.AppCatalog(
+			new Apps2Samsung.Helpers.Core.AddLatestRelease(sp.GetRequiredService<HttpClient>(), () => MobileSettings.GitHubToken),
+			sp.GetRequiredService<IOblongIconSource>()));
 		// Jellyfin config injection (server URL + auto-login + custom CSS), configured via the
 		// Settings → Jellyfin page. No-ops when no server is set (empty JellyfinFullUrl).
 		builder.Services.AddSingleton<IPackagePatcher>(sp =>

--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -94,6 +94,8 @@ public static class MauiProgram
 		// Session (holds the Samsung sign-in for the app's lifetime) + the installer page.
 		builder.Services.AddSingleton<SessionState>();
 		builder.Services.AddSingleton<InstallerPage>();
+		// The icon/title editor needs the catalog services injected (shared app list).
+		builder.Services.AddTransient<AppIconsPage>();
 
 #if DEBUG
 		builder.Logging.AddDebug();

--- a/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml
@@ -24,14 +24,11 @@
                 </Border>
 
                 <Label FontSize="12" Opacity="0.6"
-                       Text="Give an app a custom launcher icon. Enter the app name as it appears in the app list (e.g. &quot;Jellyfin&quot; or &quot;TizenYouTube&quot;) and pick a PNG — it's applied to that package when you install it." />
+                       Text="Pick an app from the list and give it a custom launcher icon (PNG) and/or a custom title. Both are applied to that package when you install it. Leave either empty to keep the package's default." />
+
+                <Label x:Name="StatusLabel" FontSize="12" Opacity="0.6" Text="Loading app list…" />
 
                 <VerticalStackLayout x:Name="IconsContainer" Spacing="10" />
-
-                <Button Text="+ Add app icon" Clicked="OnAddIcon" HorizontalOptions="Start"
-                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
-                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
-                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
 
             </VerticalStackLayout>
         </Border>

--- a/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
@@ -2,49 +2,105 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
+using Apps2Samsung.Catalog;
+using Apps2Samsung.Mobile.Catalog;
 using Apps2Samsung.Mobile.Services;
 using Microsoft.Maui.Storage;
 
 namespace Apps2Samsung.Mobile.Pages;
 
 /// <summary>
-/// Settings → App icons. Lets the user map an app (by a name substring of its .wgt, e.g. "Jellyfin")
-/// to a custom launcher PNG; the map is persisted in <see cref="MobileSettings.CustomAppIconsJson"/>
-/// and applied at install by the shared <c>CustomIconPackagePatcher</c>. Built as dynamic rows to
-/// mirror the TVApp-channels editor (no data binding), for robustness.
+/// Settings → App icons. Presents the same manifest-driven app list as the desktop head (built by the
+/// shared Core <see cref="AppCatalog"/>) and lets the user give each app a custom launcher icon (PNG)
+/// and/or a custom title. Choices are persisted per app in <see cref="MobileSettings.CustomAppIconsJson"/>
+/// / <see cref="MobileSettings.CustomAppTitlesJson"/> and applied at install by the shared
+/// <c>CustomIconPackagePatcher</c> / <c>AppTitlePackagePatcher</c> (#521).
 /// </summary>
 public partial class AppIconsPage : ContentPage
 {
-	private readonly List<IconRow> _rows = new();
+	private readonly CatalogService _catalog;
+	private readonly AppCatalog _appCatalog;
+	private readonly List<AppRow> _rows = new();
+	private bool _loaded;
 
-	private sealed record IconRow(View Container, Entry Key, Label PathLabel)
+	private sealed record AppRow(string Key, Label IconSummary)
 	{
 		public string? IconPath { get; set; }
 	}
 
-	public AppIconsPage()
+	public AppIconsPage(CatalogService catalog, AppCatalog appCatalog)
 	{
 		InitializeComponent();
-		foreach (var (key, value) in LoadMap())
-			AddRow(key, value);
+		_catalog = catalog;
+		_appCatalog = appCatalog;
 	}
 
-	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
-
-	private void OnAddIcon(object? sender, EventArgs e) => AddRow(string.Empty, string.Empty);
-
-	private void AddRow(string key, string value)
+	protected override async void OnAppearing()
 	{
-		var keyEntry = new Entry { Text = key, Placeholder = "App name (e.g. Jellyfin)", BackgroundColor = Colors.Transparent };
-		var pathLabel = new Label
+		base.OnAppearing();
+		if (_loaded)
+			return;
+		_loaded = true;
+		await LoadAsync();
+	}
+
+	private async Task LoadAsync()
+	{
+		try
+		{
+			var manifest = await _catalog.GetManifestAsync();
+			var entries = await _appCatalog.BuildAsync(manifest);
+
+			var iconMap = LoadMap(MobileSettings.CustomAppIconsJson);
+			var titleMap = LoadMap(MobileSettings.CustomAppTitlesJson);
+
+			IconsContainer.Children.Clear();
+			_rows.Clear();
+			foreach (var entry in entries)
+			{
+				iconMap.TryGetValue(entry.Key, out var icon);
+				titleMap.TryGetValue(entry.Key, out var title);
+				AddRow(entry, icon, title);
+			}
+
+			StatusLabel.Text = _rows.Count == 0
+				? "No apps loaded (offline or GitHub rate-limited). Add a token in Settings and reopen."
+				: string.Empty;
+			StatusLabel.IsVisible = _rows.Count == 0;
+		}
+		catch (Exception ex)
+		{
+			StatusLabel.Text = $"Couldn't load the app list: {ex.Message}";
+			StatusLabel.IsVisible = true;
+		}
+	}
+
+	private void AddRow(AppCatalogEntry entry, string? iconValue, string? titleValue)
+	{
+		var nameLabel = new Label
+		{
+			Text = entry.DisplayName,
+			FontAttributes = FontAttributes.Bold,
+			VerticalOptions = LayoutOptions.Center,
+		};
+
+		var titleEntry = new Entry
+		{
+			Text = titleValue ?? string.Empty,
+			Placeholder = entry.DisplayName,
+			BackgroundColor = Colors.Transparent,
+		};
+
+		var iconSummary = new Label
 		{
 			FontSize = 12,
 			Opacity = 0.6,
 			LineBreakMode = LineBreakMode.TailTruncation,
 			VerticalOptions = LayoutOptions.Center,
 		};
-		var chooseBtn = new Button { Text = "Choose…", FontSize = 13, Padding = new Thickness(10, 0), HeightRequest = 40, CornerRadius = 6 };
-		var removeBtn = new Button
+		var chooseBtn = new Button { Text = "Icon…", FontSize = 13, Padding = new Thickness(10, 0), HeightRequest = 40, CornerRadius = 6 };
+		var clearBtn = new Button
 		{
 			Text = "✕",
 			FontSize = 14,
@@ -72,40 +128,46 @@ public partial class AppIconsPage : ContentPage
 			{
 				new RowDefinition(GridLength.Auto),
 				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
 			},
 		};
-		Grid.SetColumn(keyEntry, 0); Grid.SetRow(keyEntry, 0);
-		Grid.SetColumn(chooseBtn, 1); Grid.SetRow(chooseBtn, 0);
-		Grid.SetColumn(removeBtn, 2); Grid.SetRow(removeBtn, 0);
-		Grid.SetColumn(pathLabel, 0); Grid.SetRow(pathLabel, 1); Grid.SetColumnSpan(pathLabel, 3);
-		grid.Children.Add(keyEntry);
+		// Row 0: app name. Row 1: custom-title entry (spans). Row 2: icon summary + choose/clear.
+		Grid.SetColumn(nameLabel, 0); Grid.SetRow(nameLabel, 0); Grid.SetColumnSpan(nameLabel, 3);
+		Grid.SetColumn(titleEntry, 0); Grid.SetRow(titleEntry, 1); Grid.SetColumnSpan(titleEntry, 3);
+		Grid.SetColumn(iconSummary, 0); Grid.SetRow(iconSummary, 2);
+		Grid.SetColumn(chooseBtn, 1); Grid.SetRow(chooseBtn, 2);
+		Grid.SetColumn(clearBtn, 2); Grid.SetRow(clearBtn, 2);
+		grid.Children.Add(nameLabel);
+		grid.Children.Add(titleEntry);
+		grid.Children.Add(iconSummary);
 		grid.Children.Add(chooseBtn);
-		grid.Children.Add(removeBtn);
-		grid.Children.Add(pathLabel);
+		grid.Children.Add(clearBtn);
 
-		var row = new IconRow(grid, keyEntry, pathLabel)
+		var row = new AppRow(entry.Key, iconSummary)
 		{
-			IconPath = string.IsNullOrWhiteSpace(value) ? null : value,
+			IconPath = string.IsNullOrWhiteSpace(iconValue) ? null : iconValue,
 		};
-		pathLabel.Text = DescribePath(row.IconPath);
+		iconSummary.Text = DescribeIcon(row.IconPath);
 
-		keyEntry.Unfocused += (_, _) => Save();
-		chooseBtn.Clicked += async (_, _) => { await PickAsync(row); Save(); };
-		removeBtn.Clicked += (_, _) =>
+		titleEntry.Unfocused += (_, _) => SaveTitle(entry.Key, titleEntry.Text);
+		chooseBtn.Clicked += async (_, _) => await PickIconAsync(row);
+		clearBtn.Clicked += (_, _) =>
 		{
-			IconsContainer.Children.Remove(grid);
-			_rows.Remove(row);
-			Save();
+			row.IconPath = null;
+			iconSummary.Text = DescribeIcon(null);
+			SaveIcon(row.Key, null);
 		};
 
 		_rows.Add(row);
 		IconsContainer.Children.Add(grid);
 	}
 
-	private static string DescribePath(string? path) =>
-		string.IsNullOrWhiteSpace(path) ? "No icon chosen" : $"Icon: {Path.GetFileName(path)}";
+	private static string DescribeIcon(string? path) =>
+		string.IsNullOrWhiteSpace(path) ? "Default icon" : $"Icon: {Path.GetFileName(path)}";
 
-	private async Task PickAsync(IconRow row)
+	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
+
+	private async Task PickIconAsync(AppRow row)
 	{
 		try
 		{
@@ -120,7 +182,7 @@ public partial class AppIconsPage : ContentPage
 			// Copy into app data so the path stays valid after the picker URI is released.
 			var dir = Path.Combine(FileSystem.AppDataDirectory, "app-icons");
 			Directory.CreateDirectory(dir);
-			var baseName = string.Concat((row.Key.Text ?? "icon").Select(c => char.IsLetterOrDigit(c) ? c : '_'));
+			var baseName = string.Concat(row.Key.Select(c => char.IsLetterOrDigit(c) ? c : '_'));
 			if (string.IsNullOrWhiteSpace(baseName)) baseName = "icon";
 			var dest = Path.Combine(dir, baseName + Path.GetExtension(result.FileName));
 			using (var src = await result.OpenReadAsync())
@@ -128,7 +190,8 @@ public partial class AppIconsPage : ContentPage
 				await src.CopyToAsync(dst);
 
 			row.IconPath = dest;
-			row.PathLabel.Text = DescribePath(dest);
+			row.IconSummary.Text = DescribeIcon(dest);
+			SaveIcon(row.Key, dest);
 		}
 		catch (Exception ex)
 		{
@@ -136,22 +199,29 @@ public partial class AppIconsPage : ContentPage
 		}
 	}
 
-	private void Save()
+	private void SaveIcon(string key, string? path)
 	{
-		var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-		foreach (var r in _rows)
-		{
-			var k = r.Key.Text?.Trim();
-			if (string.IsNullOrWhiteSpace(k) || string.IsNullOrWhiteSpace(r.IconPath))
-				continue;
-			map[k!] = r.IconPath!;
-		}
+		var map = LoadMap(MobileSettings.CustomAppIconsJson);
+		if (string.IsNullOrWhiteSpace(path))
+			map.Remove(key);
+		else
+			map[key] = path;
 		MobileSettings.CustomAppIconsJson = JsonSerializer.Serialize(map);
 	}
 
-	private static Dictionary<string, string> LoadMap()
+	private void SaveTitle(string key, string? title)
 	{
-		var json = MobileSettings.CustomAppIconsJson;
+		var map = LoadMap(MobileSettings.CustomAppTitlesJson);
+		var t = title?.Trim();
+		if (string.IsNullOrWhiteSpace(t))
+			map.Remove(key);
+		else
+			map[key] = t;
+		MobileSettings.CustomAppTitlesJson = JsonSerializer.Serialize(map);
+	}
+
+	private static Dictionary<string, string> LoadMap(string? json)
+	{
 		if (string.IsNullOrWhiteSpace(json))
 			return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 		try

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Apps2Samsung.Backup;
 using Apps2Samsung.Mobile.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
 using Microsoft.Maui.Storage;
 
@@ -48,7 +49,8 @@ public partial class SettingsPage : ContentPage
 
 	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
 
-	private async void OnAppIconsClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new AppIconsPage());
+	private async void OnAppIconsClicked(object? sender, EventArgs e) =>
+		await Navigation.PushAsync(IPlatformApplication.Current!.Services.GetRequiredService<AppIconsPage>());
 
 	private async void OnJellyfinClicked(object? sender, EventArgs e) => await Navigation.PushAsync(new JellyfinSettingsPage());
 

--- a/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
+++ b/Apps2Samsung.Mobile/Services/MobileAppConfig.cs
@@ -12,6 +12,7 @@ namespace Apps2Samsung.Mobile.Services;
 public sealed class MobileAppConfig : IAppConfig
 {
     private const string KeyCustomIcons = "custom_app_icons_json";
+    private const string KeyCustomTitles = "custom_app_titles_json";
 
     // ---- Install behaviour ----
     public bool DeletePreviousInstall { get => MobileSettings.DeletePreviousInstall; set => MobileSettings.DeletePreviousInstall = value; }
@@ -34,6 +35,7 @@ public sealed class MobileAppConfig : IAppConfig
 
     // ---- Package patching ----
     public string CustomAppIconsJson { get => Preferences.Get(KeyCustomIcons, string.Empty); set => Preferences.Set(KeyCustomIcons, value ?? string.Empty); }
+    public string CustomAppTitlesJson { get => Preferences.Get(KeyCustomTitles, string.Empty); set => Preferences.Set(KeyCustomTitles, value ?? string.Empty); }
     public string TvAppChannelsJson { get => MobileSettings.TvAppChannelsJson; set => MobileSettings.TvAppChannelsJson = value; }
 
     // ---- Jellyfin package patching ----

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -210,6 +210,15 @@ public static class MobileSettings
 		set => Preferences.Set("custom_app_icons_json", value ?? string.Empty);
 	}
 
+	/// <summary>Per-app custom launcher titles: JSON map { appKey -> title }, written into the wgt's
+	/// config.xml &lt;name&gt; at install by the shared AppTitlePackagePatcher. (Same Preferences key as
+	/// MobileAppConfig.CustomAppTitlesJson.)</summary>
+	public static string CustomAppTitlesJson
+	{
+		get => Preferences.Get("custom_app_titles_json", string.Empty);
+		set => Preferences.Set("custom_app_titles_json", value ?? string.Empty);
+	}
+
 	/// <summary>Splits <see cref="ManualDuids"/> into individual DUIDs.</summary>
 	public static string[] ParseDuids() =>
 		ManualDuids.Split(new[] { '\n', '\r', ',', ';' },

--- a/Jellyfin2Samsung-CrossOS/App.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/App.axaml.cs
@@ -133,6 +133,14 @@ namespace Apps2Samsung
             // overrides the package's default and composes with the app-specific patchers above.
             // Now the shared Core patcher (was Apps2Samsung.Helpers.CustomIconPackagePatcher).
             services.AddSingleton<IPackagePatcher, Apps2Samsung.Packaging.CustomIconPackagePatcher>();
+            // Custom app title → config.xml <name> at install (shared Core patcher).
+            services.AddSingleton<IPackagePatcher, Apps2Samsung.Packaging.AppTitlePackagePatcher>();
+
+            // Shared app catalog for the icon/title editor (manifest → entries; HasOblong via the
+            // bundled-oblong source, so it stays correct per head).
+            services.AddSingleton<Apps2Samsung.Catalog.AppCatalog>(sp => new Apps2Samsung.Catalog.AppCatalog(
+                new Apps2Samsung.Helpers.Core.AddLatestRelease(sp.GetRequiredService<System.Net.Http.HttpClient>()),
+                sp.GetRequiredService<Apps2Samsung.Packaging.IOblongIconSource>()));
 
             // --------------------
             // Helpers

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -41,6 +41,8 @@
   "lblIconCustom": "Custom…",
   "lblIconReset": "Reset",
   "lblIconDefault": "Default",
+  "lblAppTitle": "Custom title",
+  "lblAppTitleHint": "Optional. Rename this app's launcher tile on the TV. Leave empty to keep the package's own name. Remembered per app and written into the package at install.",
   "lblSettings": "Application settings",
   "lblDeletePrevious": "Remove old version",
   "IpWindowTitle": "Enter TV IP",

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -133,6 +133,7 @@ namespace Apps2Samsung.Helpers
         public bool LitefinUseOblongIcon { get; set; } = false;  // legacy: migrated into CustomAppIconsJson ("oblong")
         public string ManualDuids { get; set; } = "";  // extra Tizen DUIDs to pre-authorize in the distributor cert (one per line / comma-separated)
         public string CustomAppIconsJson { get; set; } = "";  // JSON map { appKey -> "oblong" | custom launcher PNG path } applied to the wgt at install
+        public string CustomAppTitlesJson { get; set; } = "";  // JSON map { appKey -> custom title } written into the wgt's config.xml <name> at install
 
         // ----- IAppConfig adapters (not serialized; map the interface onto existing state) -----
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Models/AppIconEntry.cs
+++ b/Jellyfin2Samsung-CrossOS/Models/AppIconEntry.cs
@@ -30,6 +30,12 @@ namespace Apps2Samsung.Models
         [ObservableProperty]
         private string summary = string.Empty;
 
+        /// <summary>Custom launcher title for this app. "" keeps the package's own name; otherwise
+        /// persisted in <c>AppSettings.CustomAppTitlesJson</c> keyed by <see cref="Key"/> and written
+        /// into the package's config.xml &lt;name&gt; at install.</summary>
+        [ObservableProperty]
+        private string title = string.Empty;
+
         public bool IsOblong => string.Equals(Value, OblongValue, StringComparison.OrdinalIgnoreCase);
         public bool IsCustom => !string.IsNullOrEmpty(Value) && !IsOblong;
         public bool IsDefault => string.IsNullOrEmpty(Value);

--- a/Jellyfin2Samsung-CrossOS/ViewModels/AppIconsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/AppIconsViewModel.cs
@@ -31,7 +31,7 @@ namespace Apps2Samsung.ViewModels
         private readonly ILocalizationService _localizationService;
         private readonly FileHelper _fileHelper;
         private readonly ProviderManifestService _providerManifestService;
-        private readonly AddLatestRelease _addLatestRelease;
+        private readonly Apps2Samsung.Catalog.AppCatalog _appCatalog;
 
         public ObservableCollection<AppIconEntry> AppIcons { get; } = new();
 
@@ -46,16 +46,19 @@ namespace Apps2Samsung.ViewModels
         public string LblIconCustom => _localizationService.GetString("lblIconCustom");
         public string LblIconReset => _localizationService.GetString("lblIconReset");
         public string LblIconDefault => _localizationService.GetString("lblIconDefault");
+        public string LblAppTitle => _localizationService.GetString("lblAppTitle");
+        public string LblAppTitleHint => _localizationService.GetString("lblAppTitleHint");
 
         public AppIconsViewModel(
             ILocalizationService localizationService,
             FileHelper fileHelper,
-            HttpClient httpClient)
+            HttpClient httpClient,
+            Apps2Samsung.Catalog.AppCatalog appCatalog)
         {
             _localizationService = localizationService;
             _fileHelper = fileHelper;
             _providerManifestService = new ProviderManifestService(httpClient);
-            _addLatestRelease = new AddLatestRelease(httpClient);
+            _appCatalog = appCatalog;
 
             _localizationService.LanguageChanged += OnLanguageChanged;
 
@@ -74,83 +77,68 @@ namespace Apps2Samsung.ViewModels
         {
             try
             {
+                // The head fetches the manifest; the shared Core AppCatalog does the list shaping
+                // (expand community assets, collapse Jellyfin variants, flag bundled oblong tiles),
+                // so desktop and mobile present the same app list (#521).
                 var manifest = await _providerManifestService.GetAsync();
+                var catalog = await _appCatalog.BuildAsync(manifest);
 
-                var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                var entries = new List<AppIconEntry>();
+                var iconMap = LoadIconMap();
+                var titleMap = LoadTitleMap();
 
-                void Add(string display, string key)
+                var entries = catalog.Select(c =>
                 {
-                    key = key?.Trim() ?? string.Empty;
-                    if (string.IsNullOrEmpty(key) || !seen.Add(key))
-                        return;
-
-                    entries.Add(new AppIconEntry
+                    var entry = new AppIconEntry
                     {
-                        DisplayName = string.IsNullOrWhiteSpace(display) ? key : display.Trim(),
-                        Key = key,
-                        HasOblong = HasBundledOblong(key),
-                    });
-                }
-
-                foreach (var provider in manifest.Providers)
-                {
-                    if (provider.ExpandAssets)
-                    {
-                        // Community bundle: derive one icon entry per real .wgt asset in the latest
-                        // release, so EVERY community app is offered and the list stays current with
-                        // the repo — instead of a hardcoded subset (see #462). Custom launcher icons
-                        // only apply to web apps, so skip native .tpk assets. Best-effort: a fetch
-                        // failure just yields no community rows rather than breaking the editor.
-                        if (string.IsNullOrWhiteSpace(provider.Url))
-                            continue;
-                        try
-                        {
-                            var releases = await _addLatestRelease.GetReleasesAsync(
-                                provider.Url, provider.Prefix, provider.DisplayName, provider.Take);
-                            foreach (var r in releases)
-                                foreach (var asset in r.Assets)
-                                {
-                                    if (!asset.FileName.EndsWith(".wgt", StringComparison.OrdinalIgnoreCase))
-                                        continue;
-                                    var name = Path.GetFileNameWithoutExtension(asset.FileName);
-                                    Add(name, name);
-                                }
-                        }
-                        catch (Exception ex)
-                        {
-                            Trace.WriteLine($"[AppIcons] Could not expand community assets from {provider.Url}: {ex.Message}");
-                        }
-                        continue;
-                    }
-
-                    // All Jellyfin builds share the "Jellyfin" file-name root, so collapse the
-                    // variants (AVPlay, Legacy, …) into a single entry that matches any of them.
-                    if (string.IsNullOrWhiteSpace(provider.DisplayName) ||
-                        provider.DisplayName.StartsWith("Jellyfin", StringComparison.OrdinalIgnoreCase))
-                        Add("Jellyfin", "Jellyfin");
-                    else
-                        Add(provider.DisplayName, provider.DisplayName);
-                }
-
-                var map = LoadIconMap();
-                foreach (var entry in entries)
-                {
-                    entry.Value = map.TryGetValue(entry.Key, out var v) ? v : string.Empty;
+                        DisplayName = c.DisplayName,
+                        Key = c.Key,
+                        HasOblong = c.HasOblong,
+                        Value = iconMap.TryGetValue(c.Key, out var v) ? v : string.Empty,
+                        Title = titleMap.TryGetValue(c.Key, out var t) ? t : string.Empty,
+                    };
                     RefreshSummary(entry);
-                }
+                    return entry;
+                }).ToList();
 
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
+                    // Drop the previous rows' change subscriptions before rebuilding the list.
+                    foreach (var old in AppIcons)
+                        old.PropertyChanged -= OnEntryPropertyChanged;
+
                     AppIcons.Clear();
                     foreach (var entry in entries)
+                    {
+                        entry.PropertyChanged += OnEntryPropertyChanged;
                         AppIcons.Add(entry);
+                    }
                 });
             }
             catch (Exception ex)
             {
                 Trace.WriteLine($"[AppIcons] Failed to build the app-icon list: {ex.Message}");
             }
+        }
+
+        // A custom title is edited inline (TextBox two-way bound to the entry), so persist it whenever
+        // the entry's Title changes — mirroring how SetIcon auto-saves the icon choice.
+        private void OnEntryPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppIconEntry.Title) && sender is AppIconEntry entry)
+                SaveTitle(entry);
+        }
+
+        private void SaveTitle(AppIconEntry entry)
+        {
+            var map = LoadTitleMap();
+            var title = entry.Title?.Trim() ?? string.Empty;
+            if (string.IsNullOrEmpty(title))
+                map.Remove(entry.Key);
+            else
+                map[entry.Key] = title;
+
+            AppSettings.Default.CustomAppTitlesJson = JsonSerializer.Serialize(map);
+            AppSettings.Default.Save();
         }
 
         [RelayCommand(CanExecute = nameof(HasSelectedAppIcon))]
@@ -207,13 +195,12 @@ namespace Apps2Samsung.ViewModels
                     : Path.GetFileName(entry.Value);
         }
 
-        private static bool HasBundledOblong(string key)
-            => key.IndexOf("tvapp", StringComparison.OrdinalIgnoreCase) >= 0
-            || key.IndexOf("litefin", StringComparison.OrdinalIgnoreCase) >= 0;
+        private static Dictionary<string, string> LoadIconMap() => LoadMap(AppSettings.Default.CustomAppIconsJson);
 
-        private static Dictionary<string, string> LoadIconMap()
+        private static Dictionary<string, string> LoadTitleMap() => LoadMap(AppSettings.Default.CustomAppTitlesJson);
+
+        private static Dictionary<string, string> LoadMap(string? json)
         {
-            var json = AppSettings.Default.CustomAppIconsJson;
             if (string.IsNullOrWhiteSpace(json))
                 return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
@@ -245,6 +232,8 @@ namespace Apps2Samsung.ViewModels
             OnPropertyChanged(nameof(LblIconCustom));
             OnPropertyChanged(nameof(LblIconReset));
             OnPropertyChanged(nameof(LblIconDefault));
+            OnPropertyChanged(nameof(LblAppTitle));
+            OnPropertyChanged(nameof(LblAppTitleHint));
 
             foreach (var entry in AppIcons)
                 RefreshSummary(entry);
@@ -253,6 +242,8 @@ namespace Apps2Samsung.ViewModels
         public void Dispose()
         {
             _localizationService.LanguageChanged -= OnLanguageChanged;
+            foreach (var entry in AppIcons)
+                entry.PropertyChanged -= OnEntryPropertyChanged;
         }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Views/AppIconsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/AppIconsView.axaml
@@ -56,6 +56,22 @@
 				</StackPanel>
 			</Grid>
 
+			<!-- Custom launcher title for the selected app (written into config.xml <name> at install). -->
+			<StackPanel Spacing="4" IsVisible="{Binding HasSelectedAppIcon}" Margin="0,4,0,0">
+				<TextBlock Text="{Binding LblAppTitle}"
+						   FontSize="13"
+						   FontWeight="SemiBold"
+						   Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"/>
+				<TextBox Text="{Binding SelectedAppIcon.Title, Mode=TwoWay, UpdateSourceTrigger=LostFocus}"
+						 Watermark="{Binding SelectedAppIcon.DisplayName}"
+						 HorizontalAlignment="Left"
+						 MinWidth="320"/>
+				<TextBlock Text="{Binding LblAppTitleHint}"
+						   FontSize="11"
+						   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+						   TextWrapping="Wrap"/>
+			</StackPanel>
+
 		<!-- bottom slack: ScrollViewer under-measures wrapping content, so guarantee the last row clears the fold -->
 			<Border Height="40"/>
 		</StackPanel>


### PR DESCRIPTION
Fixes #521.

Extends the icon changer into Core so **mobile and desktop share the code**, and adds the ability to **change an app's launcher title**.

## Shared Core foundation
- **`AppCatalog`** (`Apps2Samsung.Core/Catalog`) — builds the installable-app list from a `ProviderManifest` (expand community `.wgt` assets, collapse Jellyfin variants, flag bundled oblong tiles via `IOblongIconSource`). Extracted from the desktop VM so both heads present the **same list**.
- **`WgtTitlePatcher`** + **`AppTitlePackagePatcher`** (`IPackagePatcher`) — write a custom title into the package's `config.xml` `<name>` at install, mirroring the custom-icon patcher.
- **`IAppConfig.CustomAppTitlesJson`** — the per-app title map, implemented on both heads (desktop `AppSettings`, mobile `MobileAppConfig`/`MobileSettings`).

## Desktop
- `AppIconsViewModel` now calls `AppCatalog.BuildAsync` instead of its own list logic; `HasOblong` comes from the real oblong source.
- New inline **Custom title** field per app, auto-saved.

## Mobile — *upgraded to the shared app list*
- Replaces the free-form "type an app name + pick a PNG" rows with the **same manifest-driven app list as desktop**; each app offers an icon picker **and** a custom title.
- Page resolved from DI (needs `CatalogService` + `AppCatalog`); `CatalogService.GetManifestAsync` exposed.

## Notes
- New localization keys (`lblAppTitle`, `lblAppTitleHint`) added to `en.json`; other locales fall back to English until translated.
- Both heads build clean (desktop .NET 10, mobile net10.0-android).