### PR TITLE
i18n: fix the report crashing, and point both scripts at the locale-named files

### DIFF
--- a/.github/scripts/crowdin_fix_string.py
+++ b/.github/scripts/crowdin_fix_string.py
@@ -31,10 +31,9 @@ LOCALIZATION = Path("Jellyfin2Samsung-CrossOS/Assets/Localization")
 SOURCE_FILE = "en.json"
 BRANCH = "beta"
 
-# crowdin.yml names the language files by %two_letters_code%, except for the two pairs that would
-# collide - pt-BR/pt-PT both being "pt", zh-CN/zh-TW both being "zh". Those two keep their full
-# code, and their partner keeps the two-letter file. Mirror that here or the wrong file is read.
-FULL_CODE_FILES = {"pt-PT", "zh-CN"}
+# crowdin.yml names every language file by its full locale (%locale%), so the repo file for a
+# language is simply <locale>.json - nl-NL.json, pt-BR.json, zh-TW.json. The short two-letter
+# naming this used to mirror is what collided pt-BR with pt-PT and zh-CN with zh-TW.
 
 TOKEN = os.environ.get("CROWDIN_PERSONAL_TOKEN", "")
 PROJECT = os.environ.get("CROWDIN_PROJECT_ID", "")
@@ -70,7 +69,7 @@ def listing(path, **params):
 
 def language_file(language):
     """The repo file a Crowdin language maps to, or None if the repo doesn't ship it."""
-    code = language["id"] if language["id"] in FULL_CODE_FILES else language["twoLettersCode"]
+    code = language.get("locale") or language["id"]
     path = LOCALIZATION / f"{code}.json"
     return path if path.exists() else None
 

--- a/.github/scripts/crowdin_report.py
+++ b/.github/scripts/crowdin_report.py
@@ -33,7 +33,9 @@ API = "https://api.crowdin.com/api/v2"
 LOCALIZATION = Path("Jellyfin2Samsung-CrossOS/Assets/Localization")
 SOURCE_FILE = "en.json"
 BRANCH = "beta"
-FULL_CODE_FILES = {"pt-PT", "zh-CN"}          # kept in step with crowdin.yml's languages_mapping
+# crowdin.yml names every language file by its full locale (%locale%), so the repo file for a
+# language is simply <locale>.json - nl-NL.json, pt-BR.json, zh-TW.json. The short two-letter
+# naming this used to mirror is what collided pt-BR with pt-PT and zh-CN with zh-TW.
 BRANCH_ID = None
 
 TOKEN = os.environ.get("CROWDIN_PERSONAL_TOKEN", "")
@@ -112,7 +114,7 @@ def main():
     branches = [b for b in listing(f"/projects/{PROJECT}/branches") if b["name"] == BRANCH]
     if not branches:
         raise SystemExit(f"No '{BRANCH}' branch in the project.")
-    source = source_file(everything)
+    source = source_file(listing(f"/projects/{PROJECT}/files"))
     file_id = source["id"]
     print(f"Source of truth: id={file_id} {source.get('path')}\n")
     global BRANCH_ID
@@ -132,7 +134,7 @@ def main():
         p = progress.get(code, {})
         phrases = p.get("phrases", {})
         translated, total = phrases.get("translated", 0), phrases.get("total", 0)
-        name = f"{code if code in FULL_CODE_FILES else languages[code]['twoLettersCode']}.json"
+        name = f"{languages[code].get('locale') or code}.json"
         path = LOCALIZATION / name
         note = "" if path.exists() else "  <- no such file in the repo"
         if not translated:


### PR DESCRIPTION
Two bugs from my last two changes, both found by running the scripts instead of reading them.

**The report crashed.** `NameError: name 'everything' is not defined` — it referenced a variable that only ever existed on the branch where the per-file listing was prototyped, and that branch never merged. [Run 33379279145](https://github.com/Apps2Samsung/Apps2Samsung/actions/runs/33379279145).

**Both scripts still used the pre-rename filenames.** They mapped a language to `%two_letters_code%.json` with a hardcoded exception for `pt-PT`/`zh-CN` — the naming #617 removed. So the report would have reported every language as having no file in the repo, and `crowdin-fix-string` would have found no text to push for any of them, silently doing nothing.

The repo file for a language is now simply `<locale>.json`, the same rule `crowdin.yml` exports by:

```
    nl -> …/Localization/nl-NL.json
 pt-BR -> …/Localization/pt-BR.json
 zh-TW -> …/Localization/zh-TW.json
    sr -> …/Localization/sr-SP.json
    is -> None          (Crowdin has it, the repo doesn't ship it)
```

Both exercised against a stubbed API before pushing this time.