### PR TITLE
Linux: stop rpm stripping the app to pieces, and keep -beta in the asset names

### DIFF
--- a/.github/scripts/package-linux.sh
+++ b/.github/scripts/package-linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Builds the Linux packages for one architecture from an already-published self-contained folder.
 #
-#   package-linux.sh <publish-dir> <arch: x64|arm64> <version> <out-dir> <icon-png>
+#   package-linux.sh <publish-dir> <arch: x64|arm64> <version> <asset-tag> <out-dir> <icon-png>
 #
 # Produces, named the way the release assets are (Apps2Samsung-v<version>-linux-<arch>.<ext>):
 #   .tar.gz     the portable folder, for anything not covered below
@@ -18,13 +18,17 @@ set -euo pipefail
 # relative publish dir or icon would silently resolve to the wrong place.
 PUBLISH_DIR="$(realpath "${1:?publish dir}")"
 ARCH="${2:?arch (x64|arm64)}"
-VERSION="${3:?version, without the leading v}"
-mkdir -p "${4:?output dir}"
-OUT_DIR="$(realpath "$4")"
-ICON_PNG="$(realpath "${5:?256x256 png}")"
+# Two version strings, deliberately: the package metadata version (rpm-legal, no '-') and the tag the
+# asset file names carry, which for a beta is v2.7.9-beta. Deriving the file names from the version
+# alone dropped the -beta marker from the beta release's Linux assets.
+VERSION="${3:?package version, e.g. 2.7.9}"
+ASSET_TAG="${4:?asset tag, e.g. v2.7.9-beta}"
+mkdir -p "${5:?output dir}"
+OUT_DIR="$(realpath "$5")"
+ICON_PNG="$(realpath "${6:?256x256 png}")"
 
 PRODUCT="Apps2Samsung"
-TAG="v${VERSION}"
+TAG="$ASSET_TAG"
 APP_ID="apps2samsung"
 
 # rpm reserves '-' as the version/release separator, so it can never appear in Version:. Say that
@@ -96,6 +100,15 @@ echo "✔ deb"
 RPM_TOP="$WORK/rpm"
 mkdir -p "$RPM_TOP"/{BUILD,RPMS,SOURCES,SPECS,BUILDROOT}
 cat > "$RPM_TOP/SPECS/$APP_ID.spec" <<EOF
+# rpm's default post-install processing runs strip over every ELF it finds. Our payload is a .NET
+# single-file bundle — the app is appended to the host executable — and stripping it threw away 126
+# of its 138 MB, leaving a package that installs and then cannot run. It only showed up as an x64
+# rpm suspiciously smaller than the aarch64 one, which survived because strip can't process a
+# foreign-architecture binary. Turn the whole post-processing off; nothing here needs it.
+%global __os_install_post %{nil}
+%global __strip /bin/true
+%global debug_package %{nil}
+
 Name:           $APP_ID
 Version:        $VERSION
 Release:        1

--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -164,7 +164,7 @@ jobs:
         run: |
           for ARCH in x64 arm64; do
             bash .github/scripts/package-linux.sh \
-              "publish/linux-$ARCH" "$ARCH" "$VERSION" dist jellyfin.png
+              "publish/linux-$ARCH" "$ARCH" "$VERSION" "$VERSION_TAG" dist jellyfin.png
           done
 
       # ---------------- RELEASE (UPDATE SAME TAG EVERY COMMIT) ----------------

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -91,7 +91,8 @@ jobs:
               -c Release -r linux-$ARCH -p:SelfContained=true -o publish/linux-$ARCH
             # 0.0.0 rather than something like 0.0.0-pr: rpm forbids '-' in a version (it separates
             # version from release), which is what the first run of this job discovered.
-            bash .github/scripts/package-linux.sh "publish/linux-$ARCH" "$ARCH" 0.0.0 dist jellyfin.png
+            bash .github/scripts/package-linux.sh \
+              "publish/linux-$ARCH" "$ARCH" 0.0.0 v0.0.0-pr dist jellyfin.png
           done
 
       # A package that builds but is empty would still pass the step above, so assert the payload made
