### PR TITLE
docs: live F-Droid repo instructions (README + landing page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The phone app is the mobile installer head — run the whole install from your p
 
 - **Obtainium** — tracks this repo's GitHub releases and updates automatically when a new **stable** is published. Add it with one tap:
   [Add to Obtainium](https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/Apps2Samsung/Apps2Samsung), or paste `https://github.com/Apps2Samsung/Apps2Samsung` into Obtainium's *Add App*.
-- **IzzyOnDroid / F-Droid** — pending inclusion in the [IzzyOnDroid](https://apt.izzysoft.de/fdroid/) repo; once live it will auto-track new stable releases inside the F-Droid app.
+- **F-Droid** — add our repository in the F-Droid app (Settings → Repositories → Add): `https://apps2samsung.com/fdroid/repo`. It serves the latest **stable** and updates automatically. Works in F-Droid, Droid-ify and Neo Store.
 - **Direct** — grab the `-android.apk` from any [release](https://github.com/Apps2Samsung/Apps2Samsung/releases) and sideload it.
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -290,6 +290,7 @@
         <span class="eyebrow">New</span>
         <h3>Now you can install from your phone</h3>
         <p>The brand-new Android app turns your phone into the installer — scan for your TV, sign in to Samsung, pick an app and install, all from the couch. No laptop, no cables. Everything the desktop does, in your pocket.</p>
+        <p style="margin-top:.7em;font-size:.95em;opacity:.85">Want auto-updates? Add our <b>F-Droid</b> repository — <code>https://apps2samsung.com/fdroid/repo</code> — in F-Droid, Droid-ify or Neo Store, or one-tap with <a href="https://apps.obtainium.imranr.dev/redirect?r=obtainium://add/https://github.com/Apps2Samsung/Apps2Samsung">Obtainium</a>. Both track new stable releases automatically.</p>
       </div>
       <a class="btn primary" href="#download">Get the Android app</a>
     </div>


### PR DESCRIPTION
The self-hosted F-Droid repo is live at `https://apps2samsung.com/fdroid/repo`. Updates the README's Android section and the apps2samsung.com landing page (Android band) with real add-the-repo instructions + Obtainium. Docs-only.