### PR TITLE
#553: fix TVApp Android black screen (trimming) + add mobile channel sorting

### DIFF
--- a/Apps2Samsung.Core/Collections/ListReorder.cs
+++ b/Apps2Samsung.Core/Collections/ListReorder.cs
@@ -1,0 +1,25 @@
+namespace Apps2Samsung.Collections
+{
+    /// <summary>
+    /// The rule for moving an item up/down in an ordered list, shared so both heads' channel
+    /// reordering (and any other list reorder) agree on the bounds. Each head still applies the move
+    /// with its own collection type — the desktop's data-bound <c>ObservableCollection.Move</c>, the
+    /// mobile head's in-code visual list — this just computes the valid target position.
+    /// </summary>
+    public static class ListReorder
+    {
+        /// <summary>
+        /// The target index for moving the item at <paramref name="index"/> by <paramref name="delta"/>
+        /// positions in a list of <paramref name="count"/> items, or <c>null</c> if the source index is
+        /// invalid or the move would fall outside the list.
+        /// </summary>
+        public static int? TargetIndex(int count, int index, int delta)
+        {
+            if (index < 0 || index >= count)
+                return null;
+
+            var target = index + delta;
+            return target >= 0 && target < count ? target : null;
+        }
+    }
+}

--- a/Apps2Samsung.Core/Packaging/TvAppChannelInjector.cs
+++ b/Apps2Samsung.Core/Packaging/TvAppChannelInjector.cs
@@ -78,11 +78,17 @@ namespace Apps2Samsung.Packaging
                 return;
             }
 
-            // JSON is valid JS; serialize with lowercase keys to match TVApp's { name, url } shape.
-            var payload = JsonSerializer.Serialize(
-                channels.Select(c => new { name = c.Name ?? string.Empty, url = c.Url ?? string.Empty }));
+            // Build the channels JSON by hand (lowercase { name, url } keys) instead of serializing an
+            // anonymous type. Reflection-based serialization of anonymous types loses its property
+            // metadata under the mobile head's trimmed/AOT release build, which emitted empty objects
+            // (`[{},{}]`) and blackscreened the TVApp (#553). Serializing each string on its own stays
+            // trim-safe and keeps the exact same escaping.
+            var payload = "[" + string.Join(",", channels.Select(c =>
+                $"{{\"name\":{JsonSerializer.Serialize(c.Name ?? string.Empty)},\"url\":{JsonSerializer.Serialize(c.Url ?? string.Empty)}}}")) + "]";
 
-            js = ChannelsArrayRegex.Replace(js, $"var channels = {payload};", 1);
+            // Replace via a MatchEvaluator so a literal '$' in a URL isn't interpreted as a regex
+            // substitution (e.g. `$1`) in the replacement string.
+            js = ChannelsArrayRegex.Replace(js, _ => $"var channels = {payload};", 1);
 
             await File.WriteAllTextAsync(mainJsPath, js);
             ws.Repack();

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Apps2Samsung.Backup;
+using Apps2Samsung.Collections;
 using Apps2Samsung.Mobile.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
