### PR TITLE
Popup for the "Object reference" error: Samsung account has no email address

### DIFF
--- a/Apps2Samsung.Core/Certificate/CertificateProvisioningService.cs
+++ b/Apps2Samsung.Core/Certificate/CertificateProvisioningService.cs
@@ -114,6 +114,13 @@ namespace Apps2Samsung.Certificate
             if (string.IsNullOrEmpty(auth.access_token))
                 throw new InvalidOperationException("Failed to authenticate with the Samsung account.");
 
+            // The distributor CSR puts this address in the subject's emailAddress field. A Samsung
+            // account without one hands us null, which blows up inside BouncyCastle's X509Name as a
+            // bare "Object reference not set to an instance of an object" (issue #606) — so stop here
+            // and let the head tell the user to add and verify an address.
+            if (string.IsNullOrWhiteSpace(auth.inputEmailID))
+                throw new SamsungAccountEmailMissingException();
+
             var duids = BuildDistributorDuids(deviceDuid, manual, covered);
 
             string authorP12, distributorP12, password;

--- a/Apps2Samsung.Core/Certificate/SamsungAccountEmailMissingException.cs
+++ b/Apps2Samsung.Core/Certificate/SamsungAccountEmailMissingException.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Apps2Samsung.Certificate
+{
+    /// <summary>
+    /// Thrown when the Samsung account that just signed in has no email address on it, so there is
+    /// nothing to put in the distributor certificate's <c>emailAddress</c> subject field.
+    /// <para>
+    /// Without this guard the null email reaches BouncyCastle's <c>X509Name</c> while building the
+    /// distributor CSR and the user is shown a bare
+    /// "Object reference not set to an instance of an object" — see issue #606. Heads catch this and
+    /// point the user at <see cref="AccountUrl"/> to add and verify an address.
+    /// </para>
+    /// </summary>
+    public sealed class SamsungAccountEmailMissingException : Exception
+    {
+        /// <summary>Where the user adds/verifies the email on their Samsung account.</summary>
+        public const string AccountUrl = "https://account.samsung.com";
+
+        public SamsungAccountEmailMissingException()
+            : base("The Samsung account has no email address, which the distributor certificate requires.")
+        {
+        }
+    }
+}

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -467,6 +467,24 @@ public partial class InstallerPage : ContentPage
 		{
 			SetStatus(L10n.Get("statusSignInCancelled"));
 		}
+		catch (SamsungAccountEmailMissingException)
+		{
+			// The Samsung account has no email, so the distributor CSR has nothing to put in its
+			// emailAddress field — this used to surface as a bare NullReferenceException (issue #606).
+			// Only the user can fix it, on their Samsung account page, so offer to open it.
+			SetStatus(L10n.Get("statusSamsungAccountNoEmail"));
+			var openAccount = await DisplayAlert(
+				L10n.Get("lblSamsungAccountNoEmailTitle"),
+				L10n.Get("statusSamsungAccountNoEmail"),
+				L10n.Get("lblOpenSamsungAccount"),
+				L10n.Get("btn_Close"));
+
+			if (openAccount)
+			{
+				try { await Launcher.Default.OpenAsync(SamsungAccountEmailMissingException.AccountUrl); }
+				catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"[installer] Couldn't open the Samsung account page: {ex.Message}"); }
+			}
+		}
 		catch (Exception ex)
 		{
 			System.Diagnostics.Trace.WriteLine($"[installer] Install failed: {ex}");

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -410,5 +410,8 @@
   "statusSignedInTo": "Signed in to {0} - auto-login will be baked into the package.",
   "statusExportBackupFailed": "Couldn't export the backup: {0}",
   "statusImportedMobile": "Imported settings + {0} certificate file(s). Certificates are already restored. Restart the app to fully apply the imported settings.",
-  "statusImportBackupFailed": "Couldn't import the backup: {0}"
+  "statusImportBackupFailed": "Couldn't import the backup: {0}",
+  "lblSamsungAccountNoEmailTitle": "Samsung account has no email address",
+  "statusSamsungAccountNoEmail": "Your Samsung account doesn't have an email address on it, and the signing certificate can't be created without one. Open account.samsung.com, add and verify an email address, then try again.",
+  "lblOpenSamsungAccount": "Open Samsung account"
 }

