### PR TITLE
feat: implement remote app launch, stop, and debug mode port forwarding

### DIFF
--- a/Apps2Samsung.Core/Sdb/ISdbEngine.cs
+++ b/Apps2Samsung.Core/Sdb/ISdbEngine.cs
@@ -44,5 +44,11 @@ namespace Apps2Samsung.Interfaces
 
         /// <summary>Pushes the distributor device-profile XML that permits sideloading.</summary>
         Task<ProcessResult> PermitInstallAsync(string tvIpAddress, string deviceXml, string sdkToolPath);
+
+        /// <summary>Executes a generic shell command on the TV.</summary>
+        Task<ProcessResult> ShellAsync(string tvIpAddress, string command);
+
+        /// <summary>Forwards a local TCP port to a remote TCP port on the TV.</summary>
+        Task<IAsyncDisposable> ForwardAsync(string tvIpAddress, int localPort, int remotePort);
     }
 }

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
@@ -50,11 +50,21 @@
                                     <Label Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.55" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
-                            <Button Grid.Column="1" Text="Uninstall" Clicked="OnUninstallClicked"
-                                    IsVisible="{Binding IsRemovable}" VerticalOptions="Center"
-                                    BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
-                                    BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
-                                    TextColor="{AppThemeBinding Light=#B00020, Dark=#FF6B6B}" />
+                            <HorizontalStackLayout Grid.Column="1" Spacing="8" VerticalOptions="Center">
+                                <Button Text="▶" ToolTipProperties.Text="Run" Clicked="OnLaunchClicked" FontSize="18"
+                                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
+                                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=#ECEFF1}" />
+                                <Button Text="⏹" ToolTipProperties.Text="Stop" Clicked="OnStopClicked" FontSize="18"
+                                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
+                                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                                        TextColor="{AppThemeBinding Light=#2C3E50, Dark=#ECEFF1}" />
+                                <Button Text="🗑️" ToolTipProperties.Text="Uninstall" Clicked="OnUninstallClicked" FontSize="18"
+                                        IsVisible="{Binding IsRemovable}"
+                                        BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
+                                        BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                                        TextColor="{AppThemeBinding Light=#B00020, Dark=#FF6B6B}" />
+                            </HorizontalStackLayout>
                         </Grid>
                     </Border>
                 </DataTemplate>

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
@@ -151,6 +151,54 @@ public partial class InstalledAppsPage : ContentPage
 		await LoadAsync();
 	}
 
+	private async void OnLaunchClicked(object? sender, EventArgs e)
+	{
+		if (sender is not Button { BindingContext: InstalledApp app })
+			return;
+
+		SetBusy(true, $"Launching {app.DisplayName}…");
+		try
+		{
+			var result = await _sdb.LaunchAsync(_tvIp, app.TizenId);
+			if (result.ExitCode != 0)
+			{
+				await DisplayAlert("Launch failed", result.Error, "OK");
+			}
+		}
+		catch (Exception ex)
+		{
+			await DisplayAlert("Launch failed", ex.Message, "OK");
+		}
+		finally
+		{
+			SetBusy(false);
+		}
+	}
+
+	private async void OnStopClicked(object? sender, EventArgs e)
+	{
+		if (sender is not Button { BindingContext: InstalledApp app })
+			return;
+
+		SetBusy(true, $"Stopping {app.DisplayName}…");
+		try
+		{
+			var result = await _sdb.ShellAsync(_tvIp, $"0 was_kill {app.TizenId}");
+			if (result.ExitCode != 0)
+			{
+				await DisplayAlert("Stop failed", result.Error, "OK");
+			}
+		}
+		catch (Exception ex)
+		{
+			await DisplayAlert("Stop failed", ex.Message, "OK");
+		}
+		finally
+		{
+			SetBusy(false);
+		}
+	}
+
 	private void SetBusy(bool busy, string? status = null)
 	{
 		Busy.IsVisible = busy;

--- a/Apps2Samsung.Mobile/Services/InProcessSdbEngine.cs
+++ b/Apps2Samsung.Mobile/Services/InProcessSdbEngine.cs
@@ -261,4 +261,14 @@ public sealed class InProcessSdbEngine : ISdbEngine, IAsyncDisposable
 		try { await DropAsync(); }
 		finally { _gate.Release(); }
 	}
+
+	public async Task<ProcessResult> ShellAsync(string tvIpAddress, string command) => await RunConnected(tvIpAddress, async device =>
+	{
+		return await device.ShellCommandAsync(command);
+	});
+
+	public Task<IAsyncDisposable> ForwardAsync(string tvIpAddress, int localPort, int remotePort)
+	{
+		throw new NotSupportedException("Port forwarding is not supported on the Mobile SDB engine.");
+	}
 }

