### PR TITLE
Self-hosted F-Droid repo (apps2samsung.com/fdroid/repo), auto-published on stable

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -1,0 +1,112 @@
+name: F-Droid Repo
+
+# Builds and publishes a self-hosted F-Droid repository from the latest signed stable
+# APK, to docs/fdroid/repo on the `beta` branch (GitHub Pages → https://apps2samsung.com/fdroid/repo).
+# Runs after a successful stable release, or on demand.
+on:
+  workflow_run:
+    workflows: ["Stable Release"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: fdroid-repo
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    # Only after a successful stable build (or a manual run).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: beta
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android build-tools (apksigner/aapt for fdroidserver)
+        uses: android-actions/setup-android@v3
+
+      - name: Install build-tools + fdroidserver
+        run: |
+          set -euo pipefail
+          sdkmanager "build-tools;34.0.0" >/dev/null
+          echo "${ANDROID_HOME}/build-tools/34.0.0" >> "$GITHUB_PATH"
+          python -m pip install --upgrade pip
+          pip install fdroidserver
+
+      - name: Download the latest stable APK
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts \
+                --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease==false)][0].tagName')
+          echo "Latest stable: $TAG"
+          mkdir -p build/repo
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern '*-android.apk' --dir build/repo
+          ls -la build/repo
+
+      - name: Assemble F-Droid config + metadata
+        env:
+          KS_B64: ${{ secrets.FDROID_KEYSTORE_BASE64 }}
+          KS_PASS: ${{ secrets.FDROID_KEYSTORE_PASS }}
+          KS_ALIAS: ${{ secrets.FDROID_KEY_ALIAS }}
+          KEY_PASS: ${{ secrets.FDROID_KEY_PASS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${KS_B64:-}" ]; then
+            echo "::error::FDROID_KEYSTORE_BASE64 is not set. Generate a repo keystore and add the"
+            echo "::error::FDROID_KEYSTORE_BASE64 / FDROID_KEYSTORE_PASS / FDROID_KEY_ALIAS / FDROID_KEY_PASS"
+            echo "::error::secrets — see fdroid/README.md."
+            exit 1
+          fi
+          echo "$KS_B64" | base64 -d > build/keystore.p12
+          cp -r fdroid/metadata build/metadata
+          # Reuse the store listing (icon, screenshots, descriptions) from the fastlane metadata.
+          dest="build/metadata/nl.madebypatrick.apps2samsung/en-US"
+          mkdir -p "$dest"
+          cp -r fastlane/metadata/android/en-US/* "$dest/" 2>/dev/null || true
+          cat > build/config.yml <<EOF
+          repo_url: https://apps2samsung.com/fdroid/repo
+          repo_name: Apps2Samsung
+          repo_description: >-
+            Self-hosted F-Droid repository for the Apps2Samsung Android installer
+            (the phone-as-installer head). Auto-updated from the project's signed
+            GitHub stable releases.
+          archive_older: 0
+          keystore: keystore.p12
+          repo_keyalias: "${KS_ALIAS}"
+          keystorepass: "${KS_PASS}"
+          keypass: "${KEY_PASS}"
+          keydname: "CN=Apps2Samsung, O=Apps2Samsung"
+          EOF
+
+      - name: Build the repo index
+        working-directory: build
+        run: fdroid update --create-metadata --pretty --verbose
+
+      - name: Publish to docs/fdroid (GitHub Pages, served from beta:/docs)
+        run: |
+          set -euo pipefail
+          rm -rf docs/fdroid/repo
+          mkdir -p docs/fdroid
+          cp -r build/repo docs/fdroid/repo
+          git config user.name "Patrick"
+          git config user.email "patrick@madebypatrick.nl"
+          git add docs/fdroid/repo
+          if git diff --cached --quiet; then
+            echo "No changes to publish."
+          else
+            git commit -m "fdroid: publish repo for the latest stable APK [skip ci]"
+            git push origin beta
+          fi

--- a/fdroid/README.md
+++ b/fdroid/README.md
@@ -1,0 +1,49 @@
+# Apps2Samsung F-Droid repository
+
+A **self-hosted, F-Droid-compatible** repository for the Apps2Samsung Android app. The
+official F-Droid buildserver can't build .NET MAUI, and IzzyOnDroid declined the app on
+AI-usage grounds — so we host our own repo. It's built from the project's **signed stable
+release APK** and published to GitHub Pages.
+
+- **Repo URL (add this in the F-Droid app):** `https://apps2samsung.com/fdroid/repo`
+- Served from `docs/fdroid/repo` on the `beta` branch (GitHub Pages, `apps2samsung.com`).
+- Rebuilt automatically by `.github/workflows/fdroid-repo.yml` after every successful
+  **Stable Release** (or on manual `workflow_dispatch`). Only the latest APK is kept.
+
+## One-time setup: the repo signing key
+
+An F-Droid repo signs its *index* with a keystore that is **separate** from the app's
+signing key. Generate it once (locally), then add it to the repo secrets.
+
+```bash
+keytool -genkeypair -v \
+  -keystore fdroid-repo.p12 -storetype PKCS12 \
+  -alias apps2samsung -keyalg RSA -keysize 4096 -validity 10000 \
+  -dname "CN=Apps2Samsung, O=Apps2Samsung"
+# choose a password when prompted; use the SAME value for both secrets below (PKCS12
+# uses one password for the store and the key).
+
+base64 -w0 fdroid-repo.p12    # copy the output for FDROID_KEYSTORE_BASE64
+```
+
+Add these **repository secrets** (Settings → Secrets and variables → Actions):
+
+| Secret | Value |
+|--------|-------|
+| `FDROID_KEYSTORE_BASE64` | the `base64 -w0 fdroid-repo.p12` output |
+| `FDROID_KEYSTORE_PASS`   | the keystore password you chose |
+| `FDROID_KEY_ALIAS`       | `apps2samsung` |
+| `FDROID_KEY_PASS`        | same as `FDROID_KEYSTORE_PASS` (PKCS12) |
+
+⚠️ Keep `fdroid-repo.p12` and its password safe and **reuse the same keystore forever** —
+if it changes, existing users' F-Droid clients reject the repo and must re-add it.
+
+Once the secrets are set, run the **F-Droid Repo** workflow manually once
+(Actions → F-Droid Repo → Run workflow) to publish the first index; after that it runs on
+each stable release.
+
+## For users
+
+In the F-Droid app (or Droid-ify / Neo Store): **Settings → Repositories → Add**, paste
+`https://apps2samsung.com/fdroid/repo`, then install Apps2Samsung. Updates arrive
+automatically whenever a new stable is published.

--- a/fdroid/metadata/nl.madebypatrick.apps2samsung.yml
+++ b/fdroid/metadata/nl.madebypatrick.apps2samsung.yml
@@ -1,0 +1,36 @@
+Categories:
+  - Multimedia
+  - System
+License: MIT
+AuthorName: Patrick Stel
+WebSite: https://apps2samsung.com
+SourceCode: https://github.com/Apps2Samsung/Apps2Samsung
+IssueTracker: https://github.com/Apps2Samsung/Apps2Samsung/issues
+Changelog: https://github.com/Apps2Samsung/Apps2Samsung/releases
+
+AutoName: Apps2Samsung
+Summary: Install Jellyfin and other apps on your Samsung Tizen TV from your phone
+
+Description: |-
+    Apps2Samsung is a cross-platform installer that sideloads Jellyfin and other
+    web and community apps onto Samsung Tizen TVs — no PC, no Tizen Studio, and no
+    manual sideloading.
+
+    This Android build is the mobile (phone) installer head: put the TV into
+    Developer Mode, point the app at it over your local network, sign in once with a
+    free Samsung account to provision a signing certificate, and install.
+
+    Features:
+
+    * Finds Samsung Tizen TVs on your network, or connect directly by IP.
+    * Installs Jellyfin (multiple build variants) and a catalog of community apps.
+    * Give any app a custom launcher icon and a custom title.
+    * Optional Jellyfin server pre-configuration: server URL, auto-login, custom CSS.
+    * Uses a free Samsung account certificate — no paid developer account required.
+
+    Requires a Samsung Tizen TV in Developer Mode on the same local network as the
+    phone. Desktop versions for Windows, macOS and Linux are also available.
+
+# Prebuilt APKs are published to this repo from the project's signed GitHub stable
+# releases; there is no from-source build here (the app is .NET MAUI, which F-Droid's
+# buildserver can't build). `fdroid update` reads the version from the APK itself.


### PR DESCRIPTION
Since official F-Droid can't build .NET MAUI and **IzzyOnDroid declined on AI-usage grounds**, this hosts our **own F-Droid-compatible repo** — fully in our control, auto-updating on each stable.

## How it works
- Served at **`https://apps2samsung.com/fdroid/repo`** from `docs/fdroid/repo` on `beta` (Pages is legacy deploy-from-branch `beta:/docs`, so publishing there needs no Pages rework and doesn't trigger app builds — `docs/**` is in the beta workflow's paths-ignore).
- **`.github/workflows/fdroid-repo.yml`** runs after a successful **Stable Release** (or manual dispatch): downloads the signed stable APK, reuses the fastlane icon/screenshots/descriptions, runs `fdroid update` to build + sign the index, and commits `docs/fdroid/repo`. Only the latest APK is kept.
- **`fdroid/metadata/nl.madebypatrick.apps2samsung.yml`** — the app listing.
- **`fdroid/README.md`** — setup + user instructions.

## Blocker: one-time repo keystore (your step)
An F-Droid repo signs its index with a keystore separate from the app key. I can't create the secret — generate it once and add four repo secrets (`FDROID_KEYSTORE_BASE64`, `FDROID_KEYSTORE_PASS`, `FDROID_KEY_ALIAS`, `FDROID_KEY_PASS`); exact `keytool` command is in `fdroid/README.md`. Then run the **F-Droid Repo** workflow once to publish the first index.

## Note
`fdroidserver` in CI can be finicky; the first dispatch run may need a tweak or two — I'll iterate once the secrets are in. Repo APKs are committed to `docs/` (git grows slowly); happy to switch to Actions-based Pages deployment later if you'd rather not commit them.