### PR TITLE
i18n: start in the right Chinese and the right Portuguese

### DIFF
--- a/Apps2Samsung.Core/Localization/LocalizationCatalog.cs
+++ b/Apps2Samsung.Core/Localization/LocalizationCatalog.cs
@@ -88,11 +88,45 @@ namespace Apps2Samsung.Localization
         /// </summary>
         public string ResolveInitialLanguage(string? storedLanguage)
         {
-            if (!string.IsNullOrWhiteSpace(storedLanguage) && HasLanguage(storedLanguage!))
-                return storedLanguage!;
+            return Match(storedLanguage)
+                ?? Match(CultureInfo.CurrentUICulture.Name)
+                ?? DefaultLanguage;
+        }
 
-            var systemLanguage = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
-            return HasLanguage(systemLanguage) ? systemLanguage : DefaultLanguage;
+        /// <summary>
+        /// The closest language we have to <paramref name="code"/>, or null. A regional file wins over
+        /// the plain language file when the OS asks for that region, which is what keeps the two
+        /// Chinese and the two Portuguese apart: zh.json is Traditional and pt.json is Brazilian (they
+        /// were translated first and kept the plain name), so a Simplified-Chinese or European
+        /// Portuguese device has to land on zh-CN.json / pt-PT.json rather than on the file whose name
+        /// merely starts with its language. Falls back the way a locale narrows: zh-Hans-CN, then
+        /// zh-Hans, then zh - and where the OS names only the script, to the region that writes it.
+        /// </summary>
+        private string? Match(string? code)
+        {
+            if (string.IsNullOrWhiteSpace(code))
+                return null;
+
+            code = code!.Replace('_', '-').Trim();
+
+            if (HasLanguage(code))
+                return code;
+
+            // Android and Windows can report a script without a region ("zh-Hans"), which names no
+            // file of ours; point the two scripts at the file that carries them.
+            if (code.Contains("Hans", StringComparison.OrdinalIgnoreCase) && HasLanguage("zh-CN"))
+                return "zh-CN";
+            if (code.Contains("Hant", StringComparison.OrdinalIgnoreCase) && HasLanguage("zh"))
+                return "zh";
+
+            for (var cut = code.LastIndexOf('-'); cut > 0; cut = code.LastIndexOf('-', cut - 1))
+            {
+                var shorter = code[..cut];
+                if (HasLanguage(shorter))
+                    return shorter;
+            }
+
+            return null;
         }
 
         private void LoadEmbeddedLanguages()


### PR DESCRIPTION
Follow-up to #596, which gave `pt-PT` and `zh-CN` their own files for the first time.

Detection only ever asked for the two-letter code:

```csharp
var systemLanguage = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
return HasLanguage(systemLanguage) ? systemLanguage : DefaultLanguage;
```

That was fine while every language had exactly one file. It isn't any more: `zh.json` is Traditional and `pt.json` is Brazilian — they were translated first and kept the plain name — so a Simplified-Chinese phone started up in **Traditional**, and a Portuguese one in **Brazilian Portuguese**. Both variants are in the picker, so it was correctable by hand, but the automatic guess was wrong.

Now the OS locale is matched whole first (`zh-CN` → `zh-CN.json`, `pt-PT` → `pt-PT.json`), then narrowed the way a locale narrows — `zh-Hans-CN` → `zh-Hans` → `zh` — and where the OS names a script without a region (`zh-Hans`, which matches no file of ours), the script picks the file that carries it. A stored choice goes through the same matching, so a code saved before those files existed still resolves rather than silently falling back to the OS.

Both heads share this resolver, so the desktop app gets it too.

| device locale | before | after |
|---|---|---|
| `zh-CN` | `zh.json` (Traditional) | `zh-CN.json` |
| `zh-Hans-CN` | `zh.json` (Traditional) | `zh-CN.json` |
| `zh-TW` | `zh.json` (Traditional) | unchanged |
| `pt-PT` | `pt.json` (Brazilian) | `pt-PT.json` |
| `pt-BR` | `pt.json` (Brazilian) | unchanged |
| `de-DE`, `nl-NL`, … | two-letter file | unchanged |