--- a/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/ITizenInstallerService.cs
@@ -29,5 +29,9 @@ namespace Apps2Samsung.Interfaces
         /// <summary>Gathers the TV's details (DUID, Tizen version, developer mode/IP, …) for the
         /// "TV information" view, using the shared Core gatherer.</summary>
         Task<Apps2Samsung.Models.TizenDeviceInfo> GetDeviceInfoAsync(string tvIpAddress, bool debugPortOpen);
+
+        Task LaunchAppAsync(string tvIpAddress, string tizenId);
+        Task StopAppAsync(string tvIpAddress, string tizenId);
+        Task<(int LocalPort, IAsyncDisposable ForwardSession)> DebugAppAsync(string tvIpAddress, string tizenId);
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
@@ -33,7 +33,13 @@ namespace Apps2Samsung.Services
         private Window? GetMainWindow()
         {
             if (Application.Current?.ApplicationLifetime is Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                foreach (var w in desktop.Windows)
+                {
+                    if (w.IsActive) return w;
+                }
                 return desktop.MainWindow;
+            }
 
             return null;
         }

--- a/Jellyfin2Samsung-CrossOS/Services/ExeSdbEngine.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/ExeSdbEngine.cs
@@ -2,6 +2,7 @@ using Apps2Samsung.Helpers.Core;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace Apps2Samsung.Services
@@ -86,5 +87,48 @@ namespace Apps2Samsung.Services
 
         public Task<ProcessResult> PermitInstallAsync(string tvIpAddress, string deviceXml, string sdkToolPath)
             => Run($"permit-install {tvIpAddress} \"{deviceXml}\" {sdkToolPath}");
