### PR TITLE
Recreate v2.7.6 binaries — include #551 (macOS/Linux Tizen SDB redownload fix)

### DIFF
--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -144,8 +144,8 @@ namespace Apps2Samsung.Services
         {
             try
             {
-                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(existingFilePath);
-                var match = RegexPatterns.Version.FileNameVersion.Match(fileNameWithoutExtension);
+                var fileName = Path.GetFileName(existingFilePath);
+                var match = RegexPatterns.Version.FileNameVersion.Match(fileName);
 
                 if (!match.Success)
                     return true;


### PR DESCRIPTION
Rebuilds the v2.7.6 beta and stable binaries to include #551 by @eduardomozart — fixes macOS/Linux re-downloading the Tizen SDB on every launch (filename version-parsing bug). No version bump; recreates the v2.7.6 artifacts. Merge as a **merge commit**.