### PR TITLE
mobile: fix false 'Installed' when the Tizen install actually failed

### DIFF
--- a/Apps2Samsung.Core/Sdb/TizenInstallDiagnostics.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstallDiagnostics.cs
@@ -48,6 +48,21 @@ namespace Apps2Samsung.Sdb
             Has(output, Constants.TizenErrorCodes.Installing100) ||
             Has(output, Constants.TizenErrorCodes.InstallCompleted);
 
+        /// <summary>
+        /// The output reports the install actually FAILED — regardless of the process exit code.
+        /// Tizen's install helper returns process exit 0 (<c>cmd_ret:0</c>) even when the app install
+        /// itself failed (e.g. <c>app_id[...] install failed[118]</c>), so a caller must not treat a
+        /// zero exit code as success on its own — it has to classify the output. Matches any
+        /// <c>install failed[...]</c> code, a <c>val[fail]</c> result marker, and the transport /
+        /// out-of-space signals. Deliberately does NOT match a bare "failed" substring, so an
+        /// unrelated line (e.g. "Pull skipped or failed") can't be mistaken for an install failure.
+        /// </summary>
+        public static bool IndicatesFailure(string? output) =>
+            IsTransportLost(output) ||
+            IsInsufficientSpace(output) ||
+            Has(output, "install failed[") ||
+            Has(output, "val[fail]");
+
         private static bool Has(string? output, string token) =>
             !string.IsNullOrEmpty(output) && output.Contains(token, IC);
     }

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -121,7 +121,11 @@ public sealed class WgtInstaller
 
 		progress?.Invoke("Installing on TV…");
 		var install = await _sdb.InstallAsync(tvIp, wgtPath, sdkToolPath);
-		if (install.ExitCode != 0)
+		// The Tizen install helper returns a zero exit code (cmd_ret:0) even when the app install
+		// itself failed (e.g. "app_id[...] install failed[118]"). Trusting the exit code alone made
+		// the app report "✓ Installed" for installs that never landed on the TV — so classify the
+		// OUTPUT as well, mirroring the desktop head, and route real failures into recovery.
+		if (install.ExitCode != 0 || TizenInstallDiagnostics.IndicatesFailure(install.Output))
 			install = await RecoverInstallAsync(tvIp, wgtPath, sdkToolPath, packageId, install, progress, wasInstalledBefore);
 
 		if (MobileSettings.OpenAfterInstall && !string.IsNullOrWhiteSpace(appId))
@@ -185,7 +189,7 @@ public sealed class WgtInstaller
 			try { await _sdb.UninstallAsync(tvIp, packageId!); } catch { /* best-effort */ }
 
 			var retry = await _sdb.InstallAsync(tvIp, wgtPath, sdkToolPath);
-			if (retry.ExitCode == 0)
+			if (retry.ExitCode == 0 && !TizenInstallDiagnostics.IndicatesFailure(retry.Output))
 				return retry;
 
 			// Still failing after a clean slate — surface the most useful message.


### PR DESCRIPTION
## The report
Users install Overscan / Nuvio; the app shows **✓ Installed**, but the app is **not on the TV**.

## Root cause (from a user's debug log)
The install output ends with:
```
app_id[org.apps2samsung.overscan] install failed[118]
spend time for wascmd is [381]ms
cmd_ret:0
[installer] ✓ Installed Overscan…
```
Tizen's install helper **exits 0 (`cmd_ret:0`) even when the app install failed**. `WgtInstaller.InstallAsync` gated success on `install.ExitCode != 0` alone, so the failure never reached `RecoverInstallAsync` (where the `TizenInstallDiagnostics` classifier lives) and the app reported success. The **desktop** head classifies the output text, so it already handled this correctly — mobile-only bug.

## Fix
- **Core:** add `TizenInstallDiagnostics.IndicatesFailure(output)` — matches any `install failed[...]`, `val[fail]`, transport, or out-of-space marker. Deliberately **not** a bare `failed` substring, so unrelated lines ("Pull skipped or failed") can't false-trigger.
- **Mobile:** `WgtInstaller` treats an install as failed when the exit code is non-zero **or** the output indicates failure — for both the initial install and the recovery retry. Side benefit: `[118]` now actually reaches the existing uninstall-and-retry recovery instead of being skipped.

## Notes
- The underlying `[118]` for Overscan (persisting even with the Partner profile in the log) is a separate signing/privilege/leftover issue; this PR stops the app from *lying about it*. Now the user sees the real failure.
- Mobile head builds clean (net10.0-android).