@@ -107,6 +108,17 @@ jobs:
             rpm -qlp dist/*-linux-$ARCH.rpm > "rpm-$ARCH.txt"
             grep -q '/opt/apps2samsung/Apps2Samsung$' "deb-$ARCH.txt"
             grep -qx '/opt/apps2samsung/Apps2Samsung' "rpm-$ARCH.txt"
+
+            # Present is not the same as whole. rpm's default post-install strip once reduced the
+            # x64 binary from 138 MB to 11 MB — a .NET single-file bundle with its payload cut off,
+            # which installs happily and then cannot run. Compare against the published binary.
+            EXPECTED=$(stat -c%s "publish/linux-$ARCH/Apps2Samsung")
+            IN_DEB=$(awk '$6=="./opt/apps2samsung/Apps2Samsung"{print $3}' "deb-$ARCH.txt")
+            IN_RPM=$(rpm -qp --qf '[%{FILENAMES} %{FILESIZES}\n]' dist/*-linux-$ARCH.rpm \
+              | awk '$1=="/opt/apps2samsung/Apps2Samsung"{print $2}')
+            echo "$ARCH: published=$EXPECTED deb=$IN_DEB rpm=$IN_RPM"
+            test "$IN_DEB" = "$EXPECTED"
+            test "$IN_RPM" = "$EXPECTED"
           done
 
           # The tags, not just the contents: a cross-built package that came out x86_64 would install
@@ -123,4 +135,5 @@ jobs:
           ./dist/*-linux-x64.AppImage --appimage-extract >/dev/null
           test -x squashfs-root/AppRun
           test -x squashfs-root/usr/bin/Apps2Samsung
-          echo "deb, rpm and AppImage carry the app, for both architectures"
+          test "$(stat -c%s squashfs-root/usr/bin/Apps2Samsung)" = "$(stat -c%s publish/linux-x64/Apps2Samsung)"
+          echo "deb, rpm and AppImage carry the whole app, for both architectures"

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -208,7 +208,7 @@ jobs:
         run: |
           for ARCH in x64 arm64; do
             bash .github/scripts/package-linux.sh \
-              "publish/linux-$ARCH" "$ARCH" "$VERSION" dist jellyfin.png
+              "publish/linux-$ARCH" "$ARCH" "$VERSION" "$VERSION_TAG" dist jellyfin.png
           done
 
       # ---------------- CREATE/UPDATE STABLE RELEASE ----------------


### PR DESCRIPTION
The Linux packages published in the last beta release have two defects. Both were found by *reading the asset list*, not by any check I'd written — which is the part worth fixing as well.

## 1. The x64 `.rpm` was broken

rpm runs `strip` over every ELF it finds during `%install`. Our payload is a **.NET single-file bundle** — the entire app is appended to the host executable — so stripping cut it from **138 MB to 11 MB**. That package installs happily and then cannot run.

What made it visible: the x64 rpm was suspiciously *smaller* than the aarch64 one (27.6 MB vs 78 MB). aarch64 escaped only because `strip` can't process a foreign-architecture binary on the runner — so the arch I *couldn't* cross-strip is the one that came out correct.

```
before:  x64 published=137.7 MB   in-rpm=11.4 MB     ← gutted
         arm64 published=144.9 MB in-rpm=144.9 MB
after:   x64 published/deb/rpm all = 144398726 bytes
         arm64 published/deb/rpm all = 151923564 bytes
```

The spec now disables `__os_install_post`, `__strip` and `debug_package`.

## 2. The assets lost their `-beta`

File names were derived from the package version, and an rpm version can't contain `-`, so the beta's Linux assets came out `Apps2Samsung-v2.7.9-linux-x64.deb` next to the correctly named `-v2.7.9-beta-` ones from earlier runs. The script now takes **both** strings: `Version: 2.7.9` for package metadata, `v2.7.9-beta` for file names.

## The check that should have caught #1

The old assertion proved the binary was *present*. It was present — gutted. The check now compares the app binary inside each `.deb`, `.rpm` and the AppImage against the size of the published binary, per architecture, and prints the three numbers so a future mismatch is legible.

## Verification

Both architectures rebuilt locally: names carry `-beta`, published/deb/rpm sizes agree exactly, and the complete assertion block (including the new size checks and the arch tags) passes with `pipefail` set.

## Cleanup still needed

The mis-named assets from the last release are still attached to `v2.7.9-beta` — including the broken x64 rpm. They need deleting; the next release run overwrites the correctly named ones. I'll do that once this merges, so a user can't grab the broken rpm in the meantime.
