### PR TITLE
fix: TizenSdb version parsing bug on macOS and Linux

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -94,8 +94,8 @@ namespace Jellyfin2Samsung.Services
         {
             try
             {
-                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(existingFilePath);
-                var match = RegexPatterns.Version.FileNameVersion.Match(fileNameWithoutExtension);
+                var fileName = Path.GetFileName(existingFilePath);
+                var match = RegexPatterns.Version.FileNameVersion.Match(fileName);
 
                 if (!match.Success)
                     return true;


### PR DESCRIPTION
# Pull Request Template

## Branch
- [X] I branched off beta (not master) to develop this feature/fix

## Description
On macOS and Linux platforms, the downloaded `TizenSdb` binary typically lacks a `.exe` file extension (e.g., `TizenSdb_v1.1.2_macos-arm64`). When extracting the local file version using `Path.GetFileNameWithoutExtension`, .NET interprets any substring following the last dot (such as `.2_macos-arm64`) as the file extension. This truncates the filename to `TizenSdb_v1.1`, which subsequently fails the strict `RegexPatterns.Version.FileNameVersion` matcher (`_([v]?\d+\.\d+\.\d+)`). 

As a result, `ShouldUpdateBinary` fails to validate the current version and consistently returns `true`, triggering a forced redownload and replacement of the binary every time `EnsureTizenSdbAvailable` is invoked.

### Solution
Switched `Path.GetFileNameWithoutExtension` to `Path.GetFileName`. This ensures the full filename is passed to the regex engine, which correctly extracts the complete `v1.1.2` version string regardless of the presence or absence of a `.exe` suffix.

### Examples

**Before:**
```csharp
var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(existingFilePath); 
// Results in: "TizenSdb_v1.1" (strips ".2_macos-arm64" as extension)
var match = RegexPatterns.Version.FileNameVersion.Match(fileNameWithoutExtension); 
// Fails match, forces redownload
```

**After:**
```csharp
var fileName = Path.GetFileName(existingFilePath); 
// Results in: "TizenSdb_v1.1.2_macos-arm64"
var match = RegexPatterns.Version.FileNameVersion.Match(fileName); 
// Matches "v1.1.2", skips redownload
```

---

## Type of Change

- [X] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [X] My code follows the existing project structure and style  
- [X] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [ ] I have verified that the installer still works with the underlying CLI  

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
