### PR TITLE
ci: keep curated release notes in the repo so a rebuild cannot lose them

### DIFF
--- a/.github/release-notes/v2.7.9.md
+++ b/.github/release-notes/v2.7.9.md
@@ -1,0 +1,69 @@
+A big one. The **phone becomes a TV remote**, Linux gets **.rpm and AppImage**, the installer no longer downloads SDB at first launch, and the mobile head is **fully translated** for the first time — as are all 29 languages, two of which had never actually reached the app.
+
+---
+
+### 🚀 New features
+
+**📱 Use your phone (or desktop) as a TV remote**
+A **Remote** page on the Android head, reachable from the installer once a TV is selected: D-pad + OK, Back / Home / Menu / Source, playback, volume, channel, mute, power, and typing straight from the phone keyboard.
+
+It rides a different channel from the installer — Samsung's own `samsung.remote.control` WebSocket API. **No Developer Mode, no debug port**, just a TV that's awake on the same network. So the Remote is offered for *any* selected TV, including one the installer itself can't touch. First connection makes the TV show its "allow this device" prompt. The protocol lives in Core, so the desktop can adopt it later. (#583, closes #544)
+
+**🐧 Linux: .rpm and AppImage, and an app that can live in /opt**
+Fedora gets `.rpm`, everything else gets an AppImage. The formats alone would have shipped broken, because the app used to write **next to its own binary** — the `.wgt` cache and the session log both landed in the install directory, which is root-owned under `/opt` and a read-only mount inside an AppImage. Downloads failed, and bug reports arrived with no log.
+
+There's now one place that answers "where do I put this", per user, on every platform — which also retires the `chmod -R 777` lines the `.deb` workflow itself had labelled "🔥 quick+dirty". (#590, closes #589)
+
+**📦 SDB ships inside the app — installs work offline**
+The desktop used to download the Tizen SDB binary from a releases API on first launch, so a fresh install with GitHub unreachable (outage, rate limit, corporate proxy) had no SDB and nothing to fall back on. Both heads now drive one in-process engine that ships in the app. There is exactly one SDB implementation in the tree. (#580, closes #549 / #547)
+
+**🌍 The Android app is actually translated now**
+The string catalog moved out of the desktop head into Core, so both heads read the same 415 strings (#585) — and then the **30 runtime call sites** followed: every status line and dialog in the installer, installed-apps, Jellyfin-settings and settings pages. Interpolated messages became format strings, so a translator can move the value inside the sentence instead of being stuck with English word order. (#586)
+
+**⚡ Language changes apply immediately**
+Switching language on Android and reopening the app used to leave it in the old language — the main screen was a singleton, so it kept serving the language it was born with, and Android keeps the process alive across a close-and-reopen. Picking a language now rebuilds the screen straight away, and the "restart the app" prompt is gone. (#595)
+
+---
+
+### 🐛 Fixes
+
+**📁 Android: picking a file from Google Drive or OneDrive no longer throws**
+Setting a custom app icon from a cloud source died with a bare `Java.Lang.RuntimeException`. Underneath it was `NetworkOnMainThreadException`: MAUI's picker resolves the picked file on the UI thread, and a provider that has to fetch it over the network trips StrictMode. Files are now read through SAF on a background thread. (#576)
+
+**🔑 A Samsung account with no email address now says so**
+Logging in with an account that has no email on it produced a bare **"Object reference not set to an instance of an object"** with no hint what to fix — the empty field went straight into the certificate request and blew up while encoding. You now get a popup that names the actual problem. It only ever fired on a fresh login, which is why anyone with a cached profile never saw it. (#608, closes #606)
+
+**🇨🇳 Starting in the right Chinese and the right Portuguese**
+A Simplified-Chinese or European-Portuguese device could start in the wrong variant. (#601)
+
+**🐧 Linux packaging fixes**
+The aarch64 `.rpm` was broken, and rpm's own post-processing stripped the app to pieces. Both fixed, `-beta` is kept in asset names, and the PR check now packages both architectures so this can't regress unseen. (#591, #592)
+
+**📱 Android layout**
+The Remote button was clipped, typing on the TV now happens live instead of via a Send button, and the TV shortcuts sit on one line instead of wrapping. (#593, #594)
+
+---
+
+### 🌍 Translations
+
+**Every language is complete — all 415 strings, all 29 languages.**
+
+The sync had quietly stopped in June: `en.json` held 161 strings then and 415 now, so everything added since — the whole mobile string set, the Remote page, the install guards — had never been offered to a translator. Reconnecting it brought **20 languages from 38% to 100%** (#596), and the nine that Crowdin's engine refuses to machine-translate (Afrikaans, Catalan, Hebrew, Hungarian, Korean, Serbian, Turkish, Vietnamese, Traditional Chinese) were translated by hand (#603), with the last 27 strings filled in after (#604).
+
+**Two languages were never actually reaching the app.** Crowdin resolved `pt-BR` and `pt-PT` to the same filename, and `zh-CN` and `zh-TW` likewise — so each build kept one of each pair and silently dropped the other. European Portuguese and Simplified Chinese had never once been updated from a translator's work, while the app deliberately routes those devices onto exactly those files. Every language file is now named by its full locale, so the collision can't happen again — not for these two, and not for the next variant anyone adds. (#617)
+
+The language picker also reads better: it names a region only where one distinguishes something, so most entries are simply `Nederlands`, `Español`, `Српски`, while the pairs read `Português (Brasil)` / `Português (Portugal)` and `中文（中国）` / `中文（台灣）`.
+
+Also fixed: the sync used to write English text into half the language files, which looked like finished translations in the picker and hid how much was really left. (#599)
+
+---
+
+### 🧰 Under the hood
+
+- One `config.xml` reader for both heads, instead of three. (#584)
+- The localization guard now covers C# as well as markup, and fails a build where a translation drops a `{0}` its English source has — the check that would have caught a sync quietly reverting a fix. (#587, #612)
+- Crowdin tooling moved into the repo: a report of what the project actually holds per language, a way to push a single corrected string up, and a config job that keeps Crowdin's export pattern in step with `crowdin.yml`. (#613, #614, #615, #616)
+- Beta builds stamp `-beta` into the version they report, so a beta no longer claims to be the stable release. (#579)
+- F-Droid publishing and the workflows that push to `beta` share one token. (#575, #577)
+- Dependency updates, including Crowdin's action v3. (#581, #588, #611)
+- The landing page and README describe what the app actually does now, and `NOTICE.md` carries third-party attributions. (#605, #607)

--- a/.github/scripts/build_release_notes.py
+++ b/.github/scripts/build_release_notes.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Builds the body of a release from a curated file when there is one, and from GitHub's generated
+notes when there isn't.
+
+Both release workflows used to compose the body inline, from generate-notes alone. That output is
+a flat list of pull request titles, which is fine for a routine build and no substitute for the
+notes a real release gets: what changed, and why anyone should care. Hand-written notes were
+applied to the release afterwards, and the next build of the same version overwrote them - the
+comment at the top of beta-prerelease.yml records that happening.
+
+So the curated notes live in the repo instead, at .github/release-notes/<version>.md, and a build
+prefers them. Rebuild the same version as often as you like; the notes come back. Ship a version
+with no file and the generated list is used, which is the old behaviour and still perfectly good
+for a beta nobody is announcing.
+
+The file holds the middle of the page only - the summary and the sections. The heading, the
+downloads table, the security notice and the full-changelog link are added here so a beta and a
+stable release of the same content stay consistent with each other.
+
+  build_release_notes.py --tag v2.7.9-beta --channel beta --generated CHANGELOG.md
+"""
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CURATED = Path(".github/release-notes")
+
+DOWNLOADS = {
+    "stable": [
+        ("🍎 macOS (.app + dmg)", "✅ Stable", "ARM64 + Intel"),
+        ("🍎 macOS (CLI)", "✅ Stable", "Per-arch tar.gz"),
+        ("🐧 Linux", "✅ Stable", "x64 + ARM64 (tar.gz / .deb / .rpm / AppImage)"),
+        ("🪟 Windows", "✅ Stable", "CI-built"),
+        ("🤖 Android (.apk)", "✅ Stable", "Sideload; phone as installer head"),
+    ],
+    "beta": [
+        ("🍎 macOS (.app + dmg)", "⚠️ Beta", "ARM64 + Intel"),
+        ("🍎 macOS (CLI)", "⚠️ Beta", "Per-arch tar.gz"),
+        ("🐧 Linux", "⚠️ Beta", "x64 + ARM64 (tar.gz / .deb / .rpm / AppImage)"),
+        ("🪟 Windows", "⚠️ Beta", "CI-built"),
+        ("🤖 Android (.apk)", "⚠️ Beta", "Sideload; phone as installer head"),
+    ],
+}
+
+
+def base_version(tag):
+    """v2.7.9-beta and v2.7.9 are the same release, written up once."""
+    return re.sub(r"-beta.*$", "", tag)
+
+
+def tidy(generated):
+    """GitHub's generated notes, minus the parts that read as machinery: the HTML comment it opens
+    with, the redundant heading, and the "by @user in <url>/pull/N" tail on every line."""
+    out = []
+    for line in generated.splitlines():
+        if line.startswith("<!--") or re.fullmatch(r"## What's Changed\s*", line):
+            continue
+        line = re.sub(
+            r"^\* (.*) by @[^ ]+ in https?://github\.com/[^ ]+/pull/(\d+)\s*$", r"- \1 (#\2)", line)
+        if line.strip() or (out and out[-1].strip()):
+            out.append(line)
+    return "\n".join(out).strip()
+
+
+def previous_tag(tag, channel):
+    """The tag a reader would compare against: the last stable for a stable release, the previous
+    beta for a beta."""
+    try:
+        tags = subprocess.run(["git", "tag"], capture_output=True, text=True,
+                              check=True).stdout.split()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    if channel == "stable":
+        candidates = [t for t in tags if re.fullmatch(r"v\d+(\.\d+){1,3}", t) and t != tag]
+    else:
+        candidates = [t for t in tags if "beta" in t and t != tag]
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda t: [int(n) for n in re.findall(r"\d+", t)])[-1]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--channel", required=True, choices=("beta", "stable"))
+    parser.add_argument("--generated", type=Path)
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--repo", default="Apps2Samsung/Apps2Samsung")
+    args = parser.parse_args()
+
+    curated = CURATED / f"{base_version(args.tag)}.md"
+    if curated.exists():
+        body = curated.read_text(encoding="utf-8").strip()
+        print(f"Using curated notes from {curated}", file=sys.stderr)
+    elif args.generated and args.generated.exists():
+        body = tidy(args.generated.read_text(encoding="utf-8"))
+        print(f"No {curated} - using the generated notes", file=sys.stderr)
+    else:
+        body = "_No release notes for this build._"
+        print(f"No {curated} and nothing generated", file=sys.stderr)
+
+    rows = "\n".join(f"| {platform} | {status} | {note} |"
+                     for platform, status, note in DOWNLOADS[args.channel])
+
+    page = [f"## 📦 {args.tag} — {args.date}", "", body, "", "---", "",
+            "### 📥 Downloads", "",
+            "| Platform | Status | Notes |", "|----------|--------|-------|", rows, "",
+            "---", "",
+            "### 🛡️ Security notice", "",
+            "Antivirus warnings may occur and are likely **false positives** — the binaries are "
+            "unsigned and built in the open by GitHub Actions.", ""]
+
+    since = previous_tag(args.tag, args.channel)
+    if since:
+        page.append(f"**Full changelog:** https://github.com/{args.repo}/compare/{since}...{args.tag}")
+
+    print("\n".join(page))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -8,8 +8,9 @@ on:
       - 'docs/**'      # website (GitHub Pages) — deploys on its own, shouldn't trigger an app release
       - '.github/**'   # workflow / repo-meta changes shouldn't trigger an app release
       - 'fastlane/**'  # store-listing metadata (F-Droid/IzzyOnDroid) — not app code
-      - 'crowdin.yml'  # translation sync config — changing it ships nothing, but the build it fired
-                       # overwrote the curated release notes, which then had to be re-applied
+      - 'crowdin.yml'  # translation sync config — changing it ships nothing, and the build it
+                       # fired used to overwrite the curated release notes (they live in
+                       # .github/release-notes now, so a rebuild restores them instead)
   # Allow running the beta release manually (e.g. when a merge didn't fire the push trigger).
   workflow_dispatch:
 
@@ -100,32 +101,16 @@ jobs:
       - name: Prepare release notes
         shell: bash
         run: |
-          DATE=$(date +'%Y-%m-%d')
-
-          # Tidy GitHub's generated notes: drop the HTML comment + the redundant
-          # "What's Changed" heading, and shorten each
-          # "* <title> by @user in <url>/pull/N" line to "- <title> (#N)".
-          sed -E \
-            -e '/^<!--/d' \
-            -e "/^## What's Changed[[:space:]]*$/d" \
-            -e 's~^\* (.*) by @[^ ]+ in https?://github.com/[^ ]+/pull/([0-9]+)[[:space:]]*$~- \1 (#\2)~' \
-            CHANGELOG.md | cat -s > CHANGELOG.clean.md
-          mv CHANGELOG.clean.md CHANGELOG.md
-
-          {
-            echo "## 📦 ${VERSION_TAG} — ${DATE}"
-            echo ""
-            cat CHANGELOG.md
-            echo ""
-            echo ""
-            echo "| Platform | Status | Notes |"
-            echo "|----------|--------|-------|"
-            echo "| 🍎 macOS (.app + dmg) | ⚠️ Beta | ARM64 + Intel |"
-            echo "| 🍎 macOS (CLI) | ⚠️ Beta | Per-arch tar.gz |"
-            echo "| 🐧 Linux | ⚠️ Beta | x64 + ARM64 (tar.gz / .deb) |"
-            echo "| 🪟 Windows | ⚠️ Beta | CI-built |"
-            echo "| 🤖 Android (.apk) | ⚠️ Beta | Sideload; phone as installer head |"
-          } > RELEASE_NOTES.md
+          # Curated notes from .github/release-notes/<version>.md when there are any, the generated
+          # list when there aren't. See .github/scripts/build_release_notes.py.
+          python3 .github/scripts/build_release_notes.py \
+            --tag "$VERSION_TAG" \
+            --channel beta \
+            --generated CHANGELOG.md \
+            --date "$(date +'%Y-%m-%d')" \
+            --repo "$GITHUB_REPOSITORY" > RELEASE_NOTES.md
+          echo "--- release notes ---"
+          cat RELEASE_NOTES.md
 
       - uses: actions/setup-dotnet@v6
         with:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -137,37 +137,16 @@ jobs:
       - name: Prepare release notes
         shell: bash
         run: |
-          DATE=$(date +'%Y-%m-%d')
-
-          # Tidy GitHub's generated notes: drop the HTML comment + the redundant
-          # "What's Changed" heading, and shorten each
-          # "* <title> by @user in <url>/pull/N" line to "- <title> (#N)".
-          sed -E \
-            -e '/^<!--/d' \
-            -e "/^## What's Changed[[:space:]]*$/d" \
-            -e 's~^\* (.*) by @[^ ]+ in https?://github.com/[^ ]+/pull/([0-9]+)[[:space:]]*$~- \1 (#\2)~' \
-            CHANGELOG.md | cat -s > CHANGELOG.clean.md
-          mv CHANGELOG.clean.md CHANGELOG.md
-
-          {
-            echo "## 📦 ${VERSION_TAG} — ${DATE}"
-            echo ""
-            cat CHANGELOG.md
-            echo ""
-            echo ""
-            echo "| Platform | Status | Notes |"
-            echo "|----------|--------|-------|"
-            echo "| 🍎 macOS (.app + dmg) | ✅ Stable | ARM64 + Intel |"
-            echo "| 🍎 macOS (CLI) | ✅ Stable | Per-arch tar.gz |"
-            echo "| 🐧 Linux | ✅ Stable | x64 + ARM64 (tar.gz / .deb) |"
-            echo "| 🪟 Windows | ✅ Stable | CI-built |"
-            echo "| 🤖 Android (.apk) | ✅ Stable | Sideload; phone as installer head |"
-            echo ""
-            echo "---"
-            echo ""
-            echo "### 🛡️ Security Notice"
-            echo "Antivirus warnings may occur and are likely **false positives**."
-          } > RELEASE_NOTES.md
+          # Curated notes from .github/release-notes/<version>.md when there are any, the generated
+          # list when there aren't. See .github/scripts/build_release_notes.py.
+          python3 .github/scripts/build_release_notes.py \
+            --tag "$VERSION_TAG" \
+            --channel stable \
+            --generated CHANGELOG.md \
+            --date "$(date +'%Y-%m-%d')" \
+            --repo "$GITHUB_REPOSITORY" > RELEASE_NOTES.md
+          echo "--- release notes ---"
+          cat RELEASE_NOTES.md
 
       - uses: actions/setup-dotnet@v6
         with:


### PR DESCRIPTION
Both release workflows composed the release body inline from `generate-notes` — a flat list of PR titles. That's fine for a routine build and no substitute for what a release actually needs, so the real notes got written by hand onto the release afterwards. Then the next build of the same version overwrote them. `beta-prerelease.yml` carries a `paths-ignore` entry whose comment records exactly that:

> changing it ships nothing, but the build it fired **overwrote the curated release notes, which then had to be re-applied**

## What changes

Curated notes live at `.github/release-notes/<version>.md`. A build prefers them and falls back to the generated list when a version has no file — so nothing changes for a beta nobody is announcing, and a version that *has* notes gets them back on every rebuild.

`v2.7.9-beta` and `v2.7.9` read the same file, so a stable release inherits what its beta already said instead of being written twice.

The file holds the middle of the page only. The heading, downloads table, security notice and full-changelog link are composed by `build_release_notes.py`, which both workflows now call. That also stops the two footers drifting — the Linux row still advertised only `tar.gz` and `.deb`, three PRs after `.rpm` and AppImage shipped (#590).

Not under `docs/` — that tree is the GitHub Pages site.

## Included

`.github/release-notes/v2.7.9.md`, the notes currently on the v2.7.9-beta release: Remote, Linux packaging, in-process SDB, the mobile head being translated at all, instant language switching, the SAF fix, the Samsung-account-without-email popup, and the translation story including the two languages that had never reached the app.

Verified both paths locally — curated file present, and absent with a synthetic generated list.

## Related

The labels `.github/release.yml` categorises by (`ci`, `chore`, `translations`, `l10n`, `feature`, `fix`) didn't exist in the repo, so every PR fell into "🔀 Other changes" no matter what. Created them and labelled everything merged since v2.7.8; the generated notes now split cleanly across all four categories with nothing left over. That's repo state, not a file, so it isn't in this diff.