### PR TITLE
Mobile: put the TV shortcuts on one line instead of wrapping links

### DIFF
--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml
@@ -77,25 +77,38 @@
                 </Grid>
 
                 <!-- Quick peek at what's already on the selected TV.
-                     FlexLayout rather than HorizontalStackLayout: the three labels need roughly 330dp
-                     of width, which is more than the ~304dp a 360dp phone leaves inside the card, and a
-                     stack layout neither wraps nor shrinks - so the last button, Remote, was clipped off
-                     the right edge and looked missing. Wrapping also survives a larger font scale and the
-                     longer wordings these strings get once they come back from Crowdin. -->
-                <FlexLayout Wrap="Wrap" JustifyContent="Start" AlignItems="Center">
-                    <Button Text="{l:Localize lblShowInstalledApps}" Clicked="OnShowInstalledAppsClicked"
-                            BackgroundColor="Transparent" BorderWidth="0"
-                            Padding="0" Margin="0,0,18,2" FontSize="13"
-                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
-                    <Button Text="{l:Localize lblTvInformation}" Clicked="OnShowDeviceInfoClicked"
-                            BackgroundColor="Transparent" BorderWidth="0"
-                            Padding="0" Margin="0,0,18,2" FontSize="13"
-                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
-                    <Button Text="{l:Localize Key=lblRemote, Format='🎛 {0}'}" Clicked="OnShowRemoteClicked"
-                            BackgroundColor="Transparent" BorderWidth="0"
-                            Padding="0" Margin="0,0,0,2" FontSize="13"
-                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}" />
-                </FlexLayout>
+                     Three chips in an even Grid rather than a row of flat text buttons: the labels
+                     need roughly 330dp of width, more than the ~304dp a 360dp phone leaves inside the
+                     card, so they used to wrap onto a second line and read as stray links. Even
+                     columns keep this a single row whatever the font scale or the wording these
+                     strings come back with from Crowdin - a long translation wraps inside its own
+                     chip - and the borders match the pickers above. -->
+                <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                    <Button Grid.Column="0" Text="{l:Localize lblInstalledApps}"
+                            Clicked="OnShowInstalledAppsClicked"
+                            FontSize="12" LineBreakMode="WordWrap"
+                            BackgroundColor="{AppThemeBinding Light=White, Dark=#2A2A2A}"
+                            BorderWidth="1" CornerRadius="8"
+                            BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                            Padding="4,8" MinimumHeightRequest="44" />
+                    <Button Grid.Column="1" Text="{l:Localize lblTvInformation}"
+                            Clicked="OnShowDeviceInfoClicked"
+                            FontSize="12" LineBreakMode="WordWrap"
+                            BackgroundColor="{AppThemeBinding Light=White, Dark=#2A2A2A}"
+                            BorderWidth="1" CornerRadius="8"
+                            BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                            Padding="4,8" MinimumHeightRequest="44" />
+                    <Button Grid.Column="2" Text="{l:Localize lblRemote}"
+                            Clicked="OnShowRemoteClicked"
+                            FontSize="12" LineBreakMode="WordWrap"
+                            BackgroundColor="{AppThemeBinding Light=White, Dark=#2A2A2A}"
+                            BorderWidth="1" CornerRadius="8"
+                            BorderColor="{AppThemeBinding Light=#CDD3D8, Dark=#3A3A3A}"
+                            TextColor="{AppThemeBinding Light=#2C3E50, Dark=White}"
+                            Padding="4,8" MinimumHeightRequest="44" />
+                </Grid>
 
                 <!-- Status bar -->
                 <Border BackgroundColor="#2C3E50" Padding="16" StrokeThickness="0" StrokeShape="RoundRectangle 6">


### PR DESCRIPTION
## What

The three TV shortcuts on the installer card — **Show installed apps**, **TV information** and **Remote** — sat in a wrapping `FlexLayout`. The labels need roughly 330dp, more than the ~304dp a 360dp phone leaves inside the card, so the row broke onto a second line and the shortcuts read as stray text instead of part of the card.

## How

They are now three buttons in an even three-column `Grid`, wearing the same border, fill and text colours as the pickers above them (`#CDD3D8`/`#3A3A3A` border, `White`/`#2A2A2A` fill, `#2C3E50`/white text, rounded 8, 44dp minimum touch height).

Even columns keep the row a single line whatever the font scale or the wording these strings come back with from Crowdin — a long translation wraps inside its own button rather than pushing the row over.

Two smaller changes that come with it:

- the first button uses the shorter existing key `lblInstalledApps` ("Installed apps") rather than `lblShowInstalledApps` ("Show installed apps"), so it fits a third of the width;
- the Remote button drops the 🎛 it picked up in #583 — nothing else on this page carries an icon.

## Testing

Not built locally: this machine has only the `tizen` workload, no MAUI/Android one, so the mobile head builds in CI. The XAML parses as well-formed and uses only standard MAUI `Button` properties.