### PR TITLE
#541: updater downloaded stable for a detected beta; add a beta-updates toggle

### DIFF
--- a/Apps2Samsung.Core/Update/GitHubUpdateChecker.cs
+++ b/Apps2Samsung.Core/Update/GitHubUpdateChecker.cs
@@ -29,6 +29,10 @@ namespace Apps2Samsung.Update
         public string ReleasesPageUrl => $"https://github.com/{_owner}/{_repo}/releases";
         private string AtomFeedUrl => $"https://github.com/{_owner}/{_repo}/releases.atom";
         private string LatestApiUrl => $"https://api.github.com/repos/{_owner}/{_repo}/releases/latest";
+        // The specific release the feed identified — NOT /releases/latest, which GitHub always resolves
+        // to the latest *stable* (so a detected beta would otherwise download the older stable asset).
+        private string ReleaseByTagApiUrl(string tag) =>
+            $"https://api.github.com/repos/{_owner}/{_repo}/releases/tags/{Uri.EscapeDataString(tag)}";
 
         /// <param name="currentVersion">The running app's version (e.g. "v2.7.0").</param>
         /// <param name="includePrereleases">
@@ -133,7 +137,13 @@ namespace Apps2Samsung.Update
         {
             try
             {
-                using var request = new HttpRequestMessage(HttpMethod.Get, LatestApiUrl);
+                // Resolve the asset from the release the feed actually detected (may be a pre-release),
+                // so the download matches the version we told the user about. Fall back to /releases/latest
+                // only if we somehow don't have the tag.
+                var apiUrl = string.IsNullOrWhiteSpace(result.LatestVersion)
+                    ? LatestApiUrl
+                    : ReleaseByTagApiUrl(result.LatestVersion);
+                using var request = new HttpRequestMessage(HttpMethod.Get, apiUrl);
                 request.Headers.UserAgent.ParseAdd("Apps2Samsung");
                 using var response = await _http.SendAsync(request, ct);
                 if (!response.IsSuccessStatusCode)

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -101,7 +101,7 @@ public partial class InstallerPage : ContentPage
 			var current = AppInfo.Current.VersionString;
 			var result = await _updateChecker.CheckForUpdateAsync(
 				current,
-				includePrereleases: true, // mobile ships as -beta releases
+				includePrereleases: MobileSettings.IncludeBetaUpdates, // beta channel toggle (Settings)
 				assetMatcher: name => name.EndsWith(".apk", StringComparison.OrdinalIgnoreCase));
 
 			if (!result.IsSuccess || !result.IsUpdateAvailable)

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -108,6 +108,12 @@
                     <Switch Grid.Column="1" x:Name="ShowAllJfSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
                 </Grid>
                 <Grid Style="{StaticResource ToggleRow}">
+                    <Label Grid.Column="0" Text="Beta updates" VerticalOptions="Center" />
+                    <Switch Grid.Column="1" x:Name="BetaUpdatesSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
+                </Grid>
+                <Label Style="{StaticResource Hint}"
+                       Text="When on, the in-app update check offers new beta versions and downloads them. Turn off to only be notified about stable releases." />
+                <Grid Style="{StaticResource ToggleRow}">
                     <Label Grid.Column="0" Text="Partner signing (experimental)" VerticalOptions="Center" />
                     <Switch Grid.Column="1" x:Name="PartnerSigningSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
                 </Grid>

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -35,6 +35,7 @@ public partial class SettingsPage : ContentPage
 		OpenAfterSwitch.IsToggled = MobileSettings.OpenAfterInstall;
 		KeepWgtSwitch.IsToggled = MobileSettings.KeepWgtFile;
 		ShowAllJfSwitch.IsToggled = MobileSettings.ShowAllJellyfinVersions;
+		BetaUpdatesSwitch.IsToggled = MobileSettings.IncludeBetaUpdates;
 		PartnerSigningSwitch.IsToggled = MobileSettings.PartnerSigning;
 		TryOverwriteSwitch.IsToggled = MobileSettings.TryOverwrite;
 		ForceLoginSwitch.IsToggled = MobileSettings.ForceSamsungLogin;
@@ -243,6 +244,7 @@ public partial class SettingsPage : ContentPage
 		MobileSettings.OpenAfterInstall = OpenAfterSwitch.IsToggled;
 		MobileSettings.KeepWgtFile = KeepWgtSwitch.IsToggled;
 		MobileSettings.ShowAllJellyfinVersions = ShowAllJfSwitch.IsToggled;
+		MobileSettings.IncludeBetaUpdates = BetaUpdatesSwitch.IsToggled;
 		MobileSettings.PartnerSigning = PartnerSigningSwitch.IsToggled;
 		MobileSettings.TryOverwrite = TryOverwriteSwitch.IsToggled;
 		MobileSettings.ForceSamsungLogin = ForceLoginSwitch.IsToggled;

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -58,6 +58,15 @@ public static class MobileSettings
 		set => Preferences.Set(KeyShowAllJf, value);
 	}
 
+	/// <summary>Offer beta (pre-release) versions in the in-app update check, and download that beta
+	/// rather than the older stable. On by default — the mobile app has historically shipped as -beta
+	/// builds, so keep existing users on the beta channel unless they turn it off.</summary>
+	public static bool IncludeBetaUpdates
+	{
+		get => Preferences.Get("include_beta_updates", true);
+		set => Preferences.Set("include_beta_updates", value);
+	}
+
 	/// <summary>Force a fresh Samsung login + certificate even when a reusable one exists (desktop:
 	/// "Force Samsung login"). Off by default.</summary>
 	public static bool ForceSamsungLogin

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -59,6 +59,7 @@
   "InitializationFailed": "Initialization failed...",
   "lblForceLogin": "Force Samsung certificate",
   "lblShowAllJellyfinVersions": "Show all Jellyfin versions",
+  "lblIncludeBetaUpdates": "Include beta versions in update checks",
   "DeveloperModeRequired": "Samsung TV is not in developer mode...",
   "DeveloperIPMismatch": "Samsung Developer mode IP doesn't match this devices local IP, do you wish to continue?",
   "DeveloperIPReversed": "IP is in reversed order on the TV, please re-enable developer mode and type your local IP in reversed order. (ex: 192.168.1.2 → 2.1.168.192)",

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -88,6 +88,9 @@ namespace Apps2Samsung.Helpers
         // installs, and svdca may not issue Partner certs for individual accounts.
         public bool PartnerSigning { get; set; } = false;
         public bool ShowAllJellyfinVersions { get; set; } = false;
+        // When on, the in-app update check offers beta (pre-release) versions too, and downloads that
+        // beta — not the older stable. Off by default on desktop (stable channel).
+        public bool IncludeBetaUpdates { get; set; } = false;
         public bool RTLReading { get; set; } = false;
         public string JellyfinIP { get; set; } = "";
         public string JellyfinBasePath { get; set; } = "";

--- a/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/UpdaterService.cs
@@ -46,7 +46,7 @@ namespace Apps2Samsung.Services
             var platformSuffix = GetPlatformSuffix();
             var result = await _checker.CheckForUpdateAsync(
                 CurrentVersion,
-                includePrereleases: false,
+                includePrereleases: AppSettings.Default.IncludeBetaUpdates,
                 assetMatcher: name => name.Contains(platformSuffix, StringComparison.OrdinalIgnoreCase) &&
                     (name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) ||
                      name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase)),

