### PR TITLE
deps: take the NuGet bumps that don't need a migration, hold the two that do

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,19 @@ updates:
     open-pull-requests-limit: 3
     commit-message:
       prefix: deps
+    ignore:
+      # Avalonia 12 and FluentAvalonia 3 are migrations, not bumps — the first Dependabot attempt
+      # (#582) failed to build: BindingPlugins is no longer public, Avalonia.Controls.SaveFileDialog
+      # is gone (StorageProvider replaces it), and FluentAvalonia dropped SymbolIcon/Symbol. Drop
+      # these entries when someone does the port deliberately.
+      - dependency-name: "Avalonia*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "FluentAvaloniaUI"
+        update-types: ["version-update:semver-major"]
+      # Pre-1.0, so a "minor" is a breaking change: 0.21 -> 0.95 crosses a lot of them, and this one
+      # only runs on Linux, where CI can't exercise it. Patches still come through.
+      - dependency-name: "Tmds.DBus.Protocol"
+        update-types: ["version-update:semver-minor"]
     groups:
       # The SDB engine gets its own PR: it is the one dependency whose bump changes how the app
       # talks to a TV, so it wants a run against real hardware before it goes to beta.

--- a/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
+++ b/Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj
@@ -71,25 +71,24 @@
   </ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="11.3.20" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.20" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.20" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.20" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.12">
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.20">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Fleck" Version="1.2.0" />
-    <PackageReference Include="FluentAvaloniaUI" Version="2.4.0" />
-    <PackageReference Include="Jint" Version="4.4.2" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.3.0" />
-  <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.6" />
+    <PackageReference Include="FluentAvaloniaUI" Version="2.5.1" />
+    <PackageReference Include="Jint" Version="4.16.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.3.12" />
+  <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.12" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
-  <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />
   </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Replaces #582, which **fails the desktop build** — so I didn't merge it. #581 (the actions group) was green and is merged.

## Why #582 can't just go in

Three of its 13 updates are migrations, not bumps:

| Update | What breaks |
|---|---|
| Avalonia 11 → 12 | `BindingPlugins` is no longer public; `Avalonia.Controls.SaveFileDialog` is gone (StorageProvider replaces it) → `App.axaml.cs`, `TvLogsViewModel` don't compile |
| FluentAvaloniaUI 2 → 3 | `SymbolIcon` and `Symbol` removed → `DialogService` doesn't compile |
| Tmds.DBus.Protocol 0.21 → 0.95 | pre-1.0, so that range is breaking by convention — and it only runs on Linux, where CI can't exercise it |

## What this PR takes

Everything else, each inside its current major:

```
Avalonia (+ Desktop / Themes.Fluent / Fonts.Inter / Diagnostics)  11.3.12 -> 11.3.20
Avalonia.Controls.DataGrid                                        11.3.12 -> 11.3.13
FluentAvaloniaUI                                                  2.4.0   -> 2.5.1
CommunityToolkit.Mvvm                                             8.4.0   -> 8.4.2
Jint                                                              4.4.2   -> 4.16.1
Microsoft.AspNetCore                                              2.3.0   -> 2.3.12
Microsoft.AspNetCore.Server.Kestrel.Core                          2.3.6   -> 2.3.12
```

It also **drops** the explicit `System.Formats.Asn1` reference rather than bumping it: NU1510 points out it's part of the framework on net10 and doesn't need referencing, which clears that warning too.

## And stops the failing PR coming back

`dependabot.yml` now ignores the three held packages — majors for `Avalonia*` and `FluentAvaloniaUI`, minors for `Tmds.DBus.Protocol`. Otherwise the same unbuildable PR returns every week and trains everyone to ignore Dependabot. **Remove those entries when the Avalonia 12 port is done.**

## Verification

Desktop builds Release with 0 errors and no NU1510. Mobile is untouched by this file but CI builds it anyway.

Want me to open a tracking issue for the Avalonia 12 / FluentAvalonia 3 port? I have the exact break list above, and #582 can be closed in favour of this PR either way.
