### PR TITLE
i18n: stop the sync writing English over half the language files

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,9 +6,15 @@
 # last silently overwrote the other. The variant that already owns the file keeps it (pt.json is
 # Brazilian, zh.json is Traditional - those are the ones with translations in them), and the other
 # gets a file of its own.
+#
+# skip_untranslated_strings keeps a language file to what has actually been translated. Without it
+# every untranslated key is written out with its English text, which reads as a finished translation
+# in the file and in the picker, hides how much is really left, and buys nothing: the catalog already
+# falls back to English for a key a file doesn't carry.
 files:
   - source: /Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
     translation: /Jellyfin2Samsung-CrossOS/Assets/Localization/%two_letters_code%.json
+    skip_untranslated_strings: true
     languages_mapping:
       two_letters_code:
         pt-PT: pt-PT


### PR DESCRIPTION
The first successful Crowdin sync (#598) opened a PR that wanted two things it shouldn't. This fixes both.

## It rewrote the source file

`en.json` came back with `alreadyInstalled` replaced by an old English *translation* of itself:

```
- "{0} is already installed and your TV doesn't allow replacing or removing it remotely…"
+ "Jellyfin couldn't not be installed because its already installed, please remove it first…"
```

That loses the `{0}` the app formats the app name into, and reverts the string to a version that hardcodes Jellyfin. Cause: **English was configured as a target language as well as the source language**, so downloading translations wrote a translated `en.json` over the source. English has been removed as a target language in the project — that part is Crowdin-side, nothing in the repo could have prevented it.

## It filled 9 languages with English

The same PR added 2265 keys to languages that have no such translations. Without `skip_untranslated_strings`, every untranslated key is exported carrying its English text — so `af`, `ca`, `he`, `hu`, `ko`, `sr`, `tr`, `vi` and `zh-TW` would look complete in the file and in the language picker while nothing had actually been translated.

It also buys nothing: `LocalizationCatalog` already falls back to English for any key a language file doesn't carry. `skip_untranslated_strings: true` keeps each file to what has genuinely been translated.

## After this merges

Re-run **Crowdin sync**; the next PR it opens should touch only real translations. #598 should be closed rather than merged.
