### PR TITLE
Shared 'TV information' view (DUID, Tizen version, dev mode/IP, …) on both heads

### DIFF
--- a/Apps2Samsung.Core/Models/TizenDeviceInfo.cs
+++ b/Apps2Samsung.Core/Models/TizenDeviceInfo.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+
+namespace Apps2Samsung.Models
+{
+    /// <summary>One label/value pair in the TV-information view.</summary>
+    public sealed record DeviceInfoRow(string Label, string Value);
+
+    /// <summary>
+    /// Everything we can report about a connected TV, gathered by
+    /// <see cref="Apps2Samsung.Sdb.TizenDeviceInfoService"/> and shown by both heads' "TV information"
+    /// view. Values are best-effort — anything the TV didn't report shows as "—".
+    /// </summary>
+    public sealed record TizenDeviceInfo(
+        string IpAddress,
+        string DeviceName,
+        string ModelName,
+        string Manufacturer,
+        string Duid,
+        string TizenVersion,
+        string SdkToolPath,
+        string DeveloperMode,
+        string DeveloperIp,
+        bool DebugPortOpen)
+    {
+        private static string Dash(string? s) => string.IsNullOrWhiteSpace(s) ? "—" : s.Trim();
+
+        private string DeveloperModeDisplay => DeveloperMode?.Trim() switch
+        {
+            "1" => "On",
+            "0" => "Off",
+            _ => "—",
+        };
+
+        /// <summary>The info as ordered label/value rows, ready to render in a simple key/value list.</summary>
+        public IReadOnlyList<DeviceInfoRow> Rows => new List<DeviceInfoRow>
+        {
+            new("TV IP", Dash(IpAddress)),
+            new("Device name", Dash(DeviceName)),
+            new("Model", Dash(ModelName)),
+            new("Manufacturer", Dash(Manufacturer)),
+            new("Tizen OS version", Dash(TizenVersion)),
+            new("DUID", Dash(Duid)),
+            new("Developer mode", DeveloperModeDisplay),
+            new("Developer host IP", Dash(DeveloperIp)),
+            new("Debug port (26101)", DebugPortOpen ? "Open" : "Closed"),
+            new("SDK tool path", Dash(SdkToolPath)),
+        };
+    }
+}

