### PR TITLE
Retry TV DUID read (fixes install on old/slow TVs) + off-thread download

### DIFF
--- a/Apps2Samsung.Core/Sdb/TizenDuidReader.cs
+++ b/Apps2Samsung.Core/Sdb/TizenDuidReader.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Apps2Samsung.Interfaces;
+using Apps2Samsung.Models;
+
+namespace Apps2Samsung.Sdb
+{
+    /// <summary>
+    /// Reads a TV's DUID over SDB with a few retries. A single read is a coin flip on old/slow TVs
+    /// (e.g. a 2016 Tizen 2.4 set): Samsung's sdbd stalls or closes the connection mid-handshake
+    /// (broken pipe / timeout / "remote closed stream"), and even a connection that succeeds can hand
+    /// back an empty or truncated reply. The very same "0 getduid" command then succeeds on the next
+    /// attempt — which is why the TV-information view often shows a DUID the installer failed to read.
+    /// So we retry, dropping the connection between tries (the next call reconnects on a fresh socket),
+    /// and treat an empty/invalid reply as retryable, not just a transport error.
+    /// </summary>
+    public static class TizenDuidReader
+    {
+        /// <summary>
+        /// Reads and validates the TV DUID, retrying up to <paramref name="attempts"/> times.
+        /// Returns the validated DUID, or throws <see cref="InvalidOperationException"/> carrying the
+        /// last failure reason. Callers that prefer a blank over an exception can catch it.
+        /// </summary>
+        public static async Task<string> ReadAsync(ISdbEngine sdb, string tvIp, int attempts = 3, Action<string>? progress = null)
+        {
+            string lastReason = string.Empty;
+
+            for (int attempt = 1; attempt <= attempts; attempt++)
+            {
+                ProcessResult result;
+                try
+                {
+                    result = await sdb.DuidAsync(tvIp).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    lastReason = ex.Message;
+                    await SafeDisconnectAsync(sdb, tvIp).ConfigureAwait(false);
+                    result = null!;
+                }
+
+                if (result is not null)
+                {
+                    var duid = (result.Output ?? string.Empty)
+                        .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                        .FirstOrDefault()?.Trim() ?? string.Empty;
+
+                    if (result.ExitCode == 0 && TizenDuid.IsValid(duid))
+                        return duid;
+
+                    // ExitCode 0 with a bad DUID = an empty/truncated reply from a slow TV; a non-zero
+                    // exit carries the transport error. Both are retryable, so drop and try again.
+                    lastReason = !string.IsNullOrWhiteSpace(result.Error) ? result.Error
+                        : string.IsNullOrEmpty(duid) ? "empty response"
+                        : $"unexpected response '{duid}'";
+                    await SafeDisconnectAsync(sdb, tvIp).ConfigureAwait(false);
+                }
+
+                if (attempt < attempts)
+                {
+                    progress?.Invoke($"Reading TV DUID… (retry {attempt + 1}/{attempts})");
+                    await Task.Delay(500).ConfigureAwait(false); // let the old TV's sdbd settle
+                }
+            }
+
+            throw new InvalidOperationException(
+                $"Could not read a valid TV DUID{(string.IsNullOrWhiteSpace(lastReason) ? "." : $": {lastReason}")}");
+        }
+
+        private static async Task SafeDisconnectAsync(ISdbEngine sdb, string tvIp)
+        {
+            try { await sdb.DisconnectAsync(tvIp).ConfigureAwait(false); }
+            catch { /* best effort — the next read reconnects regardless */ }
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
+++ b/Apps2Samsung.Mobile/Services/CertificateProvisioner.cs
@@ -3,6 +3,7 @@ using Apps2Samsung.Configuration;
 using Apps2Samsung.Extensions;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
+using Apps2Samsung.Sdb;
 using Microsoft.Maui.Storage;
 
 namespace Apps2Samsung.Mobile.Services;
@@ -35,12 +36,9 @@ public sealed class CertificateProvisioner
 	public async Task<Result> ProvisionAsync(string tvIp, bool requirePartner = false, Action<string>? progress = null)
 	{
 		progress?.Invoke("Reading TV DUID…");
-		var duidResult = await _sdb.DuidAsync(tvIp);
-		var duid = duidResult.Output.Trim();
-		// Reject a malformed DUID (e.g. an SDB transport-error string) so it never lands in the cert SAN.
-		if (duidResult.ExitCode != 0 || !TizenDuid.IsValid(duid))
-			throw new InvalidOperationException(
-				$"Could not read a valid TV DUID{(string.IsNullOrWhiteSpace(duidResult.Error) ? "." : $": {duidResult.Error}")}");
+		// Retry the read: old/slow TVs often hand back an empty reply or drop the connection mid-command
+		// on the first try, then answer on a retry. A validated DUID is returned; anything else throws.
+		var duid = await TizenDuidReader.ReadAsync(_sdb, tvIp, progress: progress);
 
 		var caPath = await MaterializeCaAsync();
 

--- a/Apps2Samsung.Mobile/Services/WgtInstaller.cs
+++ b/Apps2Samsung.Mobile/Services/WgtInstaller.cs
@@ -38,17 +38,23 @@ public sealed class WgtInstaller
 			name = "package.wgt";
 		var dest = Path.Combine(FileSystem.CacheDirectory, name);
 
-		using var req = new HttpRequestMessage(HttpMethod.Get, url);
-		req.Headers.UserAgent.ParseAdd("Apps2Samsung-Mobile");
-		var token = MobileSettings.GitHubToken;
-		if (!string.IsNullOrWhiteSpace(token) && new Uri(url).Host.Contains("github", StringComparison.OrdinalIgnoreCase))
-			req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		// Run the transfer off the UI thread with ConfigureAwait(false): on Android, disposing the HTTP
+		// response stream can do socket I/O, which StrictMode kills with NetworkOnMainThreadException if
+		// the continuation resumes on the main thread.
+		await Task.Run(async () =>
+		{
+			using var req = new HttpRequestMessage(HttpMethod.Get, url);
+			req.Headers.UserAgent.ParseAdd("Apps2Samsung-Mobile");
+			var token = MobileSettings.GitHubToken;
+			if (!string.IsNullOrWhiteSpace(token) && new Uri(url).Host.Contains("github", StringComparison.OrdinalIgnoreCase))
+				req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-		using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead);
-		resp.EnsureSuccessStatusCode();
-		await using (var src = await resp.Content.ReadAsStreamAsync())
-		await using (var dst = File.Create(dest))
-			await src.CopyToAsync(dst);
+			using var resp = await _http.SendAsync(req, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+			resp.EnsureSuccessStatusCode();
+			await using var src = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false);
+			await using var dst = File.Create(dest);
+			await src.CopyToAsync(dst).ConfigureAwait(false);
+		}).ConfigureAwait(false);
 
 		return dest;
 	}

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -8,6 +8,7 @@ using Apps2Samsung.Helpers.Tizen.Certificate;
 using Apps2Samsung.Interfaces;
 using Apps2Samsung.Models;
 using Apps2Samsung.Packaging;
+using Apps2Samsung.Sdb;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1239,8 +1240,17 @@ namespace Apps2Samsung.Services
 
         private async Task<string> GetTvDuidAsync(string tvIpAddress)
         {
-            var output = await _sdb.DuidAsync(tvIpAddress);
-            return output.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault()?.Trim() ?? string.Empty;
+            // Retry the read — old/slow TVs often return an empty reply or drop the connection on the
+            // first try. Returns blank on total failure so the caller's IsValid check handles it.
+            try
+            {
+                return await TizenDuidReader.ReadAsync(_sdb, tvIpAddress);
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine($"[Cert] DUID read failed for {tvIpAddress}: {ex.Message}");
+                return string.Empty;
+            }
         }
 
         private async Task<bool> GetTvDiagnoseAsync(string tvIpAddress)


### PR DESCRIPTION
Fixes intermittent **"Could not read a valid TV DUID"** install failures on old/slow TVs (reported on a 2016 UA43KU6500, Tizen 2.4.0).

### Root cause
A single `0 getduid` over SDB is a coin flip on a slow set: Samsung `sdbd` stalls or closes the connection mid-command (broken pipe / timeout / "remote closed stream"), and even a connection that succeeds can return an **empty/truncated** reply. The very same command then succeeds on a retry — which is exactly why the **TV-information view showed the DUID the installer failed to read** (identical code path, different luck). Not a regression: git history confirms the DUID read/validation path was untouched by the recent PRs; the DUID itself passes validation.

### Fix
- New shared `Apps2Samsung.Sdb.TizenDuidReader.ReadAsync` — retries the read (default 3×), **drops the connection between tries** so the next reconnects on a fresh socket, and treats an empty/invalid reply as retryable (not just transport errors).
- **Both heads** use it: mobile `CertificateProvisioner` and desktop `GetTvDuidAsync` (desktop still returns blank on total failure, so its existing `IsValid` guard behaves as before).
- Bonus mobile fix: `WgtInstaller.DownloadAsync` now runs off the UI thread with `ConfigureAwait(false)`, eliminating the `NetworkOnMainThreadException` seen when the HTTP response stream is disposed (socket I/O) on the main thread.

Both heads build clean.
