### PR TITLE
Mobile: stop Release builds rendering exception messages as resource keys

### DIFF
--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -28,6 +28,15 @@
 		       <MauiXaml Update="MyPage.xaml" Inflator="Runtime" /> (force runtime inflation) -->
 		<MauiXamlInflator>SourceGen</MauiXamlInflator>
 
+		<!-- Keep real exception messages in Release. Trimming turns on
+		     System.Resources.UseSystemResourceKeys, which strips the framework's message strings and
+		     renders every exception as its raw resource KEY instead: a message-less Java exception
+		     surfaced as "Exception_WasThrown, Java.Lang.RuntimeException" in the error dialogs, so no
+		     failure reported from a release build could be diagnosed (every one of this head's ~20
+		     "Couldn't … {ex.Message}" dialogs was affected, not just one feature). Costs a little APK
+		     size for the retained resource strings; being able to read a crash is worth more. -->
+		<UseSystemResourceKeys>false</UseSystemResourceKeys>
+
 		<!-- Display name -->
 		<ApplicationTitle>Apps2Samsung</ApplicationTitle>
 

--- a/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
@@ -195,7 +195,11 @@ public partial class AppIconsPage : ContentPage
 		}
 		catch (Exception ex)
 		{
-			await DisplayAlert("App icons", $"Couldn't set the icon: {ex.Message}", "OK");
+			await DisplayAlert(
+				"App icons",
+				$"Couldn't set the icon: {ErrorText.Describe(ex, "app-icons/pick")}\n\n" +
+				"Settings \u2192 Diagnostics \u2192 Share debug log has the full details.",
+				"OK");
 		}
 	}
 

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -130,7 +130,10 @@ public partial class SettingsPage : ContentPage
 		}
 		catch (Exception ex)
 		{
-			await DisplayAlert("Export backup", $"Couldn't export the backup: {ex.Message}", "OK");
+			await DisplayAlert(
+				"Export backup",
+				$"Couldn't export the backup: {ErrorText.Describe(ex, "backup/export")}",
+				"OK");
 		}
 	}
 
@@ -175,7 +178,11 @@ public partial class SettingsPage : ContentPage
 		}
 		catch (Exception ex)
 		{
-			await DisplayAlert("Import backup", $"Couldn't import the backup: {ex.Message}", "OK");
+			await DisplayAlert(
+				"Import backup",
+				$"Couldn't import the backup: {ErrorText.Describe(ex, "backup/import")}\n\n" +
+				"Settings \u2192 Diagnostics \u2192 Share debug log has the full details.",
+				"OK");
 		}
 	}
 

--- a/Apps2Samsung.Mobile/Services/ErrorText.cs
+++ b/Apps2Samsung.Mobile/Services/ErrorText.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+
+namespace Apps2Samsung.Mobile.Services;
+
+/// <summary>
+/// Turns an exception into something a user can act on <i>and</i> something a maintainer can debug.
+/// <para>
+/// Android failures here are often Java exceptions raised inside a platform call (the file picker
+/// resolving a <c>content://</c> URI, for instance). Those frequently carry a null Java message, so
+/// <c>ex.Message</c> alone degrades to the framework's generic "Exception of type 'X' was thrown" —
+/// and in a trimmed Release build, to the bare resource key <c>Exception_WasThrown</c>. Either way the
+/// dialog said nothing. So: name the type when there's no real message, unwrap the inner chain, and
+/// always write the FULL exception (for a <c>Java.Lang.Throwable</c> that includes the Java stack
+/// trace, which names the platform API that actually failed) to the session log that
+/// Settings → Diagnostics → "Share debug log" hands off.
+/// </para>
+/// </summary>
+public static class ErrorText
+{
+	/// <summary>
+	/// Logs <paramref name="ex"/> in full under <paramref name="context"/> and returns a short
+	/// description for the UI.
+	/// </summary>
+	public static string Describe(Exception ex, string context)
+	{
+		// ex.ToString(), not ex.Message: this is the only place the Java stack trace is preserved.
+		Trace.WriteLine($"[{context}] {ex}");
+
+		var parts = new List<string>();
+		for (Exception? e = ex; e is not null && parts.Count < 3; e = e.InnerException)
+		{
+			var message = e.Message?.Trim();
+
+			// No message, or the stripped-resource-key form ("Exception_WasThrown, Java.Lang.X") that
+			// a trimmed build produces for one — the type name is strictly more informative.
+			if (string.IsNullOrEmpty(message) ||
+				message.StartsWith("Exception_WasThrown", StringComparison.Ordinal))
+				message = e.GetType().FullName ?? e.GetType().Name;
+
+			if (!parts.Contains(message))
+				parts.Add(message);
+		}
+
+		return string.Join(" → ", parts);
+	}
+}


