### PR TITLE
fdroid: push the published index with an admin PAT

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -21,11 +21,28 @@ jobs:
     # Only after a successful stable build (or a manual run).
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    env:
+      PUSH_TOKEN: ${{ secrets.FDROID_PUSH_TOKEN }}
     steps:
+      - name: Check the push token is configured
+        run: |
+          set -euo pipefail
+          if [ -z "${PUSH_TOKEN:-}" ]; then
+            echo "::error::FDROID_PUSH_TOKEN is not set. The publish step pushes straight to"
+            echo "::error::\`beta\`, which the 'Required PR checks' ruleset guards; GITHUB_TOKEN"
+            echo "::error::pushes on write level and is rejected there. Add a fine-grained PAT"
+            echo "::error::(Contents: read/write) owned by a repo admin as FDROID_PUSH_TOKEN."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           ref: beta
           fetch-depth: 0
+          # Admins are on the ruleset's bypass list, GITHUB_TOKEN is not — and the commit
+          # below carries [skip ci], so the required checks can never report on it anyway.
+          # Checking out with the PAT makes the push at the end use it too.
+          token: ${{ secrets.FDROID_PUSH_TOKEN }}
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/fdroid/README.md
+++ b/fdroid/README.md
@@ -34,6 +34,15 @@ Add these **repository secrets** (Settings → Secrets and variables → Actions
 | `FDROID_KEYSTORE_PASS`   | the keystore password you chose |
 | `FDROID_KEY_ALIAS`       | `apps2samsung` |
 | `FDROID_KEY_PASS`        | same as `FDROID_KEYSTORE_PASS` (PKCS12) |
+| `FDROID_PUSH_TOKEN`      | fine-grained PAT of a **repo admin**, this repo only, *Contents: read/write* |
+
+`FDROID_PUSH_TOKEN` exists because the workflow commits the built index straight to
+`beta`, and the *Required PR checks* ruleset guards that branch. The default
+`GITHUB_TOKEN` pushes on write level and is rejected (`3 of 3 required status checks are
+expected`) — and since the commit carries `[skip ci]`, those checks can never report on
+it either. Admins are on the ruleset's bypass list, so a PAT owned by one gets through.
+**The token expires**: when it does, the publish step starts failing on the push — mint a
+new one and update the secret.
 
 ⚠️ Keep `fdroid-repo.p12` and its password safe and **reuse the same keystore forever** —
 if it changes, existing users' F-Droid clients reject the repo and must re-add it.


### PR DESCRIPTION
The **F-Droid Repo** run after the v2.7.8 release failed on its very last step ([run 33090588716](https://github.com/Apps2Samsung/Apps2Samsung/actions/runs/33090588716)) — the index was built correctly, only the push was refused:

```
remote: error: GH013: Repository rule violations found for refs/heads/beta.
remote: - 3 of 3 required status checks are expected.
 ! [remote rejected] beta -> beta (push declined due to repository rule violations)
```

## Why

The `Required PR checks` ruleset covers `~DEFAULT_BRANCH` (= `beta`) and `master`, and rulesets apply to **direct pushes** too, not just PRs. Its bypass list is `OrganizationAdmin` / `RepositoryRole 4 (maintain)` / `RepositoryRole 5 (admin)` — `GITHUB_TOKEN` pushes as `github-actions[bot]` on **write** level, so it is not covered. On top of that the commit carries `[skip ci]`, so no checks ever run on it and it can never satisfy the rule. Every stable release would fail here from now on.

## Fix

Check out with `FDROID_PUSH_TOKEN` — a fine-grained PAT of a repo admin (this repo only, *Contents: read/write*) — so the `git push origin beta` at the end reuses it. Admins are on the ruleset's bypass list, so the push goes through and nothing about the ruleset has to be relaxed.

Deploy keys would have been the tidier credential (no expiry, scoped to one repo), but they are **disabled org-wide**: `422 Deploy keys are disabled for this repository`.

Also added:
- an upfront guard step, so a missing or expired token fails immediately with an actionable message instead of dying at the push 6 minutes in;
- the secret and the reason for it documented in `fdroid/README.md`.

⚠️ **The PAT expires.** When it does, the publish step starts failing on the push again — mint a new one and update the secret.

## Verification
The secret is already set. After merge, re-running **F-Droid Repo** should publish the v2.7.8 APK, which the repo index still misses (it is on v2.7.7).
