### PR TITLE
CI: share one push token between the workflows that push to beta

### DIFF
--- a/.github/workflows/fdroid-repo.yml
+++ b/.github/workflows/fdroid-repo.yml
@@ -22,16 +22,16 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
-      PUSH_TOKEN: ${{ secrets.FDROID_PUSH_TOKEN }}
+      PUSH_TOKEN: ${{ secrets.CI_PUSH_TOKEN }}
     steps:
       - name: Check the push token is configured
         run: |
           set -euo pipefail
           if [ -z "${PUSH_TOKEN:-}" ]; then
-            echo "::error::FDROID_PUSH_TOKEN is not set. The publish step pushes straight to"
+            echo "::error::CI_PUSH_TOKEN is not set. The publish step pushes straight to"
             echo "::error::\`beta\`, which the 'Required PR checks' ruleset guards; GITHUB_TOKEN"
             echo "::error::pushes on write level and is rejected there. Add a fine-grained PAT"
-            echo "::error::(Contents: read/write) owned by a repo admin as FDROID_PUSH_TOKEN."
+            echo "::error::(Contents: read/write) owned by a repo admin as CI_PUSH_TOKEN."
             exit 1
           fi
 
@@ -42,7 +42,7 @@ jobs:
           # Admins are on the ruleset's bypass list, GITHUB_TOKEN is not — and the commit
           # below carries [skip ci], so the required checks can never report on it anyway.
           # Checking out with the PAT makes the push at the end use it too.
-          token: ${{ secrets.FDROID_PUSH_TOKEN }}
+          token: ${{ secrets.CI_PUSH_TOKEN }}
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/update-version-table.yml
+++ b/.github/workflows/update-version-table.yml
@@ -21,7 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # The step below commits to `beta`, which the "Required PR checks" ruleset guards.
+          # GITHUB_TOKEN pushes as github-actions[bot] on write level and is rejected there
+          # ("3 of 3 required status checks are expected"); a repo admin is on the bypass list.
+          # See fdroid/README.md for what CI_PUSH_TOKEN is and when it has to be renewed.
+          token: ${{ secrets.CI_PUSH_TOKEN }}
           ref: beta
       - name: Fetch latest releases
         id: releases

--- a/fdroid/README.md
+++ b/fdroid/README.md
@@ -34,13 +34,14 @@ Add these **repository secrets** (Settings → Secrets and variables → Actions
 | `FDROID_KEYSTORE_PASS`   | the keystore password you chose |
 | `FDROID_KEY_ALIAS`       | `apps2samsung` |
 | `FDROID_KEY_PASS`        | same as `FDROID_KEYSTORE_PASS` (PKCS12) |
-| `FDROID_PUSH_TOKEN`      | fine-grained PAT of a **repo admin**, this repo only, *Contents: read/write* |
+| `CI_PUSH_TOKEN`          | fine-grained PAT of a **repo admin**, this repo only, *Contents: read/write* |
 
-`FDROID_PUSH_TOKEN` exists because the workflow commits the built index straight to
+`CI_PUSH_TOKEN` exists because the workflow commits the built index straight to
 `beta`, and the *Required PR checks* ruleset guards that branch. The default
 `GITHUB_TOKEN` pushes on write level and is rejected (`3 of 3 required status checks are
 expected`) — and since the commit carries `[skip ci]`, those checks can never report on
 it either. Admins are on the ruleset's bypass list, so a PAT owned by one gets through.
+`update-version-table.yml` pushes to `beta` for the same reason and uses the same secret.
 **The token expires**: when it does, the publish step starts failing on the push — mint a
 new one and update the secret.
 


### PR DESCRIPTION
Follow-up to #575, which fixed only `fdroid-repo.yml`. Two workflows push to `beta`, and both are hit by the same ruleset:

| Workflow | Push | Before | After |
|---|---|---|---|
| `fdroid-repo.yml` | `git push origin beta` | admin PAT (#575) | same PAT, renamed secret |
| `update-version-table.yml` | `git push` → `beta` | `GITHUB_TOKEN` ❌ | admin PAT |

`update-version-table.yml` hasn't failed yet only because its recent runs had **nothing to commit** — the last real table commit is from 21 Aug, and [run 33077078439](https://github.com/Apps2Samsung/Apps2Samsung/actions/runs/33077078439) (13:29 UTC, 10 minutes *after* the ruleset was created at 13:19 UTC) went green for exactly that reason. That changes now: the table on `beta` still reads **Stable v2.7.7** while stable is **v2.7.8**, so the next run — scheduled every 6h, or after a Beta Pre-Release — does have a change to push, and would be rejected with the same `GH013`.

The secret is renamed `FDROID_PUSH_TOKEN` → **`CI_PUSH_TOKEN`**, since it is no longer fdroid-specific. Same PAT, already set on the repo.

Not affected, checked while I was here:
- `beta-prerelease.yml` pushes a **tag** (`git push -f origin refs/tags/…`); the ruleset is `target: branch`, so tags fall outside it.
- `validate-manifest.yml` pushes to a `fix/manifest-json-*` branch, which the ruleset doesn't cover. Its auto-PR does have a separate problem — opened with `GITHUB_TOKEN`, so the required checks never run on it and it can't merge without a bypass — but that workflow only fires on a malformed manifest, so it is left alone here.

## After merge
`FDROID_PUSH_TOKEN` can be deleted; nothing references it any more. I have left it in place so merging this doesn't leave a window where the F-Droid publish has no token.