--- a/Jellyfin2Samsung-CrossOS/Interfaces/IDialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Interfaces/IDialogService.cs
@@ -12,6 +12,13 @@ namespace Apps2Samsung.Interfaces
         Task<bool> ShowConfirmationAsync(string title, string message, string? yes = null, string? no = null, Window? owner = null);
         Task<string?> PromptForIpAsync();
 
+        /// <summary>
+        /// A message dialog whose primary button opens <paramref name="url"/> in the system browser
+        /// before closing. Used where the fix lives on a web page the user has to visit (e.g. adding
+        /// a missing email to their Samsung account).
+        /// </summary>
+        Task ShowMessageWithLinkAsync(string title, string message, string linkText, string url, string? closeText = null);
+
         /// <summary>Prompts for a free-form line of text. Returns the entered text, or null if cancelled.</summary>
         Task<string?> PromptForTextAsync(string title, string message, string placeholder);
 

--- a/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/DialogService.cs
@@ -405,6 +405,59 @@ namespace Apps2Samsung.Services
             return await tcs.Task;
         }
 
+        public async Task ShowMessageWithLinkAsync(string title, string message, string linkText, string url, string? closeText = null)
+        {
+            var window = GetMainWindow();
+            if (window == null)
+                return;
+
+            var isDarkMode = AppSettings.Default.DarkMode;
+            var foregroundBrush = GetThemeBrush("SystemControlForegroundBaseHighBrush", isDarkMode);
+
+            var tcs = new TaskCompletionSource<bool>();
+            var dialog = CreateStyledDialog(
+                title,
+                new TextBlock
+                {
+                    Text = message,
+                    TextWrapping = TextWrapping.Wrap,
+                    Foreground = foregroundBrush,
+                    FontSize = 14,
+                    Margin = new Thickness(0, 5, 0, 0)
+                },
+                showButtons: true,
+                tcs: tcs,
+                yesText: linkText,
+                noText: closeText ?? "btn_Close".Localized(),
+                // The link label is a sentence, not a "Yes" — let the button grow to fit it.
+                onButtonsCreated: (yes, no) =>
+                {
+                    yes.Width = double.NaN;
+                    yes.MinWidth = 90;
+                    yes.Padding = new Thickness(14, 0);
+                    no.Width = double.NaN;
+                    no.MinWidth = 90;
+                    no.Padding = new Thickness(14, 0);
+                });
+
+            // Closing via the window chrome never resolves the TCS on its own.
+            dialog.Closed += (_, _) => tcs.TrySetResult(false);
+
+            await dialog.ShowDialog(window);
+
+            if (await tcs.Task)
+            {
+                try
+                {
+                    Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine($"Failed to open URL '{url}': {ex}");
+                }
+            }
+        }
+
         public async Task<string?> PromptForIpAsync()
         {
             var window = GetMainWindow();

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -547,6 +547,24 @@ namespace Apps2Samsung.Services
                         P12Password = profile.Password
                     };
                 }