+
+        public Task<ProcessResult> ShellAsync(string tvIpAddress, string command)
+            => Run($"shell {tvIpAddress} {command}");
+
+        public Task<IAsyncDisposable> ForwardAsync(string tvIpAddress, int localPort, int remotePort)
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = SdbPath,
+                    Arguments = $"forward {tvIpAddress} tcp:{localPort} tcp:{remotePort}",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            return Task.FromResult<IAsyncDisposable>(new ProcessForwardSession(process));
+        }
+
+        private class ProcessForwardSession : IAsyncDisposable
+        {
+            private readonly Process _process;
+
+            public ProcessForwardSession(Process process)
+            {
+                _process = process;
+            }
+
+            public ValueTask DisposeAsync()
+            {
+                try
+                {
+                    if (!_process.HasExited)
+                    {
+                        _process.Kill();
+                    }
+                    _process.Dispose();
+                }
+                catch { }
+                return default;
+            }
+        }
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -144,8 +144,8 @@ namespace Apps2Samsung.Services
         {
             try
             {
-                var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(existingFilePath);
-                var match = RegexPatterns.Version.FileNameVersion.Match(fileNameWithoutExtension);
+                var fileName = Path.GetFileName(existingFilePath);
+                var match = RegexPatterns.Version.FileNameVersion.Match(fileName);
 
                 if (!match.Success)
                     return true;
@@ -1155,6 +1155,74 @@ namespace Apps2Samsung.Services
             try
             {
                 return await _sdb.UninstallAsync(tvIpAddress, tizenId);
+            }
+            finally
+            {
+                await _sdb.DisconnectAsync(tvIpAddress);
+            }
+        }
+
+        public async Task LaunchAppAsync(string tvIpAddress, string tizenId)
+        {
+            await EnsureTizenSdbAvailable();
+            try
+            {
+                var result = await _sdb.LaunchAsync(tvIpAddress, tizenId);
+                if (result.ExitCode != 0)
+                    throw new Exception($"Failed to launch app: {result.Error}");
+            }
+            finally
+            {
+                await _sdb.DisconnectAsync(tvIpAddress);
+            }
+        }
+
+        public async Task StopAppAsync(string tvIpAddress, string tizenId)
+        {
+            await EnsureTizenSdbAvailable();
+            try
+            {
+                var result = await _sdb.ShellAsync(tvIpAddress, $"0 was_kill {tizenId}");
+                if (result.ExitCode != 0)
+                {
+                    string errorMsg = string.IsNullOrWhiteSpace(result.Error) ? result.Output : result.Error;
+                    throw new Exception($"Failed to stop app {tizenId}: {errorMsg}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"StopAppAsync failed: {ex}");
+                throw;
+            }
+            finally
+            {
+                await _sdb.DisconnectAsync(tvIpAddress);
+            }
+        }
+
+        public async Task<(int LocalPort, IAsyncDisposable ForwardSession)> DebugAppAsync(string tvIpAddress, string tizenId)
+        {
+            await EnsureTizenSdbAvailable();
+            try
+            {
+                var result = await _sdb.ShellAsync(tvIpAddress, $"0 debug {tizenId}");
+                if (result.ExitCode != 0)
+                {
+                    string errorMsg = string.IsNullOrWhiteSpace(result.Error) ? result.Output : result.Error;
+                    throw new Exception($"Failed to start debug mode for {tizenId}: {errorMsg}");
+                }
+
+                var match = System.Text.RegularExpressions.Regex.Match(result.Output, @"port:\s*(\d+)");
+                if (!match.Success)
+                {
+                    throw new Exception($"Failed to detect the debug port from the device. Output: {result.Output}");
+                }
+                
+                int remotePort = int.Parse(match.Groups[1].Value);
+                int localPort = 9222;
+
+                var forwardSession = await _sdb.ForwardAsync(tvIpAddress, localPort, remotePort);
+                return (localPort, forwardSession);
             }
             finally
             {

--- a/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
@@ -15,7 +15,7 @@ namespace Apps2Samsung.ViewModels
     /// which shares the Core parser with the mobile head) and offers a per-app uninstall for
     /// user-removable apps.
     /// </summary>
-    public partial class InstalledAppsViewModel : ViewModelBase
+    public partial class InstalledAppsViewModel : ViewModelBase, IDisposable
     {
         private readonly ITizenInstallerService _installer;
         private readonly IDialogService _dialogService;
@@ -26,7 +26,17 @@ namespace Apps2Samsung.ViewModels
         public ObservableCollection<InstalledApp> Apps { get; } = new();
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsProgressVisible))]
         private bool isBusy;
+
+        [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(IsProgressVisible))]
+        private bool isDebugging;
+
+        public bool IsProgressVisible => IsBusy || IsDebugging;
+
+        private IAsyncDisposable? _activeForwardSession;
+        private InstalledApp? _debuggedApp;
 
         [ObservableProperty]
         private string statusText = string.Empty;
@@ -110,6 +120,132 @@ namespace Apps2Samsung.ViewModels
             await Load();
         }
 
+        [RelayCommand]
+        private async Task Launch(InstalledApp? app)
+        {
+            if (app is null || IsBusy) return;
+            IsBusy = true;
+            StatusText = $"Launching {app.DisplayName}…";
+            try
+            {
+                await _installer.LaunchAppAsync(_tvIp, app.TizenId);
+                StatusText = $"Launched {app.DisplayName}.";
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowErrorAsync(ex.Message);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task Stop(InstalledApp? app)
+        {
+            if (app is null || IsBusy) return;
+            IsBusy = true;
+            StatusText = $"Stopping {app.DisplayName}…";
+            try
+            {
+                await _installer.StopAppAsync(_tvIp, app.TizenId);
+                StatusText = $"Stopped {app.DisplayName}.";
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowErrorAsync(ex.Message);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task Debug(InstalledApp? app)
+        {
+            if (app is null || IsBusy) return;
+            IsBusy = true;
+            
+            try 
+            { 
+                await _installer.StopAppAsync(_tvIp, app.TizenId); 
+            } 
+            catch { /* Ignore if it's not running */ }
+            
+            StatusText = $"Starting debug for {app.DisplayName}…";
+            try
+            {
+                var (port, session) = await _installer.DebugAppAsync(_tvIp, app.TizenId);
+                _activeForwardSession = session;
+                _debuggedApp = app;
+                IsDebugging = true;
+
+                StatusText = $"Debugging {app.DisplayName} on local port {port}…";
+
+                bool opened = false;
+                Exception? lastError = null;
+
+                try
+                {
+                    if (OperatingSystem.IsWindows())
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", "/c start chrome \"chrome://inspect\"") { CreateNoWindow = true });
+                    }
+                    else if (OperatingSystem.IsMacOS())
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("open", "-a \"Google Chrome\" \"chrome://inspect\"") { UseShellExecute = false });
+                    }
+                    else
+                    {
+                        System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("google-chrome", "\"chrome://inspect\"") { UseShellExecute = false });
+                    }
+                    opened = true;
+                }
+                catch (Exception ex1)
+                {
+                    lastError = ex1;
+                    try
+                    {
+                        if (OperatingSystem.IsWindows())
+                        {
+                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cmd", "/c start msedge \"edge://inspect\"") { CreateNoWindow = true });
+                        }
+                        else if (OperatingSystem.IsMacOS())
+                        {
+                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("open", "-a \"Microsoft Edge\" \"edge://inspect\"") { UseShellExecute = false });
+                        }
+                        else
+                        {
+                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("microsoft-edge", "\"edge://inspect\"") { UseShellExecute = false });
+                        }
+                        opened = true;
+                    }
+                    catch (Exception ex2)
+                    {
+                        lastError = ex2;
+                    }
+                }
+
+                if (!opened)
+                {
+                    await _dialogService.ShowMessageAsync("Debug Started",
+                        $"The app is now running in debug mode on the TV. The debugger is forwarded to localhost:{port}.\n\n" +
+                        "However, we could not automatically open the inspector in your browser. " +
+                        "Please manually open 'chrome://inspect' or 'edge://inspect' in your browser to attach to the TV.");
+                }
+            }
+            catch (Exception ex)
+            {
+                await _dialogService.ShowErrorAsync(ex.Message);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
         // A partial/failed install can leave a package dir that vd_applist never lists, so it can't be
         // removed from the list above. vd_appuninstall <packageId> still reclaims it — offer a manual
         // escape hatch: prompt for the package id and force-remove it.
@@ -162,5 +298,31 @@ namespace Apps2Samsung.ViewModels
 
         [RelayCommand]
         private void Close() => OnRequestClose?.Invoke();
+
+        [RelayCommand]
+        private async Task StopDebug()
+        {
+            if (!IsDebugging || _debuggedApp == null) return;
+            
+            if (_activeForwardSession != null)
+            {
+                await _activeForwardSession.DisposeAsync();
+                _activeForwardSession = null;
+            }
+            
+            IsDebugging = false;
+            _debuggedApp = null;
+            StatusText = string.Empty;
+        }
+
+        public void Dispose()
+        {
+            if (_activeForwardSession != null)
+            {
+                try { _activeForwardSession.DisposeAsync().AsTask().Wait(); } catch { }
+                _activeForwardSession = null;
+            }
+        }
+
     }
 }

