### PR TITLE
CI: don't cut a beta release for a translation-sync config change

### DIFF
--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -8,6 +8,8 @@ on:
       - 'docs/**'      # website (GitHub Pages) — deploys on its own, shouldn't trigger an app release
       - '.github/**'   # workflow / repo-meta changes shouldn't trigger an app release
       - 'fastlane/**'  # store-listing metadata (F-Droid/IzzyOnDroid) — not app code
+      - 'crowdin.yml'  # translation sync config — changing it ships nothing, but the build it fired
+                       # overwrote the curated release notes, which then had to be re-applied
   # Allow running the beta release manually (e.g. when a merge didn't fire the push trigger).
   workflow_dispatch:
 


### PR DESCRIPTION
`crowdin.yml` wasn't in the beta workflow's `paths-ignore`, so #599 — a two-line change to how the sync exports files — fired a full release build. That republished the tag, rebuilt every asset, and overwrote the curated release notes, which then had to be re-applied by hand.

Changing how translations are exported ships nothing, so it joins `.github/**` and `fastlane/**` in the ignore list. Actual translation *content* still lives under `Jellyfin2Samsung-CrossOS/Assets/Localization/` and still triggers a build, which is what you want.