### PR TITLE
Show 'restart required' TVs (Dev Mode on, SDB port down) + install-time popup

### DIFF
--- a/Apps2Samsung.Core/Network/TizenDeviceReadiness.cs
+++ b/Apps2Samsung.Core/Network/TizenDeviceReadiness.cs
@@ -1,0 +1,34 @@
+using Apps2Samsung.Models;
+
+namespace Apps2Samsung.Services
+{
+    /// <summary>
+    /// Shared readiness classification for a detected TV, so both heads agree on when a TV can be
+    /// installed to and show the same guidance when it can't. A TV that answered on the Samsung REST
+    /// API (port 8001) but whose SDB debug port (26101) isn't open has Developer Mode enabled but not
+    /// fully active yet — the TV must be restarted before it can be installed to.
+    /// </summary>
+    public static class TizenDeviceReadiness
+    {
+        /// <summary>
+        /// True when the TV was detected via the REST API only (debug port not up), so installing
+        /// can't work until it's restarted. Both heads gate the install on this and show
+        /// <see cref="RestartTitle"/> / <see cref="RestartInstructions"/>.
+        /// </summary>
+        public static bool RequiresRestart(NetworkDevice? device) =>
+            device is { DebugPortOpen: false } && !string.IsNullOrWhiteSpace(device.IpAddress);
+
+        /// <summary>Title of the "restart the TV" prompt. The desktop head shows a localized copy
+        /// (key <c>restartRequiredTitle</c>); the mobile head, which has no localization layer, uses
+        /// this string directly so both heads say the same thing.</summary>
+        public const string RestartTitle = "Restart the TV first";
+
+        /// <summary>Body of the "restart the TV" prompt (desktop key <c>restartRequiredBody</c>).</summary>
+        public const string RestartInstructions =
+            "This TV has Developer Mode on, but its install service isn't running yet, so it can't be " +
+            "installed to until it's restarted.\n\n" +
+            "• Press and hold the TV's power button until it fully shuts down, then turn it back on, or\n" +
+            "• Unplug the TV from power for a minute or two, then plug it back in.\n\n" +
+            "After it restarts, scan again and the TV will be ready.";
+    }
+}

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
+using Apps2Samsung.Services;
 using Apps2Samsung.Mobile.Catalog;
 using Apps2Samsung.Mobile.Services;
 using Apps2Samsung.Packaging;
@@ -32,6 +33,9 @@ public partial class InstallerPage : ContentPage
 	// manually added). The picker also shows a trailing ManualIpLabel entry that isn't in these.
 	private readonly List<string> _tvIps = new();
 	private readonly List<string> _tvLabels = new();
+	// Per-TV readiness, index-aligned with _tvIps: false = detected via the REST API only (SDB debug
+	// port not up yet), so it needs a restart before it can be installed to.
+	private readonly List<bool> _tvReady = new();
 	// Suppresses OnTvChanged while we rebuild the picker programmatically.
 	private bool _rebuildingTvPicker;
 	// The catalog releases backing AppPicker; the selected release's assets back VersionPicker.
@@ -253,6 +257,7 @@ public partial class InstallerPage : ContentPage
 		{
 			_tvIps.Add(ip);
 			_tvLabels.Add($"{ip} (manual)");
+			_tvReady.Add(true); // manual IPs are assumed ready; a real SDB error surfaces if not
 			idx = _tvIps.Count - 1;
 		}
 		RebuildTvPicker(idx);