--- a/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
@@ -28,8 +28,14 @@
                 </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Top">
                     <Button Content="Remove leftover…" Command="{Binding RemoveLeftoverCommand}"
-                            ToolTip.Tip="Force-remove a leftover/partial install by package id"/>
-                    <Button Content="↻" Command="{Binding LoadCommand}" ToolTip.Tip="Refresh"/>
+                            ToolTip.Tip="Force-remove a leftover/partial install by package id"
+                            IsEnabled="{Binding !IsDebugging}"/>
+                    <Button Content="↻" Command="{Binding LoadCommand}" ToolTip.Tip="Refresh"
+                            IsVisible="{Binding !IsDebugging}"/>
+                    <Button Command="{Binding StopDebugCommand}" ToolTip.Tip="Stop debugging"
+                            IsVisible="{Binding IsDebugging}" Background="#FF6B6B">
+                        <fa:SymbolIcon Symbol="StopFilled" Width="16" Height="16" Foreground="White"/>
+                    </Button>
                     <Button Content="✕" Command="{Binding CloseCommand}"/>
                 </StackPanel>
             </Grid>
@@ -39,10 +45,15 @@
 
             <!-- Busy indicator -->
             <ProgressBar DockPanel.Dock="Top" IsIndeterminate="True" Height="3" Margin="0,0,0,8"
-                         IsVisible="{Binding IsBusy}"/>
+                         IsVisible="{Binding IsProgressVisible}"/>
 
             <!-- App list -->
-            <ScrollViewer>
+            <ScrollViewer IsEnabled="{Binding !IsDebugging}">
+                <ScrollViewer.Styles>
+                    <Style Selector="ScrollViewer[IsEnabled=False]">
+                        <Setter Property="Opacity" Value="0.4"/>
+                    </Style>
+                </ScrollViewer.Styles>
                 <ItemsControl ItemsSource="{Binding Apps}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="models:InstalledApp">
@@ -60,10 +71,29 @@
                                             <TextBlock Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.55"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <Button Grid.Column="1" Content="Uninstall" VerticalAlignment="Center"
