### PR TITLE
Mobile: pick files through SAF so cloud sources stop throwing

### DIFF
--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -44,8 +44,8 @@
 		<ApplicationId>nl.madebypatrick.apps2samsung</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>2.7.8</ApplicationDisplayVersion>
-		<ApplicationVersion>4</ApplicationVersion>
+		<ApplicationDisplayVersion>2.7.9</ApplicationDisplayVersion>
+		<ApplicationVersion>5</ApplicationVersion>
 
 		<!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
 		<WindowsPackageType>None</WindowsPackageType>

--- a/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/AppIconsPage.xaml.cs
@@ -171,23 +171,17 @@ public partial class AppIconsPage : ContentPage
 	{
 		try
 		{
-			var result = await FilePicker.Default.PickAsync(new PickOptions
-			{
-				PickerTitle = "Select a launcher icon (PNG)",
-				FileTypes = FilePickerFileType.Images,
-			});
-			if (result is null)
+			var picked = await SafFilePicker.PickAsync("image/*");
+			if (picked is null)
 				return;
 
-			// Copy into app data so the path stays valid after the picker URI is released.
+			// Copy into app data: the picker cache is cleared on the next pick.
 			var dir = Path.Combine(FileSystem.AppDataDirectory, "app-icons");
 			Directory.CreateDirectory(dir);
 			var baseName = string.Concat(row.Key.Select(c => char.IsLetterOrDigit(c) ? c : '_'));
 			if (string.IsNullOrWhiteSpace(baseName)) baseName = "icon";
-			var dest = Path.Combine(dir, baseName + Path.GetExtension(result.FileName));
-			using (var src = await result.OpenReadAsync())
-			using (var dst = File.Create(dest))
-				await src.CopyToAsync(dst);
+			var dest = Path.Combine(dir, baseName + Path.GetExtension(picked.FileName));
+			File.Copy(picked.LocalPath, dest, overwrite: true);
 
 			row.IconPath = dest;
 			row.IconSummary.Text = DescribeIcon(dest);

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -185,27 +185,25 @@ public partial class InstallerPage : ContentPage
 	{
 		try
 		{
-			var result = await FilePicker.Default.PickAsync(new PickOptions { PickerTitle = "Select a .wgt package" });
-			if (result is null)
+			var picked = await SafFilePicker.PickAsync();
+			if (picked is null)
 			{
 				SetStatus("No file selected.");
 				return false;
 			}
-			if (!result.FileName.EndsWith(".wgt", StringComparison.OrdinalIgnoreCase))
+			if (!picked.FileName.EndsWith(".wgt", StringComparison.OrdinalIgnoreCase))
 			{
 				SetStatus("Please choose a .wgt file.");
 				return false;
 			}
 
-			var dest = Path.Combine(FileSystem.CacheDirectory, result.FileName);
-			using (var src = await result.OpenReadAsync())
-			using (var dst = File.Create(dest))
-				await src.CopyToAsync(dst);
+			var dest = Path.Combine(FileSystem.CacheDirectory, picked.FileName);
+			File.Copy(picked.LocalPath, dest, overwrite: true);
 
 			_customWgtPath = dest;
-			VersionPicker.ItemsSource = new List<string> { result.FileName };
+			VersionPicker.ItemsSource = new List<string> { picked.FileName };
 			VersionPicker.SelectedIndex = 0;
-			SetStatus($"Custom package ready: {result.FileName}");
+			SetStatus($"Custom package ready: {picked.FileName}");
 			return true;
 		}
 		catch (Exception ex)

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -141,25 +141,13 @@ public partial class SettingsPage : ContentPage
 	{
 		try
 		{
-			// Accept .zip archives. FilePickerFileType is per-platform; on Android match by MIME + extension.
-			var zipTypes = new FilePickerFileType(new Dictionary<DevicePlatform, IEnumerable<string>>
-			{
-				[DevicePlatform.Android] = new[] { "application/zip", "application/octet-stream" },
-				[DevicePlatform.iOS] = new[] { "public.zip-archive" },
-				[DevicePlatform.MacCatalyst] = new[] { "public.zip-archive" },
-				[DevicePlatform.WinUI] = new[] { ".zip" },
-			});
-
-			var result = await FilePicker.Default.PickAsync(new PickOptions
-			{
-				PickerTitle = "Select an Apps2Samsung backup (.zip)",
-				FileTypes = zipTypes,
-			});
-			if (result is null)
+			// Some file managers hand a .zip to the picker as application/octet-stream.
+			var picked = await SafFilePicker.PickAsync("application/zip", "application/octet-stream");
+			if (picked is null)
 				return;
 
 			BackupImportResult import;
-			using (var stream = await result.OpenReadAsync())
+			using (var stream = File.OpenRead(picked.LocalPath))
 				import = BackupService.Import(stream, CertStorePath);
 
 			if (!string.IsNullOrEmpty(import.SettingsJson))

--- a/Apps2Samsung.Mobile/Platforms/Android/MainActivity.cs
+++ b/Apps2Samsung.Mobile/Platforms/Android/MainActivity.cs
@@ -1,10 +1,17 @@
 ﻿using Android.App;
+using Android.Content;
 using Android.Content.PM;
 using Android.OS;
+using Apps2Samsung.Mobile.Services;
 
 namespace Apps2Samsung.Mobile;
 
 [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        base.OnActivityResult(requestCode, resultCode, data);
+        SafFilePicker.OnActivityResult(requestCode, resultCode, data);
+    }
 }

--- a/Apps2Samsung.Mobile/Services/SafFilePicker.cs
+++ b/Apps2Samsung.Mobile/Services/SafFilePicker.cs
@@ -1,0 +1,140 @@
+using Android.Content;
+using Android.Database;
+using AndroidApp = Android.App.Application;
+using AndroidUri = Android.Net.Uri;
+using Result = Android.App.Result;
+
+namespace Apps2Samsung.Mobile.Services;
+
+/// <summary>A file the user picked, already copied into app cache so the content URI can be released.</summary>
+public sealed record PickedFile(string FileName, string LocalPath);
+
+/// <summary>
+/// Storage Access Framework file picker, used instead of <c>FilePicker.Default.PickAsync</c>.
+///
+/// MAUI's picker resolves the picked content URI to a physical path inside
+/// <c>IntermediateActivity.OnActivityResult</c> — i.e. on the UI thread — by calling
+/// <c>ContentResolver.OpenInputStream</c>. StrictMode's thread policy travels with the Binder call
+/// to the document provider, so a provider that has to fetch the file over the network
+/// (Google Drive, OneDrive, cloud-backed Photos) trips the main-thread network check and the call
+/// comes back as <c>NetworkOnMainThreadException</c>, wrapped in a bare
+/// <c>Java.Lang.RuntimeException</c>. Picking the same file from local storage never touches the
+/// network, which is why this only reproduces on some phones and some sources.
+///
+/// So: launch the picker ourselves and do the read on a background thread, where the policy does
+/// not apply.
+/// </summary>
+public static class SafFilePicker
+{
+    // Arbitrary, only has to be unique within the activity.
+    internal const int RequestCode = 0x2A55;
+
+    private static TaskCompletionSource<AndroidUri?>? _pending;
+
+    /// <summary>
+    /// Shows the system picker and returns the chosen file, copied into app cache, or
+    /// <c>null</c> if the user cancelled.
+    /// </summary>
+    /// <param name="mimeTypes">MIME filter, e.g. <c>image/*</c>. Empty means every file.</param>
+    public static async Task<PickedFile?> PickAsync(params string[] mimeTypes)
+    {
+        var activity = Platform.CurrentActivity
+            ?? throw new InvalidOperationException("No current activity to show the file picker from.");
+
+        var tcs = new TaskCompletionSource<AndroidUri?>();
+        if (Interlocked.CompareExchange(ref _pending, tcs, null) is not null)
+            throw new InvalidOperationException("A file picker is already open.");
+
+        AndroidUri? uri;
+        try
+        {
+            try
+            {
+                activity.StartActivityForResult(Build(Intent.ActionOpenDocument, mimeTypes), RequestCode);
+            }
+            catch (ActivityNotFoundException)
+            {
+                // No document provider (stripped-down ROMs); the older chooser is still handled.
+                activity.StartActivityForResult(Build(Intent.ActionGetContent, mimeTypes), RequestCode);
+            }
+
+            uri = await tcs.Task;
+        }
+        finally
+        {
+            Interlocked.CompareExchange(ref _pending, null, tcs);
+        }
+
+        return uri is null ? null : await Task.Run(() => Copy(uri));
+    }
+
+    /// <summary>Feeds the activity result back to the waiting <see cref="PickAsync"/>.</summary>
+    /// <returns><c>true</c> if this was our request code.</returns>
+    internal static bool OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        if (requestCode != RequestCode)
+            return false;
+
+        var tcs = Interlocked.Exchange(ref _pending, null);
+        tcs?.TrySetResult(resultCode == Result.Ok ? data?.Data : null);
+        return true;
+    }
+
+    private static Intent Build(string action, string[] mimeTypes)
+    {
+        var intent = new Intent(action);
+        intent.AddCategory(Intent.CategoryOpenable);
+        intent.SetType(mimeTypes.Length == 1 ? mimeTypes[0] : "*/*");
+        if (mimeTypes.Length > 1)
+            intent.PutExtra(Intent.ExtraMimeTypes, mimeTypes);
+        return intent;
+    }
+
+    // Runs on a background thread — see the class remarks.
+    private static PickedFile Copy(AndroidUri uri)
+    {
+        var resolver = AndroidApp.Context.ContentResolver
+            ?? throw new InvalidOperationException("No ContentResolver.");
+
+        var name = Sanitize(DisplayName(resolver, uri));
+
+        // One file per pick: clearing first keeps a re-pick from reusing a stale copy and keeps
+        // the cache from growing with every icon the user tries.
+        var dir = Path.Combine(FileSystem.CacheDirectory, "picked");
+        if (Directory.Exists(dir))
+            Directory.Delete(dir, recursive: true);
+        Directory.CreateDirectory(dir);
+
+        var dest = Path.Combine(dir, name);
+        using (var src = resolver.OpenInputStream(uri)
+            ?? throw new IOException($"Couldn't open \"{name}\"."))
+        using (var dst = File.Create(dest))
+            src.CopyTo(dst);
+
+        return new PickedFile(name, dest);
+    }
+
+    private static string? DisplayName(ContentResolver resolver, AndroidUri uri)
+    {
+        // OpenableColumns.DISPLAY_NAME — spelled out to avoid depending on how the constant is bound.
+        const string DisplayNameColumn = "_display_name";
+
+        using ICursor? cursor = resolver.Query(uri, new[] { DisplayNameColumn }, null, null, null);
+        if (cursor is null || !cursor.MoveToFirst())
+            return null;
+
+        var column = cursor.GetColumnIndex(DisplayNameColumn);
+        return column < 0 ? null : cursor.GetString(column);
+    }
+
+    // The name comes from another app, so it decides neither the directory nor the extension.
+    private static string Sanitize(string? name)
+    {
+        name = Path.GetFileName(name ?? string.Empty).Trim();
+        if (string.IsNullOrEmpty(name))
+            return "picked-file";
+
+        var cleaned = new string(name.Select(c => Path.GetInvalidFileNameChars().Contains(c) ? '_' : c).ToArray());
+        return cleaned.Length > 128 ? cleaned[^128..] : cleaned;
+    }
+}

--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -15,7 +15,7 @@
 	<CFBundleName>Apps2Samsung</CFBundleName>
 	<CFBundleDisplayName>Apps2Samsung</CFBundleDisplayName>
 	<CFBundleIdentifier>com.madebypatrick.apps2samsung</CFBundleIdentifier>
-	<CFBundleVersion>2.7.8</CFBundleVersion>
+	<CFBundleVersion>2.7.9</CFBundleVersion>
 	<CFBundlePackageType>APPL</CFBundlePackageType>
 	<CFBundleSignature>????</CFBundleSignature>
 	<CFBundleExecutable>Apps2Samsung</CFBundleExecutable>

--- a/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs
@@ -157,7 +157,7 @@ namespace Apps2Samsung.Helpers
         [JsonIgnore]
         public string AuthorEndpoint { get; set; } = "https://dev.tizen.samsung.com/apis/v2/authors";
         [JsonIgnore]
-        public string AppVersion { get; set; } = "v2.7.8";
+        public string AppVersion { get; set; } = "v2.7.9";
         [JsonIgnore]
         public string TizenSdb { get; set; } = "https://api.github.com/repos/PatrickSt1991/tizen-sdb/releases";
         [JsonIgnore]

--- a/Jellyfin2Samsung-CrossOS/Info.plist
+++ b/Jellyfin2Samsung-CrossOS/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.madebypatrick.apps2samsung</string>
     <key>CFBundleVersion</key>
-    <string>2.7.8</string>
+    <string>2.7.9</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleSignature</key>


### PR DESCRIPTION
A user couldn't set a custom app icon. The log shows a bare `Java.Lang.RuntimeException` out of `FilePicker.Default.PickAsync`, and the Java trace underneath names the real one:

```
android.os.NetworkOnMainThreadException
    at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:816)
    at android.content.ContentResolver.openInputStream(ContentResolver.java:1578)
    at crc64…IntermediateActivity.onActivityResult(IntermediateActivity.java:34)
```

## Root cause

MAUI's picker resolves the picked content URI to a physical path **inside `IntermediateActivity.OnActivityResult`** — i.e. on the UI thread — via `FileSystemUtils.CacheContentFile` → `ContentResolver.OpenInputStream`.

StrictMode's thread policy travels with the Binder call into the document provider, so a provider that has to **fetch the file over the network** (Google Drive, OneDrive, cloud-backed Photos) trips the main-thread network check, and the failure is marshalled back to us as a `RuntimeException`. Picking the same file from local storage never touches the network — which is exactly why this reproduces on one phone and not on another, and why it looked like an icon-specific bug.

It is not icon-specific. All three pickers in the mobile head go through the same code path:

| Where | Picks |
|---|---|
| `InstallerPage.PickCustomWgtAsync` | a custom `.wgt` |
| `AppIconsPage.PickIconAsync` | a launcher icon |
| `SettingsPage.OnImportBackupClicked` | a backup `.zip` |

That last one is very likely the second report behind #569 ("importing a backup made on macOS" — a file that would typically come off a cloud drive).

## Fix

`SafFilePicker`: launch `ACTION_OPEN_DOCUMENT` ourselves, receive the result via `MainActivity.OnActivityResult`, and do the read on a **background thread**, where the policy doesn't apply. It copies into `CacheDirectory/picked` and hands back the local path, so callers no longer deal with content URIs at all.

- Falls back to `ACTION_GET_CONTENT` if no document provider is installed.
- The display name comes from the provider, so it's sanitised — it decides neither the directory nor the extension.
- The cache folder is cleared per pick, so re-picking can't reuse a stale copy.

## ⚠️ Testing

I can't build the mobile head locally (no `maui-android` workload on this machine), so **CI is the first compile**. More importantly this needs an on-device check that the automated build can't give:

1. Pick an icon **from Google Drive / OneDrive** (a file that is not cached locally) — this is the reported failure and should now work.
2. Pick an icon from local storage — the path that already worked.
3. Custom `.wgt` from both sources.
4. Backup import `.zip` from both sources.
5. Cancel the picker in each of the three places — should return quietly, not throw.
