### PR TITLE
Linux: fix the aarch64 rpm, and make the PR check package both architectures

### DIFF
--- a/.github/scripts/package-linux.sh
+++ b/.github/scripts/package-linux.sh
@@ -89,8 +89,10 @@ mv "$WORK/deb.deb" "$OUT_DIR/${PRODUCT}-${TAG}-linux-${ARCH}.deb"
 echo "✔ deb"
 
 # ---------------- .rpm ----------------
-# rpmbuild wants its own tree; BuildArch is forced so an x86_64 runner can build the aarch64 package
-# (nothing is compiled here — the payload is already published for the target).
+# rpmbuild wants its own tree. The architecture comes from --target alone, NOT from a BuildArch in
+# the spec: with BuildArch set, rpmbuild checks it against the host and refuses to build the aarch64
+# package on an x86_64 runner ("No compatible architectures found for build"). Nothing is compiled
+# here — the payload is already published for the target — so the target only tags the package.
 RPM_TOP="$WORK/rpm"
 mkdir -p "$RPM_TOP"/{BUILD,RPMS,SOURCES,SPECS,BUILDROOT}
 cat > "$RPM_TOP/SPECS/$APP_ID.spec" <<EOF
@@ -100,7 +102,6 @@ Release:        1
 Summary:        Install apps on Samsung Tizen TVs
 License:        MIT
 URL:            https://github.com/Apps2Samsung/Apps2Samsung
-BuildArch:      $RPM_ARCH
 Provides:       jellyfin2samsung
 # Versioned, or rpm warns: this replaces any jellyfin2samsung up to the rename.
 Obsoletes:      jellyfin2samsung < $VERSION
@@ -129,7 +130,8 @@ cp $ICON_PNG %{buildroot}/usr/share/icons/hicolor/256x256/apps/$APP_ID.png
 EOF
 desktop_entry "/opt/$APP_ID/$PRODUCT" > "$WORK/$APP_ID.desktop"
 # Quiet unless it fails: rpmbuild narrates its whole %install script otherwise.
-if ! rpmbuild --define "_topdir $RPM_TOP" -bb "$RPM_TOP/SPECS/$APP_ID.spec" > "$WORK/rpmbuild.log" 2>&1; then
+if ! rpmbuild --define "_topdir $RPM_TOP" --target "$RPM_ARCH" \
+        -bb "$RPM_TOP/SPECS/$APP_ID.spec" > "$WORK/rpmbuild.log" 2>&1; then
     cat "$WORK/rpmbuild.log" >&2
     exit 1
 fi

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -81,30 +81,46 @@ jobs:
             https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           sudo chmod +x /usr/local/bin/appimagetool
 
-      # x64 only: this proves the packaging script still works, and arm64 differs by three metadata
-      # strings. Publishing both would double the slowest part for no extra coverage.
-      - name: Publish and package (x64)
+      # BOTH architectures, like the releases do. An earlier version of this job packaged x64 only,
+      # on the assumption that arm64 differed by "three metadata strings" — it doesn't: the aarch64
+      # rpm needs rpmbuild --target, and packaging x64 alone let that reach a release (#590).
+      - name: Publish and package (x64 + arm64)
         run: |
-          dotnet publish Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj \
-            -c Release -r linux-x64 -p:SelfContained=true -o publish/linux-x64
-          # 0.0.0 rather than something like 0.0.0-pr: rpm forbids '-' in a version (it separates
-          # version from release), which is what the first run of this job discovered.
-          bash .github/scripts/package-linux.sh publish/linux-x64 x64 0.0.0 dist jellyfin.png
+          for ARCH in x64 arm64; do
+            dotnet publish Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj \
+              -c Release -r linux-$ARCH -p:SelfContained=true -o publish/linux-$ARCH
+            # 0.0.0 rather than something like 0.0.0-pr: rpm forbids '-' in a version (it separates
+            # version from release), which is what the first run of this job discovered.
+            bash .github/scripts/package-linux.sh "publish/linux-$ARCH" "$ARCH" 0.0.0 dist jellyfin.png
+          done
 
-      # A package that builds but is empty would still pass the step above, so assert the payload
-      # made it in: the binary in the .deb and the .rpm, and a runnable AppRun in the AppImage.
+      # A package that builds but is empty would still pass the step above, so assert the payload made
+      # it in, and that each package is tagged for the architecture it claims.
       - name: Check the packages contain the app
         run: |
           set -euo pipefail
           # Listings go to files first: `… | grep -q` exits on the first match, SIGPIPEs the writer,