--- a/Apps2Samsung.Core/Sdb/TizenDeviceInfoService.cs
+++ b/Apps2Samsung.Core/Sdb/TizenDeviceInfoService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+
+namespace Apps2Samsung.Sdb
+{
+    /// <summary>
+    /// Gathers everything shown in the "TV information" view into a <see cref="TizenDeviceInfo"/>, so
+    /// both heads report the same details. Reads the DUID and capabilities over SDB (works on any
+    /// connected TV) and, best-effort, the Samsung REST API (port 8001) for the friendly name, model,
+    /// and Developer-Mode host/IP. Every lookup is defensive — a TV that doesn't answer one source just
+    /// leaves those fields blank rather than failing the whole view.
+    /// </summary>
+    public static class TizenDeviceInfoService
+    {
+        private const int SamsungTvApiPort = 8001;
+
+        public static async Task<TizenDeviceInfo> GatherAsync(ISdbEngine sdb, string ip, bool debugPortOpen)
+        {
+            // ---- SDB: DUID + capabilities (Tizen version, SDK tool path) ----
+            string duid = string.Empty;
+            try
+            {
+                var d = await sdb.DuidAsync(ip);
+                duid = d.Output?.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim() ?? string.Empty;
+                if (!TizenDuid.IsValid(duid))
+                    duid = string.Empty;
+            }
+            catch { /* leave blank */ }
+
+            string tizenVersion = string.Empty, sdkToolPath = string.Empty;
+            try
+            {
+                var c = await sdb.CapabilityAsync(ip);
+                var caps = TizenCapabilities.Parse(c.Output);
+                tizenVersion = caps.PlatformVersion ?? string.Empty;
+                sdkToolPath = caps.SdkToolPath ?? string.Empty;
+            }
+            catch { /* leave blank */ }
+
+            // ---- REST /api/v2/: name, model, manufacturer, developer mode + host IP ----
+            string name = string.Empty, model = string.Empty, manufacturer = string.Empty,
+                   developerMode = string.Empty, developerIp = string.Empty;
+            try
+            {
+                using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+                var json = await http.GetStringAsync($"http://{ip}:{SamsungTvApiPort}/api/v2/");
+                var device = JsonNode.Parse(json)?["device"];
+                if (device is not null)
+                {
+                    name = WebUtility.HtmlDecode(device["name"]?.GetValue<string>() ?? string.Empty);
+                    model = device["modelName"]?.GetValue<string>() ?? string.Empty;
+                    manufacturer = device["type"]?.GetValue<string>() ?? string.Empty;
+                    developerMode = device["developerMode"]?.GetValue<string>() ?? string.Empty;
+                    developerIp = device["developerIP"]?.GetValue<string>() ?? string.Empty;
+                }
+            }
+            catch { /* REST unreachable — leave those fields blank */ }
+
+            return new TizenDeviceInfo(
+                IpAddress: ip,
+                DeviceName: name,
+                ModelName: model,
+                Manufacturer: manufacturer,
+                Duid: duid,
+                TizenVersion: tizenVersion,
+                SdkToolPath: sdkToolPath,
+                DeveloperMode: developerMode,
+                DeveloperIp: developerIp,
+                DebugPortOpen: debugPortOpen);
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Pages/DeviceInfoPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/DeviceInfoPage.xaml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Apps2Samsung.Mobile.Pages.DeviceInfoPage"
+             Title="TV information"
+             NavigationPage.HasNavigationBar="False"
+             BackgroundColor="{AppThemeBinding Light=#ECEFF1, Dark=#141414}">
+
+    <Grid RowDefinitions="Auto,Auto,*" Margin="12" RowSpacing="10">
+
+        <!-- Header banner with a back affordance -->
+        <Border Grid.Row="0" BackgroundColor="#2C3E50" Padding="12,18" StrokeThickness="0" StrokeShape="RoundRectangle 8">
+            <Grid ColumnDefinitions="44,*,44" ColumnSpacing="4" VerticalOptions="Center">
+                <Button Grid.Column="0" Text="‹" FontSize="26" TextColor="White"
+                        BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                        WidthRequest="44" HeightRequest="44" Clicked="OnBackClicked" />
+                <Label Grid.Column="1" Text="TV information" TextColor="White" FontAttributes="Bold"
+                       VerticalOptions="Center" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+                <Button Grid.Column="2" x:Name="RefreshBtn" Text="⟳" FontSize="18" TextColor="White"
+                        BackgroundColor="Transparent" BorderWidth="0" Padding="0"
+                        WidthRequest="44" HeightRequest="44" Clicked="OnRefreshClicked" />
+            </Grid>
+        </Border>
+
+        <!-- Subtitle: which TV / status -->
+        <Label Grid.Row="1" x:Name="CountLabel" FontSize="12" Opacity="0.6" Text="Loading…" />
+
+        <!-- Info rows -->
+        <CollectionView Grid.Row="2" x:Name="RowsList">
+            <CollectionView.EmptyView>
+                <Label x:Name="EmptyLabel" Text="No information to show." Padding="16"
+                       HorizontalTextAlignment="Center" Opacity="0.6" />
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Border Margin="0,4" Padding="12,10" StrokeThickness="1" StrokeShape="RoundRectangle 8"
+                            Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
+                            BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
+                        <Grid ColumnDefinitions="140,*" ColumnSpacing="12" VerticalOptions="Center">
+                            <Label Grid.Column="0" Text="{Binding Label}" FontSize="13" Opacity="0.6"
+                                   VerticalOptions="Center" />
+                            <Label Grid.Column="1" Text="{Binding Value}" FontSize="13" FontAttributes="Bold"
+                                   VerticalOptions="Center" />
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+        <!-- Busy overlay -->
+        <ActivityIndicator Grid.Row="2" x:Name="Busy" IsRunning="False" IsVisible="False"
+                           VerticalOptions="Center" HorizontalOptions="Center" Color="#2C3E50" />
+
+    </Grid>
+
+</ContentPage>

--- a/Apps2Samsung.Mobile/Pages/DeviceInfoPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/DeviceInfoPage.xaml.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Sdb;
+
+namespace Apps2Samsung.Mobile.Pages;
+
+/// <summary>
+/// Shows a TV's details (DUID, Tizen version, developer mode/IP, IP, …) gathered by the shared Core
+/// <see cref="TizenDeviceInfoService"/> — the same data the desktop head shows.
+/// </summary>
+public partial class DeviceInfoPage : ContentPage
+{
+	private readonly ISdbEngine _sdb;
+	private readonly string _tvIp;
+	private readonly string _tvLabel;
+	private readonly bool _debugPortOpen;
+
+	public DeviceInfoPage(ISdbEngine sdb, string tvIp, string tvLabel, bool debugPortOpen)
+	{
+		InitializeComponent();
+		_sdb = sdb;
+		_tvIp = tvIp;
+		_tvLabel = tvLabel;
+		_debugPortOpen = debugPortOpen;
+		CountLabel.Text = tvLabel;
+	}
+
+	protected override async void OnAppearing()
+	{
+		base.OnAppearing();
+		await LoadAsync();
+	}
+
+	private async void OnBackClicked(object? sender, EventArgs e) => await Navigation.PopAsync();
+
+	private async void OnRefreshClicked(object? sender, EventArgs e) => await LoadAsync();
+
+	private async Task LoadAsync()
+	{
+		SetBusy(true, "Reading TV information…");
+		try
+		{
+			var info = await TizenDeviceInfoService.GatherAsync(_sdb, _tvIp, _debugPortOpen);
+			RowsList.ItemsSource = info.Rows;
+			CountLabel.Text = _tvLabel;
+		}
+		catch (Exception ex)
+		{
+			RowsList.ItemsSource = null;
+			EmptyLabel.Text = $"Couldn't read TV information: {ex.Message}";
+			CountLabel.Text = _tvLabel;
+		}
+		finally
+		{
+			SetBusy(false);
+		}
+	}
+
+	private void SetBusy(bool busy, string? status = null)
+	{
+		Busy.IsVisible = busy;
+		Busy.IsRunning = busy;
+		RowsList.IsVisible = !busy;
+		if (status is not null)
+			CountLabel.Text = status;
+	}
+}

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
@@ -76,10 +76,16 @@
                 </Grid>
 
                 <!-- Quick peek at what's already on the selected TV -->
-                <Button Text="📋 Show installed apps" Clicked="OnShowInstalledAppsClicked"
-                        HorizontalOptions="Start" BackgroundColor="Transparent" BorderWidth="0"
-                        Padding="0" FontSize="13"
-                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
+                <HorizontalStackLayout Spacing="18">
+                    <Button Text="📋 Show installed apps" Clicked="OnShowInstalledAppsClicked"
+                            BackgroundColor="Transparent" BorderWidth="0"
+                            Padding="0" FontSize="13"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
+                    <Button Text="ℹ️ TV information" Clicked="OnShowDeviceInfoClicked"
+                            BackgroundColor="Transparent" BorderWidth="0"
+                            Padding="0" FontSize="13"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
+                </HorizontalStackLayout>
 
                 <!-- Status bar -->
                 <Border BackgroundColor="#2C3E50" Padding="16" StrokeThickness="0" StrokeShape="RoundRectangle 6">

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -276,6 +276,20 @@ public partial class InstallerPage : ContentPage
 		await Navigation.PushAsync(new InstalledAppsPage(_sdb, tvIp, label));
 	}
 
+	private async void OnShowDeviceInfoClicked(object? sender, EventArgs e)
+	{
+		if (TvPicker.SelectedIndex < 0 || TvPicker.SelectedIndex >= _tvIps.Count)
+		{
+			SetStatus("Select a TV first (tap refresh to scan).");
+			return;
+		}
+		var idx = TvPicker.SelectedIndex;
+		var tvIp = _tvIps[idx];
+		var label = TvPicker.SelectedItem as string ?? tvIp;
+		var debugPortOpen = idx >= _tvReady.Count || _tvReady[idx];
+		await Navigation.PushAsync(new DeviceInfoPage(_sdb, tvIp, label, debugPortOpen));
+	}
+
 	private async void OnRefreshClicked(object? sender, EventArgs e) => await ScanAsync();
 
 	private async void OnSettingsClicked(object? sender, EventArgs e) =>

--- a/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
@@ -25,5 +25,9 @@ namespace Apps2Samsung.Interfaces
 
         /// <summary>Uninstalls an app from the TV by its Tizen id. Returns the raw SDB result.</summary>
         Task<Apps2Samsung.Models.ProcessResult> UninstallAppAsync(string tvIpAddress, string tizenId);
+
+        /// <summary>Gathers the TV's details (DUID, Tizen version, developer mode/IP, …) for the
+        /// "TV information" view, using the shared Core gatherer.</summary>
+        Task<Apps2Samsung.Models.TizenDeviceInfo> GetDeviceInfoAsync(string tvIpAddress, bool debugPortOpen);
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -1100,6 +1100,19 @@ namespace Apps2Samsung.Services
             }
         }
 
