### PR TITLE
#547: don't crash startup when Tizen SDB can't be downloaded; guide manual install

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -8,6 +8,7 @@
   "FailedLoadingReleases": "Failed to load releases:",
   "InstallTizenSdb": "The Tizen SDB is required but not found. Retrying to download.",
   "FailedTizenSdb": "Tizen SDB is required but could not be found and downloaded.",
+  "TizenSdbManualDownload": "The Tizen SDB component couldn't be downloaded — GitHub may be unreachable, rate-limited, or temporarily returning no releases.\n\nTo continue, install it manually:\n\n1. Open https://github.com/PatrickSt1991/tizen-sdb/releases/latest and download the file for your operating system.\n2. Place it in this folder:\n{0}\n3. Restart Apps2Samsung.",
   "ConnectingToDevice": "Connecting to device...",
   "TvNameNotFound": "TV Name could not be found...",
   "TvDuidNotFound": "TV duid could not be found...",

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -106,7 +106,25 @@ namespace Apps2Samsung.Services
                 return TizenSdbPath;
             }
 
-            string downloadedFile = await DownloadTizenSdbAsync();
+            string? downloadedFile = await DownloadTizenSdbAsync();
+
+            // Couldn't fetch a fresh binary (offline / proxy / GitHub outage / no releases). Fall back
+            // to an existing copy if we have one; otherwise report failure (empty path) so the UI shows
+            // the FailedTizenSdb banner instead of crashing initialization (#547).
+            if (string.IsNullOrEmpty(downloadedFile))
+            {
+                if (existingFile != null && File.Exists(existingFile))
+                {
+                    Trace.WriteLine("[TizenSdb] Download unavailable — using the existing Tizen SDB binary.");
+                    await _processHelper.MakeExecutableAsync(existingFile);
+                    TizenSdbPath = existingFile;
+                    return TizenSdbPath;
+                }
+
+                Trace.WriteLine("[TizenSdb] Download unavailable and no existing binary — signalling failure.");
+                TizenSdbPath = null;
+                return string.Empty;
+            }
 
             if (existingFile != null && File.Exists(existingFile))
             {
@@ -186,7 +204,14 @@ namespace Apps2Samsung.Services
             }
         }
 
-        public async Task<string> DownloadTizenSdbAsync()
+        /// <summary>
+        /// Downloads the platform Tizen SDB binary from the tizen-sdb GitHub releases. Returns the
+        /// downloaded file path, or <c>null</c> if it couldn't be fetched (GitHub unreachable/unstable,
+        /// rate-limited, no releases, or no matching asset). Never throws for those cases, so
+        /// <see cref="EnsureTizenSdbAvailable"/> can degrade to the FailedTizenSdb banner instead of
+        /// crashing initialization (#547).
+        /// </summary>
+        public async Task<string?> DownloadTizenSdbAsync()
         {
             try
             {
@@ -194,27 +219,38 @@ namespace Apps2Samsung.Services
                 var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(json, JsonSerializerOptionsProvider.Default);
                 // Skip drafts: GitHub sorts them to the top once authenticated, but a draft's asset
                 // browser_download_url 404s. Take the newest published release.
-                var firstRelease = (releases?.FirstOrDefault(r => !r.Draft)) ?? throw new InvalidOperationException("No releases found");
-                string nameMatch = PlatformService.GetAssetPlatformIdentifier();
+                var firstRelease = releases?.FirstOrDefault(r => !r.Draft);
+                if (firstRelease is null)
+                {
+                    Trace.WriteLine("[TizenSdb] GitHub returned no releases for tizen-sdb — cannot download.");
+                    return null;
+                }
 
+                string nameMatch = PlatformService.GetAssetPlatformIdentifier();
                 var matchedAsset = firstRelease.Assets.FirstOrDefault(a =>
                     !string.IsNullOrEmpty(a.FileName) &&
                     a.FileName.Contains(nameMatch, StringComparison.OrdinalIgnoreCase));
 
-                return matchedAsset == null
-                    ? throw new InvalidOperationException($"No matching asset found for {nameMatch}")
-                    : await DownloadPackageAsync(matchedAsset.DownloadUrl);
+                if (matchedAsset is null)
+                {
+                    Trace.WriteLine($"[TizenSdb] No matching Tizen SDB asset for '{nameMatch}'.");
+                    return null;
+                }
+
+                return await DownloadPackageAsync(matchedAsset.DownloadUrl);
             }
             catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
             {
-                throw new TimeoutException(
-                    "GitHub rate limit reached while checking for Tizen SDB.\n\n" +
-                    "To avoid this, set a GitHub Personal Access Token (PAT) in settings,\n" +
-                    "or set the GITHUB_TOKEN environment variable,\n" +
-                    "or install the GitHub CLI (gh) and run 'gh auth login'.\n\n" +
-                    "Alternatively, please try again later.",
-                    ex
-                );
+                Trace.WriteLine("[TizenSdb] GitHub rate limit reached while fetching Tizen SDB. " +
+                    "Set a GitHub PAT in settings / GITHUB_TOKEN / 'gh auth login' to avoid this.");
+                return null;
+            }
+            catch (Exception ex)
+            {
+                // Offline, corporate proxy/firewall blocking api.github.com, a GitHub outage, a 404/504,
+                // or malformed JSON — degrade gracefully rather than taking down startup (#547).
+                Trace.WriteLine($"[TizenSdb] Could not download Tizen SDB: {ex.GetType().Name} — {ex.Message}");
+                return null;
             }
         }
 

--- a/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/MainWindowViewModel.cs
@@ -269,6 +269,11 @@ namespace Apps2Samsung.ViewModels
                 if (string.IsNullOrEmpty(tizenSdb))
                 {
                     SetStatus("FailedTizenSdb");
+                    // Tizen SDB couldn't be downloaded (GitHub outage/rate-limit/no releases) and there's
+                    // no local copy — tell the user how to install it by hand instead of leaving them stuck.
+                    await _dialogService.ShowMessageAsync(
+                        L("FailedTizenSdb"),
+                        string.Format(L("TizenSdbManualDownload"), AppSettings.TizenSdbPath));
                     return;
                 }
 


### PR DESCRIPTION
Fixes #547 — app crashes on startup with `InvalidOperationException: No releases found` when the tizen-sdb GitHub Releases API is unreachable/unstable or returns no releases (GitHub outage, offline, corporate proxy — reproduced on a fresh macOS clone).

## Cause
`DownloadTizenSdbAsync()` threw, and the exception propagated `EnsureTizenSdbAvailable → InitializeAsync`, surfacing as a scary *Initialization failed* error. `InitializeAsync` already handles an **empty** SDB path gracefully (shows the `FailedTizenSdb` banner) — it just never got the chance because the call threw.

## Fix (as the issue suggested)
- **`DownloadTizenSdbAsync` returns `null`** (never throws) on any fetch failure — no releases, no matching asset, rate-limited, offline, proxy/firewall, 404/504, malformed JSON. Each is logged.
- **`EnsureTizenSdbAvailable` handles `null`:** fall back to an existing local binary if one is present; otherwise return an empty path so the UI shows the **FailedTizenSdb** banner instead of crashing.
- **Manual-install popup:** `InitializeAsync` now also shows a dialog telling the user to download the binary from `https://github.com/PatrickSt1991/tizen-sdb/releases/latest` and place it in the app's Tizen SDB folder (the real per-OS path is shown), then restart.

Desktop-only (mobile uses the in-process SDB engine). Builds clean (.NET 10).