### PR TITLE
i18n: one source file in Crowdin, and refuse to guess which

### DIFF
--- a/.github/scripts/crowdin_apply_config.py
+++ b/.github/scripts/crowdin_apply_config.py
@@ -14,6 +14,12 @@ Naming every file by %locale% removes the collision by construction rather than 
 time, which is why the project's languageMapping goes too: it existed only to patch the two pairs
 that had already collided, and a new language would have needed another entry.
 
+It also removes orphaned source files. Crowdin keeps a file that was uploaded under a different
+path or before the branch existed, and that file keeps exporting: the project held three named
+en.json - the live one and two left from earlier layouts - so every build carried all three and a
+29-language export came back with 56 entries. Whichever the API happens to list first is then a
+coin toss for any tool that looks a file up by name.
+
 Run it after changing the translation pattern in crowdin.yml. Idempotent - it reports "already
 correct" and writes nothing when the two sides agree.
 
@@ -79,14 +85,22 @@ def main():
     pattern = wanted_pattern()
     print(f"{CONFIG} wants: {pattern}")
 
-    branches = [b for b in listing(f"/projects/{PROJECT}/branches") if b["name"] == BRANCH]
-    if not branches:
-        raise SystemExit(f"No '{BRANCH}' branch in the project.")
-    files = [f for f in listing(f"/projects/{PROJECT}/files", branchId=branches[0]["id"])
-             if f["name"] == SOURCE_FILE]
-    if not files:
-        raise SystemExit(f"No '{SOURCE_FILE}' under '{BRANCH}'.")
-    source = files[0]
+    everything = listing(f"/projects/{PROJECT}/files")
+    named = [f for f in everything if f["name"] == SOURCE_FILE]
+    if not named:
+        raise SystemExit(f"No '{SOURCE_FILE}' in the project.")
+
+    # The live file is the one carrying the most strings; an orphan is a snapshot of an older
+    # upload and can only be behind. Ties keep the most recently updated.
+    def freshness(f):
+        return (len(listing(f"/projects/{PROJECT}/strings", fileId=f["id"])), f.get("updatedAt", ""))
+
+    ranked = sorted(named, key=freshness, reverse=True)
+    source, orphans = ranked[0], ranked[1:]
+
+    print(f"Live source: id={source['id']} {source.get('path')}")
+    for f in orphans:
+        print(f"Orphan:      id={f['id']} {f.get('path')} (exports alongside the live file)")
 
     current = (source.get("exportOptions") or {}).get("exportPattern")
     project = call(f"/projects/{PROJECT}")["data"]
@@ -100,6 +114,8 @@ def main():
         changes.append("export pattern")
     if mapping:
         changes.append(f"languageMapping ({len(mapping)} entr(y/ies) to clear)")
+    if orphans:
+        changes.append(f"{len(orphans)} orphaned source file(s) to delete")
     if not changes:
         print("\nAlready correct - nothing to write.")
         return 0
@@ -118,6 +134,9 @@ def main():
         call(f"/projects/{PROJECT}", method="PATCH",
              body=[{"op": "replace", "path": "/languageMapping", "value": {}}])
         print("  languageMapping cleared")
+    for f in orphans:
+        call(f"/projects/{PROJECT}/files/{f['id']}", method="DELETE")
+        print(f"  deleted orphan id={f['id']} {f.get('path')}")
     return 0
 
 

--- a/.github/scripts/crowdin_fix_string.py
+++ b/.github/scripts/crowdin_fix_string.py
@@ -75,6 +75,29 @@ def language_file(language):
     return path if path.exists() else None
 
 
+def source_file(project_files):
+    """The one file crowdin.yml describes, and a hard error when the project holds more than one
+    candidate.
+
+    Crowdin accumulates orphans: a source uploaded under a different path, or before the branch
+    existed, stays in the project and keeps exporting. The project carried three files all named
+    en.json - the live one plus two left from earlier layouts - and every build contained all of
+    them, which is how a 29-language export came back with 56 entries. Picking whichever the API
+    listed first is exactly the bug that hid pt-PT and zh-CN, one level up, so this refuses to
+    guess: delete the orphans (crowdin-config does it) rather than let a script choose.
+    """
+    candidates = [f for f in project_files if f["name"] == SOURCE_FILE]
+    if not candidates:
+        raise SystemExit(f"No '{SOURCE_FILE}' in the project.")
+    if len(candidates) > 1:
+        listed = "\n".join(
+            f"    id={f['id']} branch={f.get('branchId')} path={f.get('path')}" for f in candidates)
+        raise SystemExit(
+            f"{len(candidates)} files named '{SOURCE_FILE}' - refusing to guess which one is "
+            f"live:\n{listed}\n  Run the 'Crowdin config' workflow to remove the orphans.")
+    return candidates[0]
+
+
 def main():
     if not TOKEN or not PROJECT:
         raise SystemExit("CROWDIN_PROJECT_ID / CROWDIN_PERSONAL_TOKEN are not set.")
