### PR TITLE
CI: let the Crowdin sync open its pull request

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -68,6 +68,10 @@ jobs:
             Translations downloaded from Crowdin. Merging updates the language files both heads embed.
           commit_message: 'i18n: new translations from Crowdin'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The default GITHUB_TOKEN pushes the branch fine but cannot open the pull request -
+          # "GitHub Actions is not permitted to create or approve pull requests" is an account-level
+          # setting, not something a workflow permission can grant. Use the same admin PAT the F-Droid
+          # and version-table workflows push with. See fdroid/README.md for when it has to be renewed.
+          GITHUB_TOKEN: ${{ secrets.CI_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}


### PR DESCRIPTION
The workflow added in #596 ran on merge and did its job — sources uploaded, translations came back, `l10n_beta` pushed — then failed on the last step:

```
FAILED TO CREATE PULL REQUEST
"message": "GitHub Actions is not permitted to create or approve pull requests.", "status": 403
```

That is an account-level setting, not something `permissions:` in a workflow can grant. Rather than flip it for every workflow in the org, this uses `CI_PUSH_TOKEN` — the same admin PAT the F-Droid publish and version-table workflows already push with — falling back to `GITHUB_TOKEN` if it is ever unset.

Done outside the repo at the same time: the current translation files were uploaded to Crowdin, so its state matches `beta`. Without that, every sync would try to revert the nine hand-written Dutch strings #596 deliberately kept.