### PR DESCRIPTION
Two reports from the same build — setting a custom app icon, and importing a backup made on macOS — both produced the same dialog text:

```
Exception_WasThrown, Java.Lang.RuntimeException
```

## What's actually going on

`Exception_WasThrown` isn't a message — it's the .NET **resource key** for *"Exception of type '{0}' was thrown."* Trimming enables `System.Resources.UseSystemResourceKeys`, which strips the framework's message strings and formats exceptions as `<key>, <args>`. Confirmed in the generated Release runtimeconfig before this change:

```
System.Resources.UseSystemResourceKeys = true
```

So this was never specific to icons or backups: **every** error dialog in the shipped Android head was unreadable — all ~20 `Couldn't … {ex.Message}` sites. Nothing reported from a release build could be diagnosed, which is why neither report contained anything actionable.

## Changes

* **`UseSystemResourceKeys=false`** for this head. Verified: the Release runtimeconfig now carries `\x05false` where it previously had `\x04true`. Costs a little APK size for the retained resource strings; a readable crash is worth more.
* **`ErrorText.Describe(ex, context)`**, used by the two reported flows. A Java exception raised inside a platform call often has a *null* Java message, so even with real resource strings `ex.Message` only yields the generic "Exception of type 'X' was thrown" — so this names the type when there's no real message and unwraps the inner chain. It also writes the full `ex.ToString()` to the session log — for a `Java.Lang.Throwable` that includes the **Java stack trace**, naming the platform API that actually failed — and the dialog now points at Settings → Diagnostics → Share debug log.

## What this does *not* do

It does not fix either feature. The underlying Java exception is still unidentified; this makes it *identifiable*. See below for where I got to.

## Investigation notes (for the follow-up)

I decompiled `Microsoft.Maui.Essentials` 10.0.20 (`net10.0-android36.0`) and traced the whole pick path. Findings:

* `FilePickerImplementation.PlatformPickAsync` → `IntermediateActivity.StartAsync(...)` → its `OnResult` callback → `FileSystemUtils.EnsurePhysicalPath(intent.Data, requireExtendedAccess: true)`.
* `IntermediateActivity.OnActivityResult` wraps `OnResult` in `try/catch` and does `TaskCompletionSource.TrySetException(ex)`, so the exception reaches our `catch` **unchanged** — the `Java.Lang.RuntimeException` is a genuine Java throw, not a wrapper.
* On Android ≥ 29 without `MANAGE_EXTERNAL_STORAGE`, `requireExtendedAccess` is `true`, so `ResolvePhysicalPath` short-circuits to `null` and **everything** goes through `CacheContentFile(uri)` → `IsVirtualFile(uri)` → for a virtual/cloud document, `GetVirtualFileStream` → `ContentResolver.GetStreamTypes(...)` and `ContentResolver.OpenTypedAssetFileDescriptor(...).CreateInputStream()`.
* Ruled out by evidence, not assumption: the manifest declares no `WRITE_EXTERNAL_STORAGE`, so MAUI takes the `Application.Context.CacheDir` branch (never null) rather than the nullable `ExternalCacheDir` one — so `GetTemporaryFile(null, …)` is not reachable here.
* Every *other* failure mode in that path throws a .NET exception or a **named** Java exception (`FileNotFoundException`, `IOException`, `SecurityException`), none of which matches what was reported.

The surviving suspicion — **not proven** — is a `ContentResolver` call against a virtual/cloud document (Google Photos / Drive), which fits the pattern that picking a **local** `.wgt` in `InstallerPage` works while picking an image and a `.zip` (both likely arriving via a cloud provider, the backup having come from a Mac) do not. The debug log will now say definitively.

## Verification

Release and Debug builds of `Apps2Samsung.Mobile` (`net10.0-android`) — 0 errors. Localization check passes. No file's BOM state differs from `origin/beta`.
