### PR TITLE
feat: add dynamic app icons and fallback avatars to the Installed Apps list

### DIFF
--- a/Apps2Samsung.Core/Catalog/AppIconResolver.cs
+++ b/Apps2Samsung.Core/Catalog/AppIconResolver.cs
@@ -1,0 +1,103 @@
+using Apps2Samsung.Helpers.Core;
+using Apps2Samsung.Models;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Apps2Samsung.Catalog
+{
+    public static class AppIconResolver
+    {
+        private static readonly HttpClient _httpClient = new();
+        private static Dictionary<string, string>? _iconMapCache;
+        private static bool _fetchAttempted;
+
+        private const string JsonUrl = "https://rs.ltd/data/samsung-tv-app-ids.json";
+
+        /// <summary>
+        /// Fetches and parses the community-maintained TV App IDs JSON file.
+        /// Caches the result in memory for the lifetime of the application.
+        /// Returns a dictionary mapping TizenId to Icon URL.
+        /// </summary>
+        public static async Task<IReadOnlyDictionary<string, string>> GetIconMapAsync()
+        {
+            if (_iconMapCache != null)
+                return _iconMapCache;
+
+            if (_fetchAttempted)
+                return new Dictionary<string, string>(); // Return empty map if we previously failed to fetch
+
+            _fetchAttempted = true;
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                var response = await _httpClient.GetAsync(JsonUrl);
+                if (response.IsSuccessStatusCode)
+                {
+                    var json = await response.Content.ReadAsStringAsync();
+                    var manifest = JsonSerializer.Deserialize<TvAppIconManifest>(json, JsonSerializerOptionsProvider.Default);
+
+                    if (manifest?.Items != null)
+                    {
+                        foreach (var item in manifest.Items)
+                        {
+                            if (string.IsNullOrWhiteSpace(item.Id) || string.IsNullOrWhiteSpace(item.Icon))
+                                continue;
+
+                            // The ID field can be a comma-separated list of Tizen IDs
+                            var ids = item.Id.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                            foreach (var id in ids)
+                            {
+                                // Overwrite is fine if duplicates exist
+                                map[id] = item.Icon;
+                            }
+                            
+                            // Also map by the human-readable app name for fallback resolution
+                            if (!string.IsNullOrWhiteSpace(item.Name))
+                            {
+                                map[item.Name] = item.Icon;
+                                
+                                // Also map the lower invariant for fuzzy matching
+                                map[item.Name.ToLowerInvariant()] = item.Icon;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to fetch AppIcon manifest: {ex}");
+            }
+
+            // Also map some built-in community apps as a fallback (using jellyfin defaults if needed)
+            // The JSON from rs.ltd contains mostly official apps.
+            if (!map.ContainsKey("k5Mv1gJ5iY.Jellyfin"))
+            {
+                // We don't have the ProviderManifest here easily, but we know Jellyfin's Tizen ID.
+                // We'll leave unknown apps to be handled by the fallback avatar in the UI.
+            }
+
+            _iconMapCache = map;
+            return _iconMapCache;
+        }
+
+        /// <summary>
+        /// Attempts to get the icon URL for a given Tizen ID. Returns null if not found.
+        /// </summary>
+        public static async Task<string?> TryGetIconUrlAsync(string tizenId)
+        {
+            if (string.IsNullOrWhiteSpace(tizenId))
+                return null;
+
+            var map = await GetIconMapAsync();
+            if (map.TryGetValue(tizenId, out var iconUrl))
+                return iconUrl;
+
+            // Optional: fallback checks for app titles if exact ID not matched.
+            return null;
+        }
+    }
+}

--- a/Apps2Samsung.Core/Models/InstalledApp.cs
+++ b/Apps2Samsung.Core/Models/InstalledApp.cs
@@ -8,14 +8,38 @@ namespace Apps2Samsung.Models
     /// </summary>
     public sealed record InstalledApp(
         string Title,
+        string? AppId,
         string TizenId,
         string Version,
         string InstallDate,
         bool IsRemovable,
-        long SizeBytes = 0)
+        long SizeBytes = 0,
+        string? IconUrl = null)
     {
         /// <summary>Title if the TV reported one, otherwise the Tizen id — never empty.</summary>
         public string DisplayName => string.IsNullOrWhiteSpace(Title) ? TizenId : Title;
+
+        public bool HasIcon => !string.IsNullOrWhiteSpace(IconUrl);
+        public bool MissingIcon => string.IsNullOrWhiteSpace(IconUrl);
+        public string Initials => string.IsNullOrWhiteSpace(DisplayName) ? "" : DisplayName.Substring(0, 1).ToUpperInvariant();
+
+        private static readonly string[] _fallbackColors = {
+            "#F44336", "#E91E63", "#9C27B0", "#673AB7", 
+            "#3F51B5", "#2196F3", "#03A9F4", "#00BCD4", 
+            "#009688", "#4CAF50", "#8BC34A", "#FF9800", 
+            "#FF5722", "#795548", "#607D8B"
+        };
+
+        public string FallbackColor
+        {
+            get
+            {
+                var id = string.IsNullOrWhiteSpace(DisplayName) ? TizenId : DisplayName;
+                int hash = 0;
+                foreach (char c in id) hash = (hash * 31) + c;
+                return _fallbackColors[System.Math.Abs(hash) % _fallbackColors.Length];
+            }
+        }
 
         /// <summary>Human-readable install size for this app ("—" when unknown/0).</summary>
         public string SizeDisplay => FormatSize(SizeBytes);

--- a/Apps2Samsung.Core/Models/TvAppIconManifest.cs
+++ b/Apps2Samsung.Core/Models/TvAppIconManifest.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Apps2Samsung.Models
+{
+    public sealed class TvAppIconManifest
+    {
+        [JsonPropertyName("items")]
+        public List<TvAppIconEntry> Items { get; set; } = new();
+    }
+
+    public sealed class TvAppIconEntry
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = string.Empty;
+
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        [JsonPropertyName("icon")]
+        public string Icon { get; set; } = string.Empty;
+    }
+}

--- a/Apps2Samsung.Core/Sdb/TizenInstalledApps.cs
+++ b/Apps2Samsung.Core/Sdb/TizenInstalledApps.cs
@@ -43,6 +43,7 @@ namespace Apps2Samsung.Sdb
                     long.TryParse(current.GetValueOrDefault("app_size", string.Empty).Trim(), out var size);
                     apps.Add(new InstalledApp(
                         Title: current.GetValueOrDefault("app_title", string.Empty),
+                        AppId: current.GetValueOrDefault("app_id", string.Empty).Trim(),
                         TizenId: id.Trim(),
                         Version: current.GetValueOrDefault("app_version", string.Empty),
                         InstallDate: current.GetValueOrDefault("install_date", string.Empty),

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml
@@ -39,8 +39,24 @@
                     <Border Margin="0,4" Padding="12" StrokeThickness="1" StrokeShape="RoundRectangle 8"
                             Stroke="{AppThemeBinding Light=#E2E2E2, Dark=#333}"
                             BackgroundColor="{AppThemeBinding Light=White, Dark=#1F1F1F}">
-                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10" VerticalOptions="Center">
-                            <VerticalStackLayout Grid.Column="0" Spacing="2">
+                        <Grid ColumnDefinitions="48,*,Auto" ColumnSpacing="12" VerticalOptions="Center">
+                            
+                            <!-- Icon / Avatar -->
+                            <Grid Grid.Column="0" WidthRequest="48" HeightRequest="48" VerticalOptions="Center">
+                                <Border StrokeThickness="0" BackgroundColor="{Binding FallbackColor}"
+                                        IsVisible="{Binding MissingIcon}" HorizontalOptions="Fill" VerticalOptions="Fill">
+                                    <Label Text="{Binding Initials}" TextColor="White" FontSize="20" FontAttributes="Bold"
+                                           HorizontalOptions="Center" VerticalOptions="Center"/>
+                                </Border>
+                                <Image Source="{Binding IconUrl}" Aspect="AspectFill" IsVisible="{Binding HasIcon}"
+                                       HorizontalOptions="Fill" VerticalOptions="Fill">
+                                    <Image.Clip>
+                                        <RoundRectangleGeometry CornerRadius="8" Rect="0,0,48,48"/>
+                                    </Image.Clip>
+                                </Image>
+                            </Grid>
+
+                            <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
                                 <Label Text="{Binding DisplayName}" FontAttributes="Bold" FontSize="15"
                                        LineBreakMode="TailTruncation" />
                                 <Label Text="{Binding TizenId}" FontSize="11" Opacity="0.55"
@@ -50,7 +66,8 @@
                                     <Label Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.55" />
                                 </HorizontalStackLayout>
                             </VerticalStackLayout>
-                            <Button Grid.Column="1" Text="Uninstall" Clicked="OnUninstallClicked"
+                            
+                            <Button Grid.Column="2" Text="Uninstall" Clicked="OnUninstallClicked"
                                     IsVisible="{Binding IsRemovable}" VerticalOptions="Center"
                                     BackgroundColor="Transparent" BorderWidth="1" CornerRadius="6" Padding="12,6"
                                     BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"

--- a/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstalledAppsPage.xaml.cs
@@ -86,7 +86,19 @@ public partial class InstalledAppsPage : ContentPage
 		try
 		{
 			var result = await _sdb.AppsAsync(_tvIp);
-			var apps = TizenInstalledApps.Parse(result?.Output);
+			var apps = TizenInstalledApps.Parse(result?.Output).ToList();
+			var iconMap = await Apps2Samsung.Catalog.AppIconResolver.GetIconMapAsync();
+			for (int i = 0; i < apps.Count; i++)
+			{
+				var a = apps[i];
+				if ((!string.IsNullOrEmpty(a.AppId) && iconMap.TryGetValue(a.AppId, out var iconUrl)) ||
+					iconMap.TryGetValue(a.TizenId, out iconUrl) ||
+					iconMap.TryGetValue(a.DisplayName, out iconUrl) ||
+					iconMap.TryGetValue(a.DisplayName.ToLowerInvariant(), out iconUrl))
+				{
+					apps[i] = a with { IconUrl = iconUrl };
+				}
+			}
 			AppsList.ItemsSource = apps;
 
 			if (apps.Count == 0)

--- a/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/InstalledAppsViewModel.cs
@@ -20,10 +20,12 @@ namespace Apps2Samsung.ViewModels
         private readonly ITizenInstallerService _installer;
         private readonly IDialogService _dialogService;
         private readonly string _tvIp;
+        private static readonly System.Net.Http.HttpClient _http = new();
+        private static readonly System.Collections.Generic.Dictionary<string, Avalonia.Media.Imaging.Bitmap?> _bitmapCache = new(StringComparer.OrdinalIgnoreCase);
 
         public string TvLabel { get; }
 
-        public ObservableCollection<InstalledApp> Apps { get; } = new();
+        public ObservableCollection<InstalledAppViewModel> Apps { get; } = new();
 
         [ObservableProperty]
         private bool isBusy;
@@ -48,13 +50,40 @@ namespace Apps2Samsung.ViewModels
             StatusText = "Reading installed apps…";
             try
             {
-                var apps = await _installer.GetInstalledAppsAsync(_tvIp);
+                var iconMap = await Apps2Samsung.Catalog.AppIconResolver.GetIconMapAsync();
+                var apps = (await _installer.GetInstalledAppsAsync(_tvIp)).ToList();
+                var viewModels = new System.Collections.Generic.List<InstalledAppViewModel>();
+
+                for (int i = 0; i < apps.Count; i++)
+                {
+                    var a = apps[i];
+                    if ((!string.IsNullOrEmpty(a.AppId) && iconMap.TryGetValue(a.AppId, out var iconUrl)) ||
+                        iconMap.TryGetValue(a.TizenId, out iconUrl) ||
+                        iconMap.TryGetValue(a.DisplayName, out iconUrl) ||
+                        iconMap.TryGetValue(a.DisplayName.ToLowerInvariant(), out iconUrl))
+                    {
+                        apps[i] = a with { IconUrl = iconUrl };
+                    }
+                    viewModels.Add(new InstalledAppViewModel(apps[i]));
+                }
+
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     Apps.Clear();
-                    foreach (var a in apps)
+                    foreach (var a in viewModels)
                         Apps.Add(a);
                 });
+                
+                // Start loading bitmaps in the background
+                _ = Task.Run(async () =>
+                {
+                    foreach (var vm in viewModels)
+                    {
+                        if (!string.IsNullOrEmpty(vm.App.IconUrl))
+                            await vm.LoadIconAsync(_http, _bitmapCache);
+                    }
+                });
+
                 var removable = apps.Count(a => a.IsRemovable);
                 var totalUsed = InstalledApp.FormatSize(apps.Sum(a => a.SizeBytes));
                 StatusText = apps.Count == 0
@@ -163,4 +192,43 @@ namespace Apps2Samsung.ViewModels
         [RelayCommand]
         private void Close() => OnRequestClose?.Invoke();
     }
+
+    public partial class InstalledAppViewModel : ObservableObject
+    {
+        public InstalledApp App { get; }
+        
+        [ObservableProperty]
+        private Avalonia.Media.Imaging.Bitmap? iconBitmap;
+        
+        public InstalledAppViewModel(InstalledApp app)
+        {
+            App = app;
+        }
+        
+        public async Task LoadIconAsync(System.Net.Http.HttpClient http, System.Collections.Generic.Dictionary<string, Avalonia.Media.Imaging.Bitmap?> cache)
+        {
+            if (string.IsNullOrEmpty(App.IconUrl)) return;
+            
+            if (cache.TryGetValue(App.IconUrl, out var cached))
+            {
+                IconBitmap = cached;
+                return;
+            }
+            
+            try
+            {
+                var bytes = await http.GetByteArrayAsync(App.IconUrl);
+                using var ms = new System.IO.MemoryStream(bytes);
+                var bmp = new Avalonia.Media.Imaging.Bitmap(ms);
+                cache[App.IconUrl] = bmp;
+                IconBitmap = bmp;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load app icon '{App.IconUrl}': {ex.Message}");
+                cache[App.IconUrl] = null;
+            }
+        }
+    }
 }
+

--- a/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
+++ b/Jellyfin2Samsung-CrossOS/Views/InstalledAppsWindow.axaml
@@ -45,25 +45,43 @@
             <ScrollViewer>
                 <ItemsControl ItemsSource="{Binding Apps}">
                     <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="models:InstalledApp">
+                        <DataTemplate x:DataType="viewModels:InstalledAppViewModel">
                             <Border Margin="0,3" Padding="12"
                                     Background="{DynamicResource CardBackgroundFillColorSecondaryBrush}"
                                     CornerRadius="8">
-                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                                    <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
-                                        <TextBlock Text="{Binding DisplayName}" FontWeight="SemiBold" FontSize="14"
+                                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="12">
+                                    
+                                    <!-- App Icon or initials fallback -->
+                                    <Panel Grid.Column="0" Width="48" Height="48" VerticalAlignment="Center">
+                                        <!-- Fallback placeholder -->
+                                        <Border Background="{Binding App.FallbackColor}"
+                                                IsVisible="{Binding App.MissingIcon}">
+                                            <TextBlock Text="{Binding App.Initials}" 
+                                                       Foreground="White" FontWeight="Bold" FontSize="20"
+                                                       HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                        </Border>
+                                        <!-- Actual icon -->
+                                        <Image Source="{Binding IconBitmap}" Stretch="UniformToFill" 
+                                               IsVisible="{Binding App.HasIcon}"/>
+                                    </Panel>
+
+                                    <!-- App info -->
+                                    <StackPanel Grid.Column="1" Spacing="2" VerticalAlignment="Center">
+                                        <TextBlock Text="{Binding App.DisplayName}" FontWeight="SemiBold" FontSize="14"
                                                    TextTrimming="CharacterEllipsis"/>
-                                        <TextBlock Text="{Binding TizenId}" FontSize="11" Opacity="0.55"
+                                        <TextBlock Text="{Binding App.TizenId}" FontSize="11" Opacity="0.55"
                                                    TextTrimming="CharacterEllipsis"/>
                                         <StackPanel Orientation="Horizontal" Spacing="10">
-                                            <TextBlock Text="{Binding Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55"/>
-                                            <TextBlock Text="{Binding SizeDisplay}" FontSize="11" Opacity="0.55"/>
+                                            <TextBlock Text="{Binding App.Version, StringFormat='v{0}'}" FontSize="11" Opacity="0.55"/>
+                                            <TextBlock Text="{Binding App.SizeDisplay}" FontSize="11" Opacity="0.55"/>
                                         </StackPanel>
                                     </StackPanel>
-                                    <Button Grid.Column="1" Content="Uninstall" VerticalAlignment="Center"
-                                            IsVisible="{Binding IsRemovable}"
+                                    
+                                    <!-- Uninstall button -->
+                                    <Button Grid.Column="2" Content="Uninstall" VerticalAlignment="Center"
+                                            IsVisible="{Binding App.IsRemovable}"
                                             Command="{ReflectionBinding $parent[Window].DataContext.UninstallCommand}"
-                                            CommandParameter="{Binding}"/>
+                                            CommandParameter="{Binding App}"/>
                                 </Grid>
                             </Border>
                         </DataTemplate>


### PR DESCRIPTION
# Pull Request Template

## Branch
- [X] I branched off beta (not master) to develop this feature/fix

# Description
This PR enhances the Installed Apps list on both the Desktop (Avalonia) and Mobile (.NET MAUI) clients by displaying app icons next to the application names. Since `vd_applist` and the TV shell don't easily expose high-res app icons locally, this implementation fetches known icons on the fly using a community-maintained Samsung App Store JSON map: https://cherpake.com/pt/apps/remote-control-tv/custom-apps/samsung/

<img width="561" height="653" alt="image" src="https://github.com/user-attachments/assets/db96c666-ad33-448c-af3c-92bd5e016f73" />

## Changes
* **`AppIconResolver`**: Created a new core service to fetch, parse, and in-memory cache the `rs.ltd` JSON icon manifest.
* **Robust Matching**: Updated the `TizenInstalledApps` parser to extract the numeric `app_id` from the `vd_applist` payload. The resolver checks for matches using `app_id`, `TizenId`, and a fuzzy match on the app's `DisplayName`.
* **Desktop & Mobile UI**: Updated both `InstalledAppsWindow.axaml` and `InstalledAppsPage.xaml` to bind to the new icon URLs. The Desktop `InstalledAppsViewModel` was refactored to asynchronously download the icon bytes to a `Bitmap` to prevent blocking the UI thread.
* **Vibrant Fallback Avatars**: Sideloaded apps, unknown widgets, and homebrew apps that aren't mapped in the JSON will now display a beautiful fallback avatar. The fallback extracts the app's first initial and calculates a deterministic hash to select a unique background color from a 15-color Material Design palette.

---

## Type of Change

- [ ] Bug fix (non-breaking change)
- [X] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

## Checklist

- [X] My code follows the existing project structure and style  
- [X] I have tested my changes manually  
- [ ] I have added necessary documentation (if applicable)  
- [ ] I have verified that the installer still works with the underlying CLI  

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