+        public async Task<TizenDeviceInfo> GetDeviceInfoAsync(string tvIpAddress, bool debugPortOpen)
+        {
+            await EnsureTizenSdbAvailable();
+            try
+            {
+                return await Apps2Samsung.Sdb.TizenDeviceInfoService.GatherAsync(_sdb, tvIpAddress, debugPortOpen);
+            }
+            finally
+            {
+                await _sdb.DisconnectAsync(tvIpAddress);
+            }
+        }
+
         public async Task<ProcessResult> UninstallAppAsync(string tvIpAddress, string tizenId)
         {
             await EnsureTizenSdbAvailable();

--- a/Jellyfin2Samsung-CrossOS/ViewModels/DeviceInfoViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/DeviceInfoViewModel.cs
@@ -1,0 +1,71 @@
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace Apps2Samsung.ViewModels
+{
+    /// <summary>
+    /// Shows a TV's details (DUID, Tizen version, developer mode/IP, IP, …) gathered by the shared
+    /// Core <see cref="Apps2Samsung.Sdb.TizenDeviceInfoService"/> — the same data the mobile head shows.
+    /// </summary>
+    public partial class DeviceInfoViewModel : ViewModelBase
+    {
+        private readonly ITizenInstallerService _installer;
+        private readonly string _tvIp;
+        private readonly bool _debugPortOpen;
+
+        public string TvLabel { get; }
+
+        public ObservableCollection<DeviceInfoRow> Rows { get; } = new();
+
+        [ObservableProperty]
+        private bool isBusy;
+
+        [ObservableProperty]
+        private string statusText = string.Empty;
+
+        public event Action? OnRequestClose;
+
+        public DeviceInfoViewModel(ITizenInstallerService installer, string tvIp, string tvLabel, bool debugPortOpen)
+        {
+            _installer = installer;
+            _tvIp = tvIp;
+            TvLabel = tvLabel;
+            _debugPortOpen = debugPortOpen;
+        }
+
+        [RelayCommand]
+        private async Task Load()
+        {
+            IsBusy = true;
+            StatusText = "Reading TV information…";
+            try
+            {
+                var info = await _installer.GetDeviceInfoAsync(_tvIp, _debugPortOpen);
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    Rows.Clear();
+                    foreach (var row in info.Rows)
+                        Rows.Add(row);
+                });
+                StatusText = TvLabel;
+            }
+            catch (Exception ex)
+            {
+                StatusText = $"Couldn't read TV information: {ex.Message}";
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        private void Close() => OnRequestClose?.Invoke();
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -622,6 +622,35 @@ namespace Apps2Samsung.ViewModels
         }
 
         [RelayCommand]
+        private async Task ShowDeviceInfoAsync()
+        {
+            try
+            {
+                if (SelectedDevice is null ||
+                    string.IsNullOrWhiteSpace(SelectedDevice.IpAddress) ||
+                    SelectedDevice.IpAddress == L("lblOther"))
+                {
+                    await _dialogService.ShowMessageAsync("TV information", "Select a TV first.");
+                    return;
+                }
+
+                if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop)
+                    return;
+
+                var label = string.IsNullOrWhiteSpace(SelectedDevice.DisplayText)
+                    ? SelectedDevice.IpAddress
+                    : SelectedDevice.DisplayText;
+                var vm = new DeviceInfoViewModel(_tizenInstaller, SelectedDevice.IpAddress, label, SelectedDevice.DebugPortOpen);
+                var window = new Views.DeviceInfoWindow(vm);
+                await window.ShowDialog(desktop.MainWindow);
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowErrorAsync($"Failed to open TV information: {ex}");
+            }
+        }
+
+        [RelayCommand]
         private async Task BrowseWgtAsync()
         {
             var mainWindow = Avalonia.Application.Current?.ApplicationLifetime is

--- a/Jellyfin2Samsung-CrossOS/Views/DeviceInfoWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/DeviceInfoWindow.axaml
@@ -1,0 +1,61 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:viewModels="clr-namespace:Apps2Samsung.ViewModels"
+        xmlns:models="clr-namespace:Apps2Samsung.Models;assembly=Apps2Samsung.Core"
+        x:Class="Apps2Samsung.Views.DeviceInfoWindow"
+        x:Name="Root"
+        x:DataType="viewModels:DeviceInfoViewModel"
+        Width="520" MinWidth="420"
+        Height="480" MinHeight="360"
+        WindowStartupLocation="CenterOwner"
+        Title="TV information">
+
+    <Window.Styles>
+        <StyleInclude Source="avares://Avalonia.Themes.Fluent/FluentTheme.xaml"/>
+        <StyleInclude Source="avares://Apps2Samsung/Styles/Buttons.axaml"/>
+        <StyleInclude Source="avares://Apps2Samsung/Styles/TextBlocks.axaml"/>
+    </Window.Styles>
+
+    <Border Background="{DynamicResource CardBackgroundFillColorDefaultBrush}" Padding="16">
+        <DockPanel LastChildFill="True">
+
+            <!-- Header -->
+            <Grid DockPanel.Dock="Top" ColumnDefinitions="*,Auto" Margin="0,0,0,4">
+                <StackPanel Grid.Column="0" Spacing="2">
+                    <TextBlock Text="TV information" FontSize="18" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding TvLabel}" FontSize="12" Opacity="0.6"/>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
+                    <Button Content="↻" Command="{Binding LoadCommand}" ToolTip.Tip="Refresh"/>
+                    <Button Content="✕" Command="{Binding CloseCommand}"/>
+                </StackPanel>
+            </Grid>
+
+            <!-- Busy indicator -->
+            <ProgressBar DockPanel.Dock="Top" IsIndeterminate="True" Height="3" Margin="0,8,0,8"
+                         IsVisible="{Binding IsBusy}"/>
+
+            <!-- Info rows -->
+            <ScrollViewer>
+                <ItemsControl ItemsSource="{Binding Rows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="models:DeviceInfoRow">
+                            <Border Margin="0,3" Padding="12,10"
+                                    Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
+                                    CornerRadius="8">
+                                <Grid ColumnDefinitions="150,*" ColumnSpacing="12">
+                                    <TextBlock Grid.Column="0" Text="{Binding Label}" FontSize="13" Opacity="0.6"
+                                               VerticalAlignment="Center"/>
+                                    <SelectableTextBlock Grid.Column="1" Text="{Binding Value}" FontSize="13"
+                                                         FontWeight="SemiBold" TextWrapping="Wrap"
+                                                         VerticalAlignment="Center"/>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+
+        </DockPanel>
+    </Border>
+</Window>

--- a/Jellyfin2Samsung-CrossOS/Views/DeviceInfoWindow.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/Views/DeviceInfoWindow.axaml.cs
@@ -1,0 +1,20 @@
+using Avalonia.Controls;
+using Apps2Samsung.ViewModels;
+
+namespace Apps2Samsung.Views
+{
+    public partial class DeviceInfoWindow : Window
+    {
+        public DeviceInfoWindow(DeviceInfoViewModel vm)
+        {
+            InitializeComponent();
+            DataContext = vm;
+            vm.OnRequestClose += Close;
+            // Kick off the initial load once the window is shown.
+            Opened += async (_, _) => await vm.LoadCommand.ExecuteAsync(null);
+        }
+
+        // Parameterless ctor for the XAML designer.
+        public DeviceInfoWindow() => InitializeComponent();
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/MainWindow.axaml
@@ -149,13 +149,22 @@
 				</Grid>
 
 				<!-- Quick peek at what's already on the selected TV -->
-				<Button HorizontalAlignment="Left" Padding="0" Background="Transparent" BorderThickness="0"
-						Command="{Binding ShowInstalledAppsCommand}">
-					<StackPanel Orientation="Horizontal" Spacing="6">
-						<fa:SymbolIcon Symbol="List" Width="16" Height="16"/>
-						<TextBlock Text="Show installed apps" VerticalAlignment="Center"/>
-					</StackPanel>
-				</Button>
+				<StackPanel Orientation="Horizontal" Spacing="16">
+					<Button HorizontalAlignment="Left" Padding="0" Background="Transparent" BorderThickness="0"
+							Command="{Binding ShowInstalledAppsCommand}">
+						<StackPanel Orientation="Horizontal" Spacing="6">
+							<fa:SymbolIcon Symbol="List" Width="16" Height="16"/>
+							<TextBlock Text="Show installed apps" VerticalAlignment="Center"/>
+						</StackPanel>
+					</Button>
+					<Button HorizontalAlignment="Left" Padding="0" Background="Transparent" BorderThickness="0"
+							Command="{Binding ShowDeviceInfoCommand}">
+						<StackPanel Orientation="Horizontal" Spacing="6">
+							<fa:SymbolIcon Symbol="Important" Width="16" Height="16"/>
+							<TextBlock Text="TV information" VerticalAlignment="Center"/>
+						</StackPanel>
+					</Button>
+				</StackPanel>
 
 			</StackPanel>
 


### PR DESCRIPTION
Adds a **TV information** panel next to *Installed apps*, showing everything we know about the selected TV — mirroring the installed-apps feature's shared pattern.

## Fields
TV IP · device name · model · manufacturer · Tizen OS version · DUID · developer mode · developer host IP · debug port (26101) state · SDK tool path.

## Shared in Core
- **`TizenDeviceInfo`** — the model, with ready-to-render `Rows` (label/value), "—" for anything the TV didn't report.
- **`TizenDeviceInfoService.GatherAsync(sdb, ip, debugPortOpen)`** — reads DUID + capabilities over SDB (works on any connected TV) and, best-effort, the Samsung `/api/v2` REST API for name/model/developer-mode/IP. Fully defensive: one unreachable source just blanks those fields.

## Heads
- **Desktop:** `DeviceInfoViewModel` + `DeviceInfoWindow`, opened from a new **TV information** link beside *Show installed apps* (via `ITizenInstallerService.GetDeviceInfoAsync`).
- **Mobile:** `DeviceInfoPage` + an **ℹ️ TV information** button on the installer page.

Both heads build clean (desktop .NET 10, mobile net10.0-android).