@@ -91,15 +114,10 @@ def main():
     project = call("GET", f"/projects/{PROJECT}")["data"]
     print(f"Project: {project['name']} (#{PROJECT})")
 
-    branches = [b for b in listing(f"/projects/{PROJECT}/branches") if b["name"] == BRANCH]
-    if not branches:
-        raise SystemExit(f"No '{BRANCH}' branch in the project.")
-    files = [f for f in listing(f"/projects/{PROJECT}/files", branchId=branches[0]["id"])
-             if f["name"] == SOURCE_FILE]
-    if not files:
-        raise SystemExit(f"No '{SOURCE_FILE}' under the '{BRANCH}' branch.")
+    source = source_file(listing(f"/projects/{PROJECT}/files"))
+    print(f"Source of truth: id={source['id']} {source.get('path')}")
 
-    strings = [s for s in listing(f"/projects/{PROJECT}/strings", fileId=files[0]["id"])
+    strings = [s for s in listing(f"/projects/{PROJECT}/strings", fileId=source["id"])
                if s["identifier"] == key]
     if not strings:
         raise SystemExit(f'"{key}" is not in Crowdin - upload the sources first.')

--- a/.github/scripts/crowdin_report.py
+++ b/.github/scripts/crowdin_report.py
@@ -81,6 +81,29 @@ def archive_entries():
         return sorted(i.filename for i in archive.infolist() if not i.is_dir())
 
 
+def source_file(project_files):
+    """The one file crowdin.yml describes, and a hard error when the project holds more than one
+    candidate.
+
+    Crowdin accumulates orphans: a source uploaded under a different path, or before the branch
+    existed, stays in the project and keeps exporting. The project carried three files all named
+    en.json - the live one plus two left from earlier layouts - and every build contained all of
+    them, which is how a 29-language export came back with 56 entries. Picking whichever the API
+    listed first is exactly the bug that hid pt-PT and zh-CN, one level up, so this refuses to
+    guess: delete the orphans (crowdin-config does it) rather than let a script choose.
+    """
+    candidates = [f for f in project_files if f["name"] == SOURCE_FILE]
+    if not candidates:
+        raise SystemExit(f"No '{SOURCE_FILE}' in the project.")
+    if len(candidates) > 1:
+        listed = "\n".join(
+            f"    id={f['id']} branch={f.get('branchId')} path={f.get('path')}" for f in candidates)
+        raise SystemExit(
+            f"{len(candidates)} files named '{SOURCE_FILE}' - refusing to guess which one is "
+            f"live:\n{listed}\n  Run the 'Crowdin config' workflow to remove the orphans.")
+    return candidates[0]
+
+
 def main():
     if not TOKEN or not PROJECT:
         raise SystemExit("CROWDIN_PROJECT_ID / CROWDIN_PERSONAL_TOKEN are not set.")
@@ -89,11 +112,9 @@ def main():
     branches = [b for b in listing(f"/projects/{PROJECT}/branches") if b["name"] == BRANCH]
     if not branches:
         raise SystemExit(f"No '{BRANCH}' branch in the project.")
-    files = [f for f in listing(f"/projects/{PROJECT}/files", branchId=branches[0]["id"])
-             if f["name"] == SOURCE_FILE]
-    if not files:
-        raise SystemExit(f"No '{SOURCE_FILE}' under '{BRANCH}'.")
-    file_id = files[0]["id"]
+    source = source_file(everything)
+    file_id = source["id"]
+    print(f"Source of truth: id={file_id} {source.get('path')}\n")
     global BRANCH_ID
     BRANCH_ID = branches[0]["id"]
 


### PR DESCRIPTION
The project holds **three** files named `en.json`:

| id | path | strings | last updated |
|---|---|---|---|
| 14 | `/beta/en.json` | **415** | 2026-08-30 |
| 11 | `/beta/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json` | 412 | 2026-08-29 |
| 12 | `/en.json` | 412 | 2026-08-29 |

Id 14 is live. The other two are left from earlier layouts, frozen at 412 strings — and Crowdin keeps exporting them, which is why a 29-language build came back with **56 archive entries**, one set per file.

Every script in `.github/scripts/crowdin_*.py` looked its file up by name and took the first match, so which one it read depended on the order the API happened to return. It was reading the live one — but by luck, not by rule. That is the same shape as the bug that hid `pt-PT` and `zh-CN`: a path collision resolved silently by whatever came first.

**So they stop guessing.** More than one candidate is now a hard error naming all of them, rather than a pick:

```
3 files named 'en.json' - refusing to guess which one is live:
    id=11 branch=1 path=/beta/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
    ...
  Run the 'Crowdin config' workflow to remove the orphans.
```

And `crowdin-config` removes them, ranked by string count so the live file is the one that survives. Reported first, deleted only with `apply` on.

After this: dispatch **Crowdin config** with `apply`, then **Crowdin report** — the archive should drop from 56 entries to 29.