@@ -256,40 +257,45 @@ public partial class SettingsPage : ContentPage
 	{
 		var nameEntry = new Entry { Text = name, Placeholder = "Name", BackgroundColor = Colors.Transparent };
 		var urlEntry = new Entry { Text = url, Placeholder = "https://…/stream.m3u8", BackgroundColor = Colors.Transparent };
-		var removeBtn = new Button
-		{
-			Text = "✕",
-			FontSize = 14,
-			Padding = 0,
-			WidthRequest = 40,
-			HeightRequest = 40,
-			CornerRadius = 6,
-			BackgroundColor = Colors.Transparent,
-			BorderWidth = 1,
-			BorderColor = Color.FromArgb("#CDD3D8"),
-			TextColor = Color.FromArgb("#B00020"),
-		};
+		var upBtn = SmallChannelButton("↑", "#2C3E50");
+		var downBtn = SmallChannelButton("↓", "#2C3E50");
+		var removeBtn = SmallChannelButton("✕", "#B00020");
 
+		// Row 0: name + url. Row 1: reorder (↑ ↓) + remove, right-aligned, so the entries stay wide.
 		var grid = new Grid
 		{
 			ColumnSpacing = 8,
+			RowSpacing = 2,
 			ColumnDefinitions =
 			{
 				new ColumnDefinition(GridLength.Star),
 				new ColumnDefinition(GridLength.Star),
-				new ColumnDefinition(new GridLength(40)),
+			},
+			RowDefinitions =
+			{
+				new RowDefinition(GridLength.Auto),
+				new RowDefinition(GridLength.Auto),
 			},
 		};
-		Grid.SetColumn(nameEntry, 0);
-		Grid.SetColumn(urlEntry, 1);
-		Grid.SetColumn(removeBtn, 2);
+		Grid.SetColumn(nameEntry, 0); Grid.SetRow(nameEntry, 0);
+		Grid.SetColumn(urlEntry, 1); Grid.SetRow(urlEntry, 0);
+
+		var buttons = new HorizontalStackLayout { Spacing = 6, HorizontalOptions = LayoutOptions.End };
+		buttons.Children.Add(upBtn);
+		buttons.Children.Add(downBtn);
+		buttons.Children.Add(removeBtn);
+		Grid.SetColumn(buttons, 0); Grid.SetRow(buttons, 1); Grid.SetColumnSpan(buttons, 2);
+
 		grid.Children.Add(nameEntry);
 		grid.Children.Add(urlEntry);
-		grid.Children.Add(removeBtn);
+		grid.Children.Add(buttons);
 
 		var row = new ChannelRow(grid, nameEntry, urlEntry);
 		nameEntry.Unfocused += (_, _) => SaveChannels();
 		urlEntry.Unfocused += (_, _) => SaveChannels();
+		// Channels play on the TV in list order, so let the user reorder them (mirrors the desktop head).
+		upBtn.Clicked += (_, _) => MoveChannelRow(row, -1);
+		downBtn.Clicked += (_, _) => MoveChannelRow(row, +1);
 		removeBtn.Clicked += (_, _) =>
 		{
 			ChannelsContainer.Children.Remove(grid);
@@ -299,6 +305,38 @@ public partial class SettingsPage : ContentPage
 
 		_channelRows.Add(row);
 		ChannelsContainer.Children.Add(grid);
+	}
+
+	private static Button SmallChannelButton(string text, string textColor) => new()
+	{
+		Text = text,
+		FontSize = 14,
+		Padding = 0,
+		WidthRequest = 40,
+		HeightRequest = 40,
+		CornerRadius = 6,
+		BackgroundColor = Colors.Transparent,
+		BorderWidth = 1,
+		BorderColor = Color.FromArgb("#CDD3D8"),
+		TextColor = Color.FromArgb(textColor),
+	};
+
+	private void MoveChannelRow(ChannelRow row, int delta)
+	{
+		var i = _channelRows.IndexOf(row);
+		// Shared bounds rule with the desktop head (Core Collections.ListReorder).
+		if (ListReorder.TargetIndex(_channelRows.Count, i, delta) is not int j)
+			return;
+
+		_channelRows.RemoveAt(i);
+		_channelRows.Insert(j, row);
+
+		// Rebuild the visual order to match, then persist.
+		ChannelsContainer.Children.Clear();
+		foreach (var r in _channelRows)
+			ChannelsContainer.Children.Add(r.Container);
+
+		SaveChannels();
 	}
 
 	private void SaveChannels()

--- a/Jellyfin2Samsung-CrossOS/ViewModels/TvAppSettingsViewModel.cs
+++ b/Jellyfin2Samsung-CrossOS/ViewModels/TvAppSettingsViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Apps2Samsung.Collections;
 using Apps2Samsung.Helpers;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
@@ -118,7 +119,9 @@ namespace Apps2Samsung.ViewModels
                 Channels.Remove(channel);
         }
 
-        // Channels play on the TV in this list's order, so let the user arrange it.
+        // Channels play on the TV in this list's order, so let the user arrange it. The bounds rule is
+        // shared with the mobile head via Collections.ListReorder; the Move keeps the data binding's
+        // single Move notification.
         [RelayCommand]
         private void MoveChannelUp(TvAppChannel? channel)
         {
@@ -126,8 +129,8 @@ namespace Apps2Samsung.ViewModels
                 return;
 
             var index = Channels.IndexOf(channel);
-            if (index > 0)
-                Channels.Move(index, index - 1);
+            if (ListReorder.TargetIndex(Channels.Count, index, -1) is int target)
+                Channels.Move(index, target);
         }
 
         [RelayCommand]
@@ -137,8 +140,8 @@ namespace Apps2Samsung.ViewModels
                 return;
 
             var index = Channels.IndexOf(channel);
-            if (index >= 0 && index < Channels.Count - 1)
-                Channels.Move(index, index + 1);
+            if (ListReorder.TargetIndex(Channels.Count, index, +1) is int target)
+                Channels.Move(index, target);
         }
 
         private void OnLanguageChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Fixes #553 (both parts).

## 🐛 Android black screen (macOS works)
The shared `TvAppChannelInjector` serialized an **anonymous type** (`new { name, url }`) via reflection. Android **Release** builds trim by default (no override in the mobile csproj), and trimming strips anonymous-type metadata, so the released APK wrote broken/empty objects (`[{},{}]`) into the TVApp's `main.js` → malformed `var channels` → **black screen**. Desktop isn't trimmed, so the identical code worked and showed the channels. (Also wouldn't repro in a Debug APK.)

**Fix:** build the channels JSON without anonymous-type reflection — serialize each string individually (trim-safe, identical escaping). Bonus: switched the regex replace to a `MatchEvaluator` so a literal `$` in a stream URL can't be mangled as a regex substitution.

## ✨ Channel sorting (mobile)
Desktop already had up/down reordering; added it to the **mobile** channel editor (↑ ↓ per channel). The shared bounds rule moved into Core (`Collections.ListReorder`); each head keeps its framework-native move.

Both heads build clean.