--- a/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/AppSettingsViewModel.cs
@@ -61,6 +61,9 @@ namespace Apps2Samsung.ViewModels
         private bool showAllJellyfinVersions;
 
         [ObservableProperty]
+        private bool includeBetaUpdates;
+
+        [ObservableProperty]
         private bool rtlReading;
 
         [ObservableProperty]
@@ -102,6 +105,7 @@ namespace Apps2Samsung.ViewModels
         public string LblDeletePrevious => _localizationService.GetString("lblDeletePrevious");
         public string LblForceLogin => _localizationService.GetString("lblForceLogin");
         public string LblShowAllJellyfinVersions => _localizationService.GetString("lblShowAllJellyfinVersions");
+        public string LblIncludeBetaUpdates => _localizationService.GetString("lblIncludeBetaUpdates");
         public string LblRTL => _localizationService.GetString("lblRTL");
         public string LblKeepWGTFile => _localizationService.GetString("lblKeepWGTFile");
         public string LblSettingsHeader => _localizationService.GetString("lblSettings");
@@ -163,6 +167,7 @@ namespace Apps2Samsung.ViewModels
             OnPropertyChanged(nameof(LblDeletePrevious));
             OnPropertyChanged(nameof(LblForceLogin));
             OnPropertyChanged(nameof(LblShowAllJellyfinVersions));