-                                            IsVisible="{Binding IsRemovable}"
-                                            Command="{ReflectionBinding $parent[Window].DataContext.UninstallCommand}"
-                                            CommandParameter="{Binding}"/>
+                                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                        <Button ToolTip.Tip="Run"
+                                                Command="{ReflectionBinding $parent[Window].DataContext.LaunchCommand}"
+                                                CommandParameter="{Binding}">
+                                            <fa:SymbolIcon Symbol="Play" Width="16" Height="16"/>
+                                        </Button>
+                                        <Button ToolTip.Tip="Stop"
+                                                Command="{ReflectionBinding $parent[Window].DataContext.StopCommand}"
+                                                CommandParameter="{Binding}">
+                                            <fa:SymbolIcon Symbol="Stop" Width="16" Height="16"/>
+                                        </Button>
+                                        <Button ToolTip.Tip="Debug"
+                                                Command="{ReflectionBinding $parent[Window].DataContext.DebugCommand}"
+                                                CommandParameter="{Binding}">
+                                            <fa:SymbolIcon Symbol="Code" Width="16" Height="16"/>
+                                        </Button>
+                                        <Button ToolTip.Tip="Uninstall"
+                                                IsVisible="{Binding IsRemovable}"
+                                                Command="{ReflectionBinding $parent[Window].DataContext.UninstallCommand}"
+                                                CommandParameter="{Binding}">
+                                            <fa:SymbolIcon Symbol="Delete" Width="16" Height="16" Foreground="#FF6B6B"/>
+                                        </Button>
+                                    </StackPanel>
                                 </Grid>
                             </Border>
                         </DataTemplate>

--- a/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml.cs
+++ b/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml.cs
@@ -12,6 +12,9 @@ namespace Apps2Samsung.Views
             vm.OnRequestClose += Close;
             // Kick off the initial load once the window is shown.
             Opened += async (_, _) => await vm.LoadCommand.ExecuteAsync(null);
+            Closed += (s, e) => {
+                if (vm is System.IDisposable d) d.Dispose();
+            };
         }
 
         // Parameterless ctor for the XAML designer.


### PR DESCRIPTION
# Pull Request Template

## Branch
- [X] I branched off beta (not master) to develop this feature/fix

## Description

This PR introduces comprehensive lifecycle management directly from the Installed Apps list, allowing users to remotely launch, stop, and explicitly debug applications on their Samsung TV without needing to leave the Apps2Samsung interface.

<img width="561" height="653" alt="SCR-20260817-osup" src="https://github.com/user-attachments/assets/a733b5e9-b7df-4a9c-b282-a0131fb53794" />

It significantly lowers the barrier for end-users to easily gather log information and troubleshoot apps when reporting issues to developers (e.g., users submitting bug reports for [Moonlight Tizen](https://github.com/brightcraft/moonlight-tizen/issues)). By utilizing the newly implemented port forwarding capabilities of `tizen-sdb`, users no longer have to mess with command-line tools, manually configure SDB tunnels, or parse terminal outputs just to get logs.

### Key Features
* **Remote App Lifecycle**: Added dedicated Play and Stop buttons to each installed app in the list, enabling users to seamlessly launch or kill apps remotely with a single click.
* **Automated Debug Tunneling**: Parses the debug port from the TV and automatically initiates an asynchronous, background port forwarding session to map it locally.
* **Cross-Platform Browser Inspector**: Automatically launches Google Chrome or Microsoft Edge (with cross-platform support for Windows, macOS, and Linux) directly to `chrome://inspect` or `edge://inspect` once the tunnel is connected.
* **Intelligent App Synchronization**: Proactively stops the target app before initializing the debugger to prevent SDB hangs, while keeping the app running safely on the TV when the debug tunnel is later terminated.
* **Revamped Debug UI**:
  * An interactive infinite progress bar remains visible to indicate the debug tunnel is alive.
  * The main app list explicitly fades out and disables to prevent conflicting actions during a debug session.
  * A dedicated red `Stop` button seamlessly replaces the `Refresh` button in the header during the session.
  * Robust fallback handling cleanly catches when a TV refuses debug mode and displays a clear error dialog instead of crashing.

<img width="561" height="653" alt="SCR-20260817-osxm" src="https://github.com/user-attachments/assets/e2203584-eb53-407a-b6e2-a121bf2e0e71" />

<img width="1442" height="807" alt="SCR-20260817-osyj" src="https://github.com/user-attachments/assets/e9c88bb4-0ad9-46d5-9ca6-3e6285a4b93b" />

## Prerequisites

> [!WARNING]  
> The debugging portion of this feature relies on the newly implemented port forwarding capabilities in the underlying `tizen-sdb` client.

For the debug tunnel to work, you must be using a version of `tizen-sdb` compiled with the following PRs applied:
* [PatrickSt1991/tizen-sdb#7](https://github.com/PatrickSt1991/tizen-sdb/pull/7) - SDB Shell command (fix)
* [PatrickSt1991/tizen-sdb#8](https://github.com/PatrickSt1991/tizen-sdb/pull/8) - Port forwarding session support (feat)

---

## Type of Change

- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [X] My code follows the existing project structure and style  
- [X] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [ ] I have verified that the installer still works with the underlying CLI  

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
