### PR TITLE
CI: stamp "-beta" into the version a beta build reports

### DIFF
--- a/.github/scripts/stamp-beta-version.py
+++ b/.github/scripts/stamp-beta-version.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Stamp the beta marker into the version the app shows at runtime (issue #578).
+
+The `beta` branch keeps a clean version (e.g. `v2.7.9`) because the Stable Release workflow
+refuses to build a version that still carries `-beta`. A beta build should still tell the user
+it is a beta, so the Beta Pre-Release workflow runs this script on its checkout right before
+building: the marker is added to the working tree only and is never committed.
+
+Stamped:
+  AppSettings.AppVersion   ->  "v2.7.9-beta"  (desktop footer + desktop update check)
+
+Not stamped, on purpose:
+  * the Android versionName — the workflow passes it on the command line
+    (`-p:ApplicationDisplayVersion=<version>-beta`), which overrides the .csproj anyway;
+  * the macOS Info.plist (CFBundle*Version) and the .deb control `Version`, which are
+    packaging fields that want a plain numeric version.
+
+The beta marker is cosmetic for update checks: GitHubUpdateChecker.CleanVersionString() drops
+any `-suffix` before comparing, so a running `v2.7.9-beta` is neither newer nor older than the
+`v2.7.9-beta` release it came from.
+
+Idempotent: a version that already ends in the suffix is left alone. Exits non-zero when a
+target file or its version line is missing, so a rename can't silently ship an unmarked beta.
+
+Usage: .github/scripts/stamp-beta-version.py [suffix]    # suffix defaults to "beta"
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# (path relative to the repo root, pattern, what the stamped version is used for).
+# Each pattern must capture: prefix, version (numeric core), suffix (any existing -marker), tail.
+TARGETS = [
+    (
+        "Jellyfin2Samsung-CrossOS/Helpers/AppSettings.cs",
+        re.compile(
+            r'(?P<prefix>AppVersion\s*\{\s*get;\s*set;\s*\}\s*=\s*")'
+            r'(?P<version>v?\d+(?:\.\d+){1,3})'
+            r'(?P<suffix>[^"]*)'
+            r'(?P<tail>")'
+        ),
+        "desktop footer + desktop update check",
+    ),
+]
+
+
+def stamp(relative_path: str, pattern: re.Pattern[str], usage: str, suffix: str) -> None:
+    path = REPO_ROOT / relative_path
+    if not path.is_file():
+        sys.exit(f"::error::{relative_path} not found — update {Path(__file__).name}")
+
+    # newline="" keeps the file's own line endings (and its BOM) byte-for-byte, so the only
+    # change in the build tree is the version string itself.
+    with open(path, encoding="utf-8", newline="") as handle:
+        original = handle.read()
+    match = pattern.search(original)
+    if match is None:
+        sys.exit(f"::error::no version line matched in {relative_path} — update {Path(__file__).name}")
+
+    marker = f"-{suffix}"
+    if match.group("suffix") == marker:
+        print(f"= {relative_path}: already {match.group('version')}{marker} ({usage})")
+        return
+
+    stamped = f"{match.group('prefix')}{match.group('version')}{marker}{match.group('tail')}"
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        handle.write(original[: match.start()] + stamped + original[match.end() :])
+    print(f"✔ {relative_path}: {match.group('version')}{match.group('suffix')} -> "
+          f"{match.group('version')}{marker} ({usage})")
+
+
+def main() -> None:
+    suffix = (sys.argv[1] if len(sys.argv) > 1 else "beta").lstrip("-")
+    if not suffix:
+        sys.exit("::error::empty version suffix")
+
+    for relative_path, pattern, usage in TARGETS:
+        stamp(relative_path, pattern, usage, suffix)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -28,6 +28,7 @@ jobs:
 
     outputs:
       VERSION: ${{ env.VERSION }}
+      VERSION_BETA: ${{ env.VERSION_BETA }}
       VERSION_TAG: ${{ env.VERSION_TAG }}
 
     steps:
@@ -47,8 +48,20 @@ jobs:
             exit 1
           fi
 
+          # VERSION      = 2.7.9        packaging fields that want a plain number (.deb, Info.plist)
+          # VERSION_BETA = 2.7.9-beta   the version the app itself reports (see the stamp step below)
+          # VERSION_TAG  = v2.7.9-beta  git tag, release name and asset file names
           echo "VERSION=${VERSION#v}" >> $GITHUB_ENV
+          echo "VERSION_BETA=${VERSION#v}-beta" >> $GITHUB_ENV
           echo "VERSION_TAG=${VERSION}-beta" >> $GITHUB_ENV
+
+      # ---------------- BETA MARKER (#578) ----------------
+      # The branch keeps a clean version (the Stable Release workflow rejects a "-beta" one), so
+      # CI adds the marker here — in the build tree only, never committed — and a beta build
+      # reports itself as "v2.7.9-beta" instead of claiming to be the stable v2.7.9.
+      - name: Stamp beta version
+        shell: bash
+        run: python3 .github/scripts/stamp-beta-version.py
 
       # ---------------- RELEASE NOTES ----------------
       # PR-based notes via GitHub's generate-notes API (categorised by
@@ -224,6 +237,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Fresh checkout — stamp the beta marker again (see the beta-release job).
+      - name: Stamp beta version
+        shell: bash
+        run: python3 .github/scripts/stamp-beta-version.py
+
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
@@ -375,6 +394,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fresh checkout — stamp the beta marker again (see the beta-release job). The APK's own
+      # versionName comes from the -p:ApplicationDisplayVersion below, not from this file.
+      - name: Stamp beta version
+        shell: bash
+        run: python3 .github/scripts/stamp-beta-version.py
+
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
@@ -413,7 +438,7 @@ jobs:
         run: |
           dotnet publish Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj \
             -c Release -f net10.0-android \
-            -p:ApplicationDisplayVersion=${{ needs.beta-release.outputs.VERSION }} \
+            -p:ApplicationDisplayVersion=${{ needs.beta-release.outputs.VERSION_BETA }} \
             -p:ApplicationVersion=${{ github.run_number }} \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore="$PWD/a2s.keystore" \

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -49,6 +49,10 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
 
       # ---------------- VERSION (NO -beta allowed) ----------------
+      # The beta marker is added by CI at build time (.github/scripts/stamp-beta-version.py, run
+      # from the Beta Pre-Release workflow) and never committed, so the version in the branch must
+      # always be clean. A "-beta" here means someone hand-edited it — fail instead of shipping a
+      # stable release that calls itself a beta.
       - name: Validate AppVersion (must be stable)
         id: version
         shell: bash
@@ -60,6 +64,7 @@ jobs:
           if echo "$VERSION_LINE" | grep -q '\-beta"'; then
             echo "❌ AppVersion still contains '-beta'"
             echo "   Stable releases must use a clean version like v2.0.0.1"
+            echo "   CI stamps the beta marker itself — don't commit it (see stamp-beta-version.py)"
             exit 1
           fi
 


### PR DESCRIPTION
Closes #578

## Why

The beta channel already tags and names its assets `v2.7.9-beta`, but the build *inside* those assets reported the plain stable number — the desktop footer, the desktop update check and the mobile version label all read `v2.7.9`. The version can't simply be hand-edited in the branch either: `stable-release.yml` hard-fails on a version carrying `-beta`. So CI adds the marker at build time.

## What

- **New `.github/scripts/stamp-beta-version.py`** — rewrites `AppSettings.AppVersion` (`"v2.7.9"` → `"v2.7.9-beta"`) in the checkout only, never committed. Table-driven, idempotent, preserves the file's BOM and line endings byte-for-byte, and exits non-zero if the file or its version line is missing, so a rename can't silently ship an unmarked beta. Optional suffix argument (`rc1`, …).
- **`beta-prerelease.yml`** — new `VERSION_BETA` output (`2.7.9-beta`) alongside `VERSION` (`2.7.9`) and `VERSION_TAG` (`v2.7.9-beta`); a `Stamp beta version` step in all three jobs (each checks out fresh), after the version is read and before anything is built; the APK's `ApplicationDisplayVersion` (Android `versionName`) now comes from `VERSION_BETA`, so the mobile label reads `v2.7.9-beta`.
- **`stable-release.yml`** — comment + error line documenting that CI stamps the marker, so a `-beta` in the branch means a hand-edit.

Left numeric on purpose: the macOS `Info.plist` `CFBundle*Version` and the `.deb` control `Version` — packaging fields that want a plain number.

## Verification

- Stamp runs idempotently and changes exactly one line (`git diff --stat` = 1 insertion); the file's hash restores exactly after a revert.
- Simulated CI snippet yields `VERSION=2.7.9`, `VERSION_BETA=2.7.9-beta`, `VERSION_TAG=v2.7.9-beta`.
- Desktop head builds Release with the stamp applied: 0 errors (pre-existing warnings only).
- Both workflows parse as YAML.
- Update checks unaffected: `GitHubUpdateChecker.CleanVersionString` drops the `-suffix` before comparing, so a running `v2.7.9-beta` is neither newer nor older than the release it came from. Every other version compare in the codebase is `TryParse`-based on unrelated values (SDB binary, Tizen platform).