+            OnPropertyChanged(nameof(LblIncludeBetaUpdates));
             OnPropertyChanged(nameof(LblRTL));
             OnPropertyChanged(nameof(LblKeepWGTFile));
             OnPropertyChanged(nameof(LblSettingsHeader));
@@ -186,6 +191,7 @@ namespace Apps2Samsung.ViewModels
             ForceSamsungLogin = AppSettings.Default.ForceSamsungLogin;
             PartnerSigning = AppSettings.Default.PartnerSigning;
             ShowAllJellyfinVersions = AppSettings.Default.ShowAllJellyfinVersions;
+            IncludeBetaUpdates = AppSettings.Default.IncludeBetaUpdates;
             RtlReading = AppSettings.Default.RTLReading;
             LocalIP = AppSettings.Default.LocalIp ?? string.Empty;
             TryOverwrite = AppSettings.Default.TryOverwrite;
@@ -506,6 +512,12 @@ namespace Apps2Samsung.ViewModels
         partial void OnShowAllJellyfinVersionsChanged(bool value)
         {
             AppSettings.Default.ShowAllJellyfinVersions = value;
+            AppSettings.Default.Save();
+        }
+
+        partial void OnIncludeBetaUpdatesChanged(bool value)
+        {
+            AppSettings.Default.IncludeBetaUpdates = value;
             AppSettings.Default.Save();
         }
 

--- a/Jellyfin2Samsung-CrossOS/Views/AppSettingsView.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/AppSettingsView.axaml
@@ -205,6 +205,17 @@
 								  VerticalAlignment="Center"/>
 				</Grid>
 
+				<!-- Include beta versions in update checks -->
+				<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+					<TextBlock Grid.Column="0"
+							   Text="{Binding LblIncludeBetaUpdates}"
+							   Classes="label"
+							   VerticalAlignment="Center"/>
+					<ToggleSwitch Grid.Column="1"
+								  IsChecked="{Binding IncludeBetaUpdates}"
+								  VerticalAlignment="Center"/>
+				</Grid>
+
 				<!-- RTL Reading -->
 				<Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
 					<TextBlock Grid.Column="0"


### PR DESCRIPTION
Fixes #541 — *"Inline update shows 2.7.5-beta but downloads 2.7.4 stable."*

## Root cause
The version was detected from the releases **Atom feed** (honors pre-releases → `2.7.5-beta`), but the download URL was resolved from GitHub's **`/releases/latest`**, which always returns the newest **stable** (`2.7.4`). Version and download came from different releases.

## Fix
1. **Core (`GitHubUpdateChecker`)** — resolve the asset from the **detected release's tag** (`/releases/tags/<tag>`) rather than `/releases/latest`. Now the shown version and the downloaded file always match (beta → beta, stable → stable).
2. **Opt-in beta toggle** on both heads, as requested:
   - Desktop: a **"Include beta versions in update checks"** Settings toggle (default **off** — stable channel).
   - Mobile: a **"Beta updates"** switch (default **on** — preserves the mobile beta channel, since mobile ships as -beta builds).
   - It gates whether pre-releases are both **offered** and **downloaded**.

Result: opt in → see & download beta; opt out → stable only.

Both heads build clean (desktop .NET 10, mobile net10.0-android).