### PR TITLE
CI: tell the Crowdin sync which branch the strings live on

### DIFF
--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -57,6 +57,11 @@ jobs:
         if: steps.creds.outputs.configured == 'true'
         uses: crowdin/github-action@v2
         with:
+          # The strings live under Crowdin's own "beta" branch (its file is /beta/...en.json), while
+          # crowdin.yml addresses the repo root. Without naming the branch the CLI compares the two
+          # and drops what doesn't line up - "Downloaded translations don't match the current project
+          # configuration ... will be omitted".
+          crowdin_branch_name: beta
           upload_sources: true
           upload_translations: false
           download_translations: true


### PR DESCRIPTION
Every sync so far has ended on this warning, even the green ones:

```
⚠️ Downloaded translations don't match the current project configuration.
   The translations for the following sources will be omitted
```

The project keeps its strings under a Crowdin *branch* named `beta`, so the source file is `/beta/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json`, while `crowdin.yml` addresses the repo root. The workflow never told the CLI which branch it was working on, so the two paths didn't line up and the CLI dropped what it couldn't match — quietly, while still exiting 0.

`crowdin_branch_name: beta` lines them up.

Nothing is visibly broken today because the repo and Crowdin are in agreement (the last two syncs ended in `NOTHING TO COMMIT`), but the omissions are exactly where the newly split `pt-PT.json` and `zh-CN.json` would go missing once translations start moving again.