+                catch (SamsungAccountEmailMissingException)
+                {
+                    // Core's guard for a Samsung account with no email on it, which the distributor
+                    // CSR needs for its subject. Left to the generic handler below it would come out
+                    // as a bare error dialog, so show the account page instead (issue #606).
+                    Trace.WriteLine("[Cert] Samsung account has no email address; can't build the distributor CSR.");
+                    await _dialogService.ShowMessageWithLinkAsync(
+                        "lblSamsungAccountNoEmailTitle".Localized(),
+                        "statusSamsungAccountNoEmail".Localized(),
+                        "lblOpenSamsungAccount".Localized(),
+                        SamsungAccountEmailMissingException.AccountUrl);
+
+                    return new CertificateResult
+                    {
+                        Success = false,
+                        InstallResult = InstallResult.FailureResult("statusSamsungAccountNoEmail".Localized())
+                    };
+                }
                 catch (Exception ex)
                 {
                     Trace.WriteLine($"[Cert] Provisioning failed: {ex.Message}");
@@ -599,6 +617,25 @@ namespace Apps2Samsung.Services
                     {
                         Success = false,
                         InstallResult = InstallResult.FailureResult("statusAuthFailed".Localized())
+                    };
+                }
+
+                // The distributor CSR needs the account's email for its subject. Samsung accounts
+                // without one hand us null, which used to surface as a bare "Object reference not set
+                // to an instance of an object" from inside BouncyCastle (issue #606). Point the user
+                // straight at their account page instead.
+                if (string.IsNullOrWhiteSpace(auth.inputEmailID))
+                {
+                    await _dialogService.ShowMessageWithLinkAsync(
+                        "lblSamsungAccountNoEmailTitle".Localized(),
+                        "statusSamsungAccountNoEmail".Localized(),
+                        "lblOpenSamsungAccount".Localized(),
+                        SamsungAccountEmailMissingException.AccountUrl);
+
+                    return new CertificateResult
+                    {
+                        Success = false,
+                        InstallResult = InstallResult.FailureResult("statusSamsungAccountNoEmail".Localized())
                     };
                 }
 


### PR DESCRIPTION
Closes #606.

## Why it happens

A Samsung account with no email address on it makes the OAuth callback return a null `inputEmailID`. That value goes straight into the **distributor** CSR's subject as the `emailAddress` field:

`Apps2Samsung.Core/Certificate/TizenCertificateService.cs` — `GenerateDistributorCsr()`

```csharp
var subject = new X509Name(
    new ArrayList { X509Name.CN, ..., X509Name.EmailAddress },
    new ArrayList { "TizenSDK", "", "", "", "", "", userEmail });
```

BouncyCastle's `X509Name` dereferences that null while encoding, so the user is shown a bare **"Object reference not set to an instance of an object"** with no hint at all about what to fix. Nothing between the login and the CSR checked the field — only `access_token` was guarded.

It only fires on a path that actually logs in, which is why users with a cached, still-valid profile never see it.

## What this changes

Guard it at the login boundary and tell the user what to do, with a button that takes them there.

**Core** — `SamsungAccountEmailMissingException` (carries the `account.samsung.com` URL), thrown by `CertificateProvisioningService.EnsureAsync` right after the existing access-token check, so both heads inherit the same guard.

**Desktop** — new `IDialogService.ShowMessageWithLinkAsync(title, message, linkText, url)`: the app's own styled dialog with a primary button that opens the URL in the system browser. Both cert paths in `HandleCertificateAsync` are wired up:
- the **auto** path, which provisions through Core — its generic `catch (Exception)` would otherwise flatten the guard back into a plain error dialog;
- the **legacy** path (bundled Jellyfin cert / user-imported cert), which does its own login, so it checks `inputEmailID` inline next to the existing `access_token` check.

**Mobile** — `InstallerPage` catches the exception ahead of the generic handler and offers the same choice via `DisplayAlert` + `Launcher`.

## Message

> **Samsung account has no email address**
>
> Your Samsung account doesn't have an email address on it, and the signing certificate can't be created without one. Open account.samsung.com, add and verify an email address, then try again.
>
> [ Open Samsung account ]  [ Close ]

## Testing

- `dotnet build Jellyfin2Samsung-CrossOS/Apps2Samsung.csproj -c Release` — clean (Core comes along as a project reference); no new warnings.
- `.github/scripts/check_localization.py` passes — the three new keys are in `en.json` for Crowdin to pick up.
- The Android head is compiled by the PR build job here.