### PR TITLE
i18n: fail a translation that drops a placeholder, and let a sync push repo fixes up

### DIFF
--- a/.github/scripts/check_localization.py
+++ b/.github/scripts/check_localization.py
@@ -2,7 +2,7 @@
 """
 Localization guard for both heads.
 
-Two checks, both hard failures, so the base translation file (en.json) stays 1:1 with the
+Four checks, all hard failures, so the base translation file (en.json) stays 1:1 with the
 code and Crowdin always has every user-facing string to translate (issue #560):
 
   A. Every localization KEY referenced in code exists in en.json.
@@ -17,6 +17,12 @@ code and Crowdin always has every user-facing string to translate (issue #560):
      and localize internally) or come from a lookup ("key".Localized() / L10n.Get("key")).
      Interpolated strings are read as their literal parts, so $"{L("k")}: {ex}" is fine while
      $"Failed to open: {ex}" is not.
+  D. Every translation carries the same {0}/{1} placeholders its English source does. A
+     translation that drops one leaves string.Format with nothing to substitute, so the message
+     names the wrong app (or the wrong number, or the wrong path) in that language — and one that
+     invents an index en.json doesn't have throws FormatException at runtime. This is what a
+     Crowdin sync writing an older revision back over a fix looks like (PR #610), and without
+     this check it merges green.
 
 Both heads are checked: the desktop head (Avalonia) and the mobile head (MAUI), which shares
 the same en.json now that the string catalog lives in Core.
@@ -30,7 +36,8 @@ from pathlib import Path
 
 DESKTOP = Path("Jellyfin2Samsung-CrossOS")
 MOBILE = Path("Apps2Samsung.Mobile")
-EN = DESKTOP / "Assets" / "Localization" / "en.json"
+LOCALIZATION = DESKTOP / "Assets" / "Localization"
+EN = LOCALIZATION / "en.json"
 
 # Strings that are intentionally NOT translated: example token / URL / CSS samples, and the
 # product names themselves.
@@ -67,6 +74,9 @@ CS_SINK_CALL = re.compile(
     r'|ShowConfirmationAsync|PromptForTextAsync|ShowCertificateCountdownAsync|FailureResult)\s*\(')
 CS_SINK_ASSIGN = re.compile(r'\b(?:StatusText|Status)\s*=\s*(?=[$@"])')
 WORDS = re.compile(r"[A-Za-z]{3,}")
+
+# string.Format placeholders. `{{` is a literal brace and is stripped before matching.
+PLACEHOLDER = re.compile(r"\{(\d+)\}")
 
 
 def read_string(text, i):
@@ -171,8 +181,20 @@ def markup_files():
     yield from source_files(".xaml", roots=(MOBILE,))
 
 
+def listed(indexes):
+    return ", ".join("{%s}" % i for i in sorted(indexes, key=int))
+
+
+def placeholders(text):
+    """The set of {N} indexes a string substitutes. A set rather than a list: a translation may
+    naturally repeat a placeholder more or fewer times than English does ("{0} … {0}" reads badly
+    in some languages), which is fine — dropping or inventing an index is not."""
+    return set(PLACEHOLDER.findall(text.replace("{{", "").replace("}}", "")))
+
+
 def main():
-    keys = set(json.loads(EN.read_text(encoding="utf-8")).keys())
+    english = json.loads(EN.read_text(encoding="utf-8"))
+    keys = set(english.keys())
     errors = []
 
     # A. referenced keys must exist. Each head has its own accessor, and they are checked
@@ -226,11 +248,32 @@ def main():
                         f"[hardcoded-cs] {f}:{line}: {match.group(0).strip()} \"{literal}\" "
                         f"— pass a key instead (\"key\".Localized() / L10n.Get(\"key\"))")
 
+    # D. every translation substitutes the same placeholders as its English source
+    for f in sorted(LOCALIZATION.glob("*.json")):
+        if f == EN:
+            continue
+        translations = json.loads(f.read_text(encoding="utf-8"))
+        for k, translated in translations.items():
+            source = english.get(k)
+            if not isinstance(source, str) or not isinstance(translated, str):
+                continue                       # a key en.json no longer has is simply unused
+            want, got = placeholders(source), placeholders(translated)
+            if want == got:
+                continue
+            problems = []
+            if want - got:
+                problems.append("drops " + listed(want - got))
+            if got - want:
+                problems.append("adds " + listed(got - want))
+            errors.append(
+                f"[placeholder] {f}: \"{k}\" {' and '.join(problems)} — en.json substitutes "
+                f"{listed(want) if want else 'nothing'}")
+
     if errors:
         print("Localization check FAILED (%d issue(s)):\n" % len(errors) + "\n".join(sorted(errors)))
         return 1
-    print("Localization check passed — every key exists in en.json and no hard-coded UI strings "
-          "(desktop + mobile).")
+    print("Localization check passed — every key exists in en.json, no hard-coded UI strings "
+          "(desktop + mobile), and every translation keeps its placeholders.")
     return 0
 
 

--- a/.github/workflows/check-localization.yml
+++ b/.github/workflows/check-localization.yml
@@ -13,7 +13,8 @@ on:
     paths:
       - 'Jellyfin2Samsung-CrossOS/**/*.cs'
       - 'Jellyfin2Samsung-CrossOS/**/*.axaml'
-      - 'Jellyfin2Samsung-CrossOS/Assets/Localization/en.json'
+      # Every language file, not just en.json: check D compares the translations against it.
+      - 'Jellyfin2Samsung-CrossOS/Assets/Localization/*.json'
 
 jobs:
   check-localization:

--- a/.github/workflows/crowdin-sync.yml
+++ b/.github/workflows/crowdin-sync.yml
@@ -25,6 +25,18 @@ on:
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
+    inputs:
+      upload_translations:
+        description: >-
+          Push the repo's language files UP to Crowdin before downloading. Off by default, and it
+          must stay off for the scheduled and push runs: Crowdin owns the translations, the repo is
+          downstream of it, and a download PR can sit open for days - during which the repo files
+          are OLDER than Crowdin's. Uploading on every run would eventually write that stale copy
+          over a translator's fresh edit, silently, inside Crowdin. Turn it on by hand for the one
+          case it is for: strings fixed directly in the repo that Crowdin still holds an earlier
+          revision of, which it otherwise keeps handing back (see PR #610).
+        type: boolean
+        default: false
 
 concurrency:
   group: crowdin-sync
@@ -63,7 +75,8 @@ jobs:
           # configuration ... will be omitted".
           crowdin_branch_name: beta
           upload_sources: true
-          upload_translations: false
+          # Only ever true for a deliberate workflow_dispatch; `inputs` is null on schedule/push.
+          upload_translations: ${{ inputs.upload_translations || false }}
           download_translations: true
           localization_branch_name: l10n_beta
           create_pull_request: true


### PR DESCRIPTION
Fixes the two gaps [#610](https://github.com/Apps2Samsung/Apps2Samsung/pull/610) walked through together.

## The guard never looked at a translation

`check_localization.py` compared code to `en.json` and stopped there. So #610 rewrote `alreadyInstalled` in 27 languages back to the revision that predates #603 — hardcoded `Jellyfin` instead of `{0}`, English text sitting in `af`/`ar`/`ca`/`el`/`es`, typo and all — with all four required checks green.

Check **D** compares the `{N}` placeholders in every language file against their English source. A translation that drops one leaves `string.Format` with nothing to substitute, so the message names the wrong app for anyone installing something other than Jellyfin; one that invents an index en.json doesn't have throws `FormatException` at runtime.

Run against #610's diff:

```
Localization check FAILED (27 issue(s)):
[placeholder] …/af.json: "alreadyInstalled" drops {0} — en.json substitutes {0}
[placeholder] …/ar.json: "alreadyInstalled" drops {0} — en.json substitutes {0}
…
```

`beta` itself is clean: 415 keys, 48 of them with placeholders, 29 languages, zero mismatches. It compares *sets* of indexes, not counts — a translation may naturally repeat `{0}` more or fewer times than English does; dropping or inventing one is the bug.

The push filter on the workflow now covers every `Localization/*.json`, not just `en.json`, since D reads them all. The `pull_request` trigger stays unfiltered — it is a required check, and a filtered-out check is never reported.

## The sync had no way to correct Crowdin

`upload_translations` was hardcoded `false`, so anything fixed by hand in the repo never reached Crowdin — which keeps handing the older revision back on every run. #610 is that, and closing it changes nothing: the next `en.json` push regenerates the identical PR.

`workflow_dispatch` now takes an `upload_translations` input, default `false`. It stays `false` for the scheduled and push runs deliberately: Crowdin owns the translations, the repo is downstream, and a download PR can sit open for days — during which the repo files are *older* than Crowdin's. Uploading on every run would eventually write that stale copy over a translator's fresh edit, silently, inside Crowdin. That is the same bug pointed the other way and much harder to notice.

## After this merges

1. Run the sync once from the Actions tab with `upload_translations` ticked — that puts #603's `alreadyInstalled` into Crowdin.
2. Run it again normally. The action updates `l10n_beta` in place, so #610's diff should collapse to nothing.
3. If it doesn't, the existing Crowdin translation is approved and outranks the import, and those need fixing in the UI.

Don't merge #610 before that — step 2 is the verification.