### PR TITLE
Mobile: apply a language change immediately instead of asking for a restart

### DIFF
--- a/Apps2Samsung.Mobile/MauiProgram.cs
+++ b/Apps2Samsung.Mobile/MauiProgram.cs
@@ -93,7 +93,11 @@ public static class MauiProgram
 
 		// Session (holds the Samsung sign-in for the app's lifetime) + the installer page.
 		builder.Services.AddSingleton<SessionState>();
-		builder.Services.AddSingleton<InstallerPage>();
+		// Transient, not a singleton: {l:Localize} resolves while a page is being built, so a cached
+		// installer page would serve the language it was born with for the whole life of the process -
+		// and Android keeps the process alive across closing and reopening the app, so "restart it"
+		// didn't rebuild it either. A language change resolves a fresh one (see SettingsPage).
+		builder.Services.AddTransient<InstallerPage>();
 		// The icon/title editor needs the catalog services injected (shared app list).
 		builder.Services.AddTransient<AppIconsPage>();
 

--- a/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/SettingsPage.xaml.cs
@@ -432,9 +432,23 @@ public partial class SettingsPage : ContentPage
 
 		L10n.SetLanguage(code);
 
-		// {l:Localize} resolves when a page is built, so pages already on the stack keep the old
-		// language until the app is reopened. Say that rather than leaving a half-translated UI.
-		await DisplayAlert(L10n.Get("lblLanguage"), L10n.Get("hintLanguage"), L10n.Get("btn_Close"));
+		// {l:Localize} resolves while a page is being built, so every page already on the stack - this
+		// one and the installer page under it - still holds the old language. Asking the user to
+		// restart didn't help: Android keeps the process alive when the app is closed and reopened, so
+		// the same page objects came back. Rebuild the stack instead, and land the user back on this
+		// page so they can see the switch took.
+
+		// Let the picker finish closing before the tree it lives in is swapped out from under it.
+		await Task.Yield();
+
+		var services = IPlatformApplication.Current!.Services;
+		var window = Application.Current?.Windows.FirstOrDefault();
+		if (window is null)
+			return;
+
+		var root = new NavigationPage(services.GetRequiredService<InstallerPage>());
+		window.Page = root;
+		await root.Navigation.PushAsync(new SettingsPage(), animated: false);
 	}
 }
 

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -295,7 +295,7 @@
   "hintCommunityThemes": "Themes from github.com/kingchenc/JellyThemes - selecting one replaces the CSS with its @import.",
   "hintBetaUpdates": "When on, the in-app update check offers new beta versions and downloads them. Turn off to only be notified about stable releases.",
   "hintMdnsAddress": "⚠️ .local (mDNS) addresses are often unreliable on Samsung TVs. Prefer the server's IP address if you can.",
-  "hintLanguage": "The app's language. Restart the app after changing it so every screen picks up the new language.",
+  "hintLanguage": "The app's language. Every screen switches over straight away. Strings a translator hasn't reached yet stay in English.",
   "statusCatalogUnavailable": "Couldn't load the app list - you can still install a custom .wgt.",
   "statusCatalogEmpty": "No apps loaded (offline or GitHub rate-limited). Add a token in Settings, or install a custom .wgt.",
   "statusCatalogPartial": "Ready - but {0} of {1} app sources failed (likely GitHub rate limit). Add a GitHub token in Settings.",


### PR DESCRIPTION
Switching language in the Android app and reopening it left the app in the old language. There are two causes, and only one of them is a bug in this repo.

## The bug: the main screen never rebuilt

`InstallerPage` was registered `AddSingleton`. `{l:Localize}` resolves while a page is being built, so that single instance served the language it was born with for the whole life of the process — and Android keeps the process alive when the app is closed and reopened, so "restart the app" didn't rebuild it either. Every other page is `new`'d per navigation, so those *did* switch, which is why the app looked half-translated rather than untouched.

`InstallerPage` is transient now, and picking a language rebuilds the window's root page and re-pushes a fresh Settings page. The switch is visible straight away, and the "restart the app" alert is gone — `hintLanguage` now says the change is immediate and that strings a translator hasn't reached yet stay in English (only `en` had that key, so no translation is lost).

## The rest of it: there is almost nothing to switch to

| | keys |
|---|---|
| `en.json` at the last Crowdin sync (04c9770, 2026-06-01) | 161 |
| `en.json` today | 412 |
| every other language | 158–170 |

The 251 strings added since — the whole mobile string set from #585/#586, the Remote page, the install guards — have never been offered to a translator. Of the 164 keys the mobile head displays, **27 have a Dutch translation**; on the installer page it is 4 of 12. So even with the bug above fixed, switching to Dutch changes four labels until translations land.

`origin/l10n_beta` has had no commit since 2026-06-01, so the Crowdin GitHub integration that used to push there stopped delivering — the org rename to `Apps2Samsung/Apps2Samsung` is the likely reason it came loose. That is being reconnected on the Crowdin side, so nothing in this repo changes for it.

## Testing

Not built locally: this machine has only the `tizen` workload, no MAUI/Android one, so the mobile head builds in CI.
