### PR TITLE
mobile: Certificate picker (Automatic/Public/Partner) + default to imported cert

### DIFF
--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml
@@ -114,11 +114,12 @@
                 <Label Style="{StaticResource Hint}"
                        Text="When on, the in-app update check offers new beta versions and downloads them. Turn off to only be notified about stable releases." />
                 <Grid Style="{StaticResource ToggleRow}">
-                    <Label Grid.Column="0" Text="Partner signing (experimental)" VerticalOptions="Center" />
-                    <Switch Grid.Column="1" x:Name="PartnerSigningSwitch" OnColor="#2C3E50" Toggled="OnToggle" />
+                    <Label Grid.Column="0" Text="Certificate" VerticalOptions="Center" />
+                    <Picker Grid.Column="1" x:Name="CertificatePicker" SelectedIndexChanged="OnCertificateChanged"
+                            HorizontalOptions="End" MinimumWidthRequest="150" />
                 </Grid>
                 <Label Style="{StaticResource Hint}"
-                       Text="Partner signing is only needed for apps that use restricted privileges (e.g. VPN). Some TVs may reject partner-signed installs, and Samsung may not issue Partner certs for individual accounts. Leave off unless an app requires it." />
+                       Text="Which signing certificate to use. Automatic picks Public, or Partner when an app requires it. Partner is only needed for apps that use restricted privileges (e.g. VPN); some TVs reject partner-signed installs. After importing a backup this defaults to the imported certificate." />
                 <Grid Style="{StaticResource ToggleRow}">
                     <Label Grid.Column="0" Text="Force Samsung login" VerticalOptions="Center" />
                     <Switch Grid.Column="1" x:Name="ForceLoginSwitch" OnColor="#2C3E50" Toggled="OnToggle" />

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Apps2Samsung.Backup;
+using Apps2Samsung.Certificate;
 using Apps2Samsung.Collections;
+using Apps2Samsung.Interfaces;
 using Apps2Samsung.Mobile.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.ApplicationModel.DataTransfer;
@@ -37,7 +39,7 @@ public partial class SettingsPage : ContentPage
 		KeepWgtSwitch.IsToggled = MobileSettings.KeepWgtFile;
 		ShowAllJfSwitch.IsToggled = MobileSettings.ShowAllJellyfinVersions;
 		BetaUpdatesSwitch.IsToggled = MobileSettings.IncludeBetaUpdates;
-		PartnerSigningSwitch.IsToggled = MobileSettings.PartnerSigning;
+		LoadCertificatePicker();
 		TryOverwriteSwitch.IsToggled = MobileSettings.TryOverwrite;
 		ForceLoginSwitch.IsToggled = MobileSettings.ForceSamsungLogin;
 
@@ -160,6 +162,9 @@ public partial class SettingsPage : ContentPage
 			if (!string.IsNullOrEmpty(import.SettingsJson))
 				await ApplySettingsJsonAsync(import.SettingsJson!);
 
+			// Make the imported certificate the selected one.
+			DefaultCertificateToImportedProfile();
+
 			// Refresh visible controls from the newly-applied settings.
 			OnAppearing();
 
@@ -246,9 +251,47 @@ public partial class SettingsPage : ContentPage
 		MobileSettings.KeepWgtFile = KeepWgtSwitch.IsToggled;
 		MobileSettings.ShowAllJellyfinVersions = ShowAllJfSwitch.IsToggled;
 		MobileSettings.IncludeBetaUpdates = BetaUpdatesSwitch.IsToggled;
-		MobileSettings.PartnerSigning = PartnerSigningSwitch.IsToggled;
 		MobileSettings.TryOverwrite = TryOverwriteSwitch.IsToggled;
 		MobileSettings.ForceSamsungLogin = ForceLoginSwitch.IsToggled;
+	}
+
+	// Populates the certificate picker (Automatic / Public / Partner) and selects the current preference.
+	private void LoadCertificatePicker()
+	{
+		CertificatePicker.ItemsSource ??= new List<string>
+		{
+			MobileSettings.CertificatePreferenceAuto,
+			MobileSettings.CertificatePreferencePublic,
+			MobileSettings.CertificatePreferencePartner,
+		};
+		CertificatePicker.SelectedItem = MobileSettings.CertificatePreference;
+	}
+
+	private void OnCertificateChanged(object? sender, EventArgs e)
+	{
+		if (!_loaded)
+			return;
+		if (CertificatePicker.SelectedItem is string pref)
+			MobileSettings.CertificatePreference = pref;
+	}
+
+	// After an import, default the certificate picker to whichever level profile was restored — so the
+	// imported certificate becomes the selected one (when exactly one level is present).
+	private static void DefaultCertificateToImportedProfile()
+	{
+		var store = CertStorePath;
+		bool Has(CertificatePrivilegeLevel level) =>
+			CertificateProvisioningService.HasUsableAuthorCert(
+				Path.Combine(store, CertificateProvisioningService.ProfileName(level)));
+
+		bool partner = Has(CertificatePrivilegeLevel.Partner);
+		bool pub = Has(CertificatePrivilegeLevel.Public);
+
+		if (partner && !pub)
+			MobileSettings.CertificatePreference = MobileSettings.CertificatePreferencePartner;
+		else if (pub && !partner)
+			MobileSettings.CertificatePreference = MobileSettings.CertificatePreferencePublic;
+		// If both or neither were imported, leave the preference as-is (Automatic covers "both").
 	}
 
 	private void OnAddChannel(object? sender, EventArgs e) => AddChannelRow(string.Empty, string.Empty);

