### PR TITLE
i18n: an unapproved translation that already matches is not a change

### DIFF
--- a/.github/scripts/crowdin_fix_string.py
+++ b/.github/scripts/crowdin_fix_string.py
@@ -121,9 +121,13 @@ def main():
                            stringId=string_id, languageId=language["id"])
         approvals = listing(f"/projects/{PROJECT}/approvals",
                             stringId=string_id, languageId=language["id"])
-        if len(existing) == 1 and existing[0]["text"] == wanted and approvals:
+        # An approval is not required for Crowdin to export a string - export_only_approved is
+        # off, so the single stored translation is the one that ships. Text match is the test;
+        # demanding an approval too would report every language as needing a rewrite it doesn't.
+        if len(existing) == 1 and existing[0]["text"] == wanted:
             skipped += 1
-            print(f"{language['id']:>6}  ✓ already correct and approved")
+            state = "approved" if approvals else "unapproved, which still exports"
+            print(f"{language['id']:>6}  ✓ already matches the repo ({state})")
             continue
 
         current = existing[0]["text"] if existing else "(none)"


### PR DESCRIPTION
Fixes a wrong condition in the script #613 added, found by its first real dry run against the project.

`crowdin_fix_string.py` counted a language as already correct only when its translation was equal to the repo's **and** approved. The project has no approvals at all, so [the dry run](https://github.com/Apps2Samsung/Apps2Samsung/actions/runs/33369543185) reported all 29 languages as needing a rewrite while printing before/after strings that were plainly identical.

`export_only_approved` is off, so the single stored translation is the one that ships whether or not it carries a tick. Text match is the test; the approval state is reported alongside, not required:

```
    nl  ✓ already matches the repo (unapproved, which still exports)
```

This also matters for what the run revealed: #612's upload **did** land, and Crowdin already emits the corrected `alreadyInstalled`. The `NOTHING TO COMMIT` on both sync runs since means the download matches `beta` exactly — the action downloads into a tree checked out at `beta`, so a matching download leaves nothing to carry over to `l10n_beta`. #610 is a stale branch that can no longer update itself, and a future genuine change would commit on top of its revert. Closing it and dropping the branch is the follow-up; the action recreates it from `beta` when there is something real to bring down.