@@ -285,9 +290,10 @@ public partial class InstallerPage : ContentPage
 		SetStatus("Scanning for TVs…");
 		try
 		{
-			var devices = (await _networkService.GetLocalTizenAddresses())
-				.Where(d => d.DebugPortOpen)
-				.ToList();
+			// Keep not-ready TVs (REST API answered but the SDB debug port isn't up): they're shown
+			// with a ⚠ marker so the user knows the TV was found but needs a restart first, instead of
+			// silently disappearing from the list.
+			var devices = (await _networkService.GetLocalTizenAddresses()).ToList();
 
 			var selected = TvPicker.SelectedIndex >= 0 && TvPicker.SelectedIndex < _tvIps.Count
 				? _tvIps[TvPicker.SelectedIndex]
@@ -295,18 +301,23 @@ public partial class InstallerPage : ContentPage
 
 			_tvIps.Clear();
 			_tvLabels.Clear();
+			_tvReady.Clear();
 			foreach (var d in devices)
 			{
 				_tvIps.Add(d.IpAddress);
 				_tvLabels.Add(d.DisplayText);
+				_tvReady.Add(d.DebugPortOpen);
 			}
 
 			var keep = selected is null ? -1 : _tvIps.IndexOf(selected);
 			RebuildTvPicker(_tvIps.Count > 0 ? (keep >= 0 ? keep : 0) : -1);
 
+			var notReady = _tvReady.Count(r => !r);
 			SetStatus(_tvIps.Count == 0
-				? "No debug-ready TVs found. Enable Developer Mode on the TV and refresh, or tap the TV list to enter an IP manually."
-				: "Ready for use…");
+				? "No TVs found. Enable Developer Mode on the TV and refresh, or tap the TV list to enter an IP manually."
+				: notReady > 0
+					? $"Found {_tvIps.Count} TV(s). ⚠ {notReady} need a restart before installing."
+					: "Ready for use…");
 		}
 		catch (Exception ex)
 		{
@@ -324,6 +335,18 @@ public partial class InstallerPage : ContentPage
 		{
 			SetStatus("Select a TV first (tap refresh to scan).");
 			return;
+		}
+
+		// The selected TV answered on the REST API but its SDB debug port isn't up yet — it can't be
+		// installed to until it's restarted. Warn (Continue/Stop) like the desktop head does.
+		if (TvPicker.SelectedIndex < _tvReady.Count && !_tvReady[TvPicker.SelectedIndex])
+		{
+			bool continueAnyway = await DisplayAlert(
+				TizenDeviceReadiness.RestartTitle,
+				TizenDeviceReadiness.RestartInstructions,
+				"Continue", "Stop");
+			if (!continueAnyway)
+				return;
 		}
 
 		var custom = CustomSelected;

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -65,6 +65,8 @@
   "DevNotReadyEnableDevMode": "⚠ TV detected, but Developer Mode is off. On the TV: open Apps, type 1 2 3 4 5, switch Developer Mode On, enter this PC's IP, restart the TV, then rescan.",
   "DevNotReadyPowerCycle": "⚠ TV detected and Developer Mode is on, but its debug port isn't responding yet. Fully power-cycle the TV (unplug ~30s), then rescan.",
   "DevNotReadyIpMismatch": "⚠ TV detected, but its Developer Mode IP doesn't match this PC. Re-enter this PC's IP in the TV's Developer Mode settings, power-cycle the TV, then rescan.",
+  "restartRequiredTitle": "Restart the TV first",
+  "restartRequiredBody": "This TV has Developer Mode on, but its install service isn't running yet, so it can't be installed to until it's restarted.\n\n• Press and hold the TV's power button until it fully shuts down, then turn it back on, or\n• Unplug the TV from power for a minute or two, then plug it back in.\n\nAfter it restarts, scan again and the TV will be ready.",
   "lblRTL": "Reverse IP (for Arabic/Hebrew)",
   "ServerIP": "Server IP",
   "Theme": "Theme",

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/PackageHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/PackageHelper.cs
@@ -2,6 +2,7 @@
 using Apps2Samsung.Extensions;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
+using Apps2Samsung.Services;
 using Apps2Samsung.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -41,6 +42,20 @@ namespace Apps2Samsung.Helpers.Core
         }
         public async Task<bool> InstallPackageAsync(string? packagePath, NetworkDevice selectedDevice, CancellationToken cancellationToken, ProgressCallback? progress = null, Action? onSamsungLoginStarted = null)
         {
+            // A TV detected only via the REST API (8001) has Developer Mode on but its SDB debug port
+            // (26101) isn't up yet — installing can't work until the TV is restarted. Gate it like the
+            // other pre-install confirmations: let the user stop (and restart the TV) or continue.
+            if (TizenDeviceReadiness.RequiresRestart(selectedDevice))
+            {
+                bool continueAnyway = await _dialogService.ShowConfirmationAsync(
+                    "restartRequiredTitle".Localized(),
+                    "restartRequiredBody".Localized(),
+                    "keyContinue".Localized(),
+                    "keyStop".Localized());
+                if (!continueAnyway)
+                    return false;
+            }
+
             if(selectedDevice.DeveloperIP == null) return false;
 
             var localIps = _networkService.GetRelevantLocalIPs()


### PR DESCRIPTION
## What
When a TV has **Developer Mode enabled but its SDB debug port (26101) isn't up yet**, it answers on the REST API (8001) only. Those TVs are now **shown in the dropdown marked as needing a restart**, and trying to install to one raises a **Continue/Stop popup** explaining how to restart — mirroring the developer-IP-mismatch gate.

## Detection
Already existed: the scan surfaces such TVs as `NetworkDevice.DebugPortOpen = false` (enriched via `/api/v2/`). This PR builds the UX on top.

## Changes
- **Core (new):** `TizenDeviceReadiness.RequiresRestart(device)` + the shared restart-prompt title/instructions, so both heads agree on readiness and wording.
- **Desktop:** `PackageHelper.InstallPackageAsync` gates install with a localized Continue/Stop popup (`restartRequiredTitle`/`restartRequiredBody`). Not-ready TVs were already listed with a ⚠ marker + a status hint; this adds the blocking confirmation.
- **Mobile:** the installer **no longer filters not-ready TVs out** of the picker — they show with the ⚠ marker and a "N need a restart before installing" summary — and install is gated with the same Continue/Stop popup.

## Popup wording
Tells the user to **press and hold the power button until the TV fully shuts down** and turn it back on, **or unplug it for a minute or two**, then rescan.

Both heads build clean (desktop .NET 10, mobile net10.0-android). Independent of #535 (different files).