--- a/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
+++ b/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
@@ -44,11 +44,17 @@ public sealed class CertificateProvisioner
 
 		var caPath = await MaterializeCaAsync();
 
-		// Opt-in Partner signing (experimental) — needed only by apps that use restricted privileges
-		// (e.g. vpnservice). Partner if the global toggle is on OR the selected package declares it.
-		var level = (_config.PartnerSigning || requirePartner)
-			? CertificatePrivilegeLevel.Partner
-			: CertificatePrivilegeLevel.Public;
+		// Which certificate/level to sign with, from the user's Certificate preference (Settings):
+		//  • Partner   → always Partner.
+		//  • Public    → always Public (the user's explicit choice).
+		//  • Automatic → Public, unless the selected package declares it needs Partner (requirePartner).
+		// Partner is only needed by apps that use restricted privileges (e.g. vpnservice).
+		var level = MobileSettings.CertificatePreference switch
+		{
+			MobileSettings.CertificatePreferencePartner => CertificatePrivilegeLevel.Partner,
+			MobileSettings.CertificatePreferencePublic => CertificatePrivilegeLevel.Public,
+			_ => requirePartner ? CertificatePrivilegeLevel.Partner : CertificatePrivilegeLevel.Public,
+		};
 
 		ProgressCallback? cb = progress is null ? null : new ProgressCallback(progress);
 		var profile = await _provisioning.EnsureAsync(

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -90,8 +90,25 @@ public static class MobileSettings
 	/// </summary>
 	public static bool PartnerSigning
 	{
-		get => Preferences.Get(KeyPartnerSigning, false);
-		set => Preferences.Set(KeyPartnerSigning, value);
+		// Kept as a derived alias so IAppConfig/MobileAppConfig readers still work; the source of truth
+		// is now CertificatePreference (a 3-way choice), like the desktop's certificate picker.
+		get => CertificatePreference == CertificatePreferencePartner;
+		set => CertificatePreference = value ? CertificatePreferencePartner : CertificatePreferenceAuto;
+	}
+
+	public const string CertificatePreferenceAuto = "Automatic";
+	public const string CertificatePreferencePublic = "Public";
+	public const string CertificatePreferencePartner = "Partner";
+	private const string KeyCertPreference = "certificate_preference";
+
+	/// <summary>Which signing certificate/level to use: "Automatic" (Public unless a package requires
+	/// Partner), "Public", or "Partner" — mirrors the desktop's certificate picker. Migrates from the old
+	/// <see cref="KeyPartnerSigning"/> flag on first read.</summary>
+	public static string CertificatePreference
+	{
+		get => Preferences.Get(KeyCertPreference,
+			Preferences.Get(KeyPartnerSigning, false) ? CertificatePreferencePartner : CertificatePreferenceAuto);
+		set => Preferences.Set(KeyCertPreference, value ?? CertificatePreferenceAuto);
 	}
 
 	/// <summary>Extra TV DUIDs to pre-authorize in the signing cert (one per line/comma-separated).</summary>


### PR DESCRIPTION
Adds to the **mobile** head what the desktop already has: an explicit **certificate picker**, and makes an imported certificate the selected one.

## Why
Community ask: *"Is there a way to toggle the certificate type on Android like on the macOS app?"* — mobile only had a Partner on/off switch. And after importing a backup, the imported cert should become the default.

## Changes (mobile only)
- **Settings → Certificate picker: Automatic / Public / Partner** (replaces the Partner switch). Automatic = Public unless a package requires Partner; Public/Partner force the level. These map to the shared `Jelly2Sams - Public/Partner` profiles via the same Core `CertificateProvisioningService.EnsureAsync` (which already reuses an imported profile with no login when it covers the TV's DUID).
- Stored in `MobileSettings.CertificatePreference`; migrates existing Partner-toggle users; `PartnerSigning` kept as a derived alias so `IAppConfig`/export-import stay intact.
- **After importing a backup**, the picker defaults to whichever level profile was restored — so the imported certificate is selected.

Mobile builds clean (net10.0-android). Desktop unchanged (it already has its certificate dropdown).