### PR TITLE
Share the Tizen-version gate in Core + add it to mobile

### DIFF
--- a/Apps2Samsung.Core/Packaging/WgtManifest.cs
+++ b/Apps2Samsung.Core/Packaging/WgtManifest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Apps2Samsung.Packaging
+{
+    /// <summary>
+    /// Reads values from a <c>.wgt</c> package's <c>config.xml</c> that both heads need before install.
+    /// Kept in Core so the desktop and mobile installers share one implementation instead of each
+    /// parsing the manifest their own way.
+    /// </summary>
+    public static class WgtManifest
+    {
+        // <tizen:application ... required_version="X.Y" ...> — the minimum Tizen platform the package runs on.
+        private static readonly Regex RequiredVersionRegex = new(
+            @"<tizen:application\b[^>]*\brequired_version\s*=\s*""(?<version>[^""]+)""",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>
+        /// Reads the package's declared minimum Tizen version (<c>required_version</c>) from its
+        /// <c>config.xml</c>. Returns null if the file is missing, has no <c>config.xml</c>, or declares
+        /// no required version.
+        /// </summary>
+        public static async Task<string?> ReadRequiredVersionAsync(string wgtPath)
+        {
+            if (string.IsNullOrEmpty(wgtPath) || !File.Exists(wgtPath))
+                return null;
+
+            try
+            {
+                using var fs = File.OpenRead(wgtPath);
+                using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
+                var configEntry = archive.GetEntry("config.xml");
+                if (configEntry is null)
+                    return null;
+
+                using var reader = new StreamReader(configEntry.Open(), Encoding.UTF8);
+                var configContent = await reader.ReadToEndAsync();
+
+                var match = RequiredVersionRegex.Match(configContent);
+                return match.Success ? match.Groups["version"].Value : null;
+            }
+            catch
+            {
+                // A corrupt/unreadable package shouldn't crash the version gate — treat as "no requirement"
+                // and let the actual install surface the real error.
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// True when the TV can't run the package because its Tizen version is older than the package's
+        /// <paramref name="requiredVersion"/>. Lenient: returns false (allow the install) when the TV
+        /// version is unknown or the required version can't be parsed, so a malformed value never wrongly
+        /// blocks an install — the install itself will still surface any real incompatibility.
+        /// </summary>
+        public static bool RequiresNewerTizen(Version? tvVersion, string? requiredVersion) =>
+            tvVersion is not null
+            && Version.TryParse(requiredVersion, out var required)
+            && tvVersion < required;
+    }
+}

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -65,6 +65,15 @@ public sealed class WgtInstaller
 		// version before install and/or launch the app afterwards.
 		var (appId, packageId) = ReadPackageIds(wgtPath);
 
+		// Pre-install Tizen version gate (shared Core check, same as the desktop head): if the package
+		// declares a required_version newer than this TV, fail up front with a clear message instead of
+		// signing + pushing and getting back the ambiguous [118, -4] "operation not allowed".
+		var requiredVersion = await WgtManifest.ReadRequiredVersionAsync(wgtPath);
+		if (WgtManifest.RequiresNewerTizen(version, requiredVersion))
+			throw new InvalidOperationException(
+				$"This app needs Tizen {requiredVersion} or newer, but this TV is Tizen {caps.PlatformVersion}. " +
+				"Install an older build of the app, or update the TV's firmware.");
+
 		// Was this package already on the TV before we started? Needed so the failure-cleanup below
 		// only clears a partial from a FRESH install and never removes a pre-existing working app.
 		bool wasInstalledBefore = false;

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/FileHelper.cs
@@ -204,34 +204,6 @@ public async Task<string?> BrowseWgtFilesAsync(IStorageProvider storageProvider)
         
             return match.Success ? match.Groups["id"].Value : null;
         }
-        public static async Task<string?> ReadWgtRequiredVersion(string wgtPath)
-        {
-            if (!File.Exists(wgtPath))
-                return null;
-
-            using var memoryStream = new MemoryStream();
-            using (var originalStream = File.OpenRead(wgtPath))
-                await originalStream.CopyToAsync(memoryStream);
-
-            memoryStream.Position = 0;
-
-            using var archive = new ZipArchive(memoryStream, ZipArchiveMode.Read, true);
-            var configEntry = archive.GetEntry("config.xml");
-            if (configEntry == null)
-                return null;
-
-            string configContent;
-            using (var reader = new StreamReader(configEntry.Open(), Encoding.UTF8))
-                configContent = await reader.ReadToEndAsync();
-
-            var match = Regex.Match(
-                configContent,
-                @"<tizen:application\b[^>]*\brequired_version\s*=\s*""(?<version>[^""]+)""",
-                RegexOptions.IgnoreCase);
-
-            return match.Success ? match.Groups["version"].Value : null;
-        }
-
         /// <summary>
         /// True when the package bundles a background <c>&lt;tizen:service&gt;</c> component.
         /// Older Samsung TVs (Tizen 2.x/3.x) can't install such multi-component widgets and

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -7,6 +7,7 @@ using Apps2Samsung.Helpers.Jellyfin;
 using Apps2Samsung.Helpers.Tizen.Certificate;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
+using Apps2Samsung.Packaging;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -368,17 +369,14 @@ namespace Apps2Samsung.Services
                     return InstallResult.FailureResult(Constants.LocalizationKeys.TvNameNotFound.Localized());
                 }
 
-                // Step 3: Check is WGT is compatible with TV's Tizen version
-                var requiredTizenVersion = await FileHelper.ReadWgtRequiredVersion(packageUrl);
-                if (requiredTizenVersion != null)
+                // Step 3: Check the WGT is compatible with the TV's Tizen version (shared Core check,
+                // so the mobile head applies the exact same gate).
+                var requiredTizenVersion = await WgtManifest.ReadRequiredVersionAsync(packageUrl);
+                if (WgtManifest.RequiresNewerTizen(deviceInfo.TizenVersion, requiredTizenVersion))
                 {
-                    var requiredVersion = new Version(requiredTizenVersion);
-                    if (deviceInfo.TizenVersion < requiredVersion)
-                    {
-                        progress?.Invoke(Constants.LocalizationKeys.IncompatiblePackage.Localized());
-                        Trace.WriteLine($"Package requires Tizen {requiredVersion} but device has {deviceInfo.TizenVersion}");
-                        return InstallResult.FailureResult(string.Format(Constants.LocalizationKeys.IncompatiblePackageDetailed.Localized(), requiredTizenVersion, deviceInfo.TizenVersion));
-                    }
+                    progress?.Invoke(Constants.LocalizationKeys.IncompatiblePackage.Localized());
+                    Trace.WriteLine($"Package requires Tizen {requiredTizenVersion} but device has {deviceInfo.TizenVersion}");
+                    return InstallResult.FailureResult(string.Format(Constants.LocalizationKeys.IncompatiblePackageDetailed.Localized(), requiredTizenVersion, deviceInfo.TizenVersion));
                 }
 
                 // Step 4: Handle certificate selection/generation


### PR DESCRIPTION
## What
The **desktop** head already refuses a package before install when the TV's Tizen version is older than the package's `config.xml` `required_version`. The **mobile** head had **no such check** — it signed + pushed and only got back the ambiguous `[118, -4]` ("operation not allowed"), which can mean *too old* **or** *needs Partner signing*, so users couldn't tell which.

## Change (no duplicate code)
Moved the read logic out of the desktop `FileHelper` into **Core**, and both heads now use it:
- **Core (new) `WgtManifest`:** `ReadRequiredVersionAsync(wgt)` + `RequiresNewerTizen(tvVersion, requiredVersion)`. Lenient parsing — an unparseable/missing value never wrongly blocks an install.
- **Desktop:** `TizenInstallerService` Step 3 now calls the shared helper; `FileHelper.ReadWgtRequiredVersion` **removed** (it was the only caller).
- **Mobile:** `WgtInstaller` gates before signing/pushing — if the package needs a newer Tizen than the TV, it throws a clear *"This app needs Tizen X, but this TV is Tizen Y"* instead of the vague `[118, -4]`.

Both heads build clean (desktop .NET 10, mobile net10.0-android). Independent of #535/#536.