-          # and pipefail then reports the whole pipeline as failed. It only looks fine when the
-          # listing is small enough to fit the pipe buffer, which is how this passed locally and
-          # failed here.
-          dpkg-deb -c dist/*.deb > deb-listing.txt
-          rpm -qlp dist/*.rpm > rpm-listing.txt
-          grep -q '/opt/apps2samsung/Apps2Samsung$' deb-listing.txt
-          grep -qx '/opt/apps2samsung/Apps2Samsung' rpm-listing.txt
-          ./dist/*.AppImage --appimage-extract >/dev/null
+          # and pipefail then reports the whole pipeline as failed. Whether it trips depends on the
+          # listing fitting in the pipe buffer, which is why it passed locally and failed here.
+          for ARCH in x64 arm64; do
+            dpkg-deb -c dist/*-linux-$ARCH.deb > "deb-$ARCH.txt"
+            rpm -qlp dist/*-linux-$ARCH.rpm > "rpm-$ARCH.txt"
+            grep -q '/opt/apps2samsung/Apps2Samsung$' "deb-$ARCH.txt"
+            grep -qx '/opt/apps2samsung/Apps2Samsung' "rpm-$ARCH.txt"
+          done
+
+          # The tags, not just the contents: a cross-built package that came out x86_64 would install
+          # on the wrong machines and fail on the right ones.
+          test "$(dpkg-deb -f dist/*-linux-x64.deb Architecture)" = amd64
+          test "$(dpkg-deb -f dist/*-linux-arm64.deb Architecture)" = arm64
+          test "$(rpm -qp --qf '%{ARCH}' dist/*-linux-x64.rpm)" = x86_64
+          test "$(rpm -qp --qf '%{ARCH}' dist/*-linux-arm64.rpm)" = aarch64
+          file -b dist/*-linux-arm64.AppImage | grep -q 'ARM aarch64'
+
+          # Only the x64 AppImage can be unpacked here: --appimage-extract runs the AppImage's own
+          # runtime, and the arm64 one is an aarch64 binary. Its payload is the same publish output
+          # the .deb and .rpm above were built from, and its runtime arch is asserted just above.
+          ./dist/*-linux-x64.AppImage --appimage-extract >/dev/null
           test -x squashfs-root/AppRun
           test -x squashfs-root/usr/bin/Apps2Samsung
-          echo "deb, rpm and AppImage all carry the app"
+          echo "deb, rpm and AppImage carry the app, for both architectures"


### PR DESCRIPTION
Follow-up to #590 — the beta release after it **failed**, and the cause is a blind spot I built into the check myself.

## What happened

The PR check packaged **x64 only**, with a comment asserting arm64 "differs by three metadata strings". It doesn't. In the release:

```
x64:   ✔ tar.gz  ✔ deb  ✔ rpm  ✔ AppImage
arm64: ✔ tar.gz  ✔ deb  ✗ error: No compatible architectures found for build
```

`rpmbuild` won't build the aarch64 package on an x86_64 runner from a spec `BuildArch` alone.

## The fix, established by probing rather than guessing

| Attempt | Result |
|---|---|
| `BuildArch: aarch64`, no `--target` | `No compatible architectures found for build` |
| `BuildArch: aarch64` + `--target aarch64` | still refuses |
| **no `BuildArch`** + `--target aarch64` | **builds, tagged aarch64** |

So the spec drops `BuildArch` and the architecture comes from `--target`.

## Closing the blind spot

The check now packages **x64 and arm64**, like the releases, and asserts the *tags* rather than merely that something appeared — a cross-built package that silently came out x86_64 would install on the wrong machines and fail on the right ones:

```
deb Architecture   amd64 / arm64
rpm %{ARCH}        x86_64 / aarch64
arm64 AppImage     runtime reports "ARM aarch64"
```

One asymmetry is deliberate: only the **x64** AppImage is unpacked in CI, because `--appimage-extract` runs the AppImage's own runtime and the arm64 one is an aarch64 binary. Locally I unpacked it anyway — `unsquashfs` at the payload offset — and confirmed the `AppRun`/desktop/icon layout over an **ELF aarch64** binary. So CI asserts the arch and the payload was checked by hand once.

## Verification

Both architectures packaged locally from real `linux-x64` and `linux-arm64` publishes: all four formats build, every tag is correct, and the complete assertion block from the check passes with `pipefail` set.
