### PR TITLE
ci: label pull requests so the release notes sort themselves

### DIFF
--- a/.github/scripts/label_pull_request.py
+++ b/.github/scripts/label_pull_request.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Puts a changelog category on a pull request, so the release notes sort themselves.
+
+.github/release.yml groups the generated notes by label. Nothing was labelled, so every release
+landed as one flat "Other changes" list with the Remote page and a CI tweak side by side - and the
+labels it groups by (ci, chore, translations, l10n, feature, fix) did not even exist in the repo
+until they were created by hand, so nothing could ever have reached those categories.
+
+This labels only what it can tell for certain, and says nothing when it can't:
+
+  1. A pull request that already carries a category label is left alone. A person decided; that
+     beats a regex.
+  2. What the diff touches, which is the strongest signal - only language files is a translation,
+     only .github/ is CI, only prose is documentation, whatever the title claims. (The tooling for
+     the Crowdin sync was titled "i18n:" and belonged under CI, which is exactly this case.)
+  3. Failing that, the title prefix this repo already uses: docs:, CI:, deps:, i18n:, fix:, feat:.
+  4. Failing that, the branch prefix: fix/, feature/, ci/, docs/.
+
+Anything else is left unlabelled on purpose. "Remote: use the phone as a TV remote" is a feature
+and "Mobile: pick files through SAF so cloud sources stop throwing" is a fix, and nothing in
+either sentence says so - guessing would put the wrong thing in front of a reader, which is worse
+than the one click it costs to say.
+"""
+import json
+import os
+import re
+import sys
+import urllib.request
+
+API = "https://api.github.com"
+
+# Every label .github/release.yml groups by. One of these already present means hands off.
+CATEGORIES = {"feature", "enhancement", "bug", "fix", "translations", "l10n",
+              "chore", "ci", "dependencies", "documentation"}
+
+LOCALIZATION = "Jellyfin2Samsung-CrossOS/Assets/Localization/"
+
+TITLE_RULES = [
+    (r"^docs\b", "documentation"),
+    (r"^(ci|fdroid)\b", "ci"),
+    (r"^deps\b", "dependencies"),
+    (r"^i18n\b", "translations"),
+    (r"^fix\b", "fix"),
+    (r"^feat(ure)?\b", "feature"),
+]
+
+BRANCH_RULES = [
+    ("fix/", "fix"),
+    ("feature/", "feature"),
+    ("feat/", "feature"),
+    ("ci/", "ci"),
+    ("docs/", "documentation"),
+]
+
+
+def call(path, method="GET", body=None):
+    request = urllib.request.Request(
+        f"{API}{path}", method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                 "Accept": "application/vnd.github+json"})
+    with urllib.request.urlopen(request) as response:
+        payload = response.read()
+    return json.loads(payload) if payload else {}
+
+
+def changed_files(repo, number):
+    files, page = [], 1
+    while page <= 10:                          # 300 files is plenty to classify a pull request
+        batch = call(f"/repos/{repo}/pulls/{number}/files?per_page=100&page={page}")
+        files += [f["filename"] for f in batch]
+        if len(batch) < 100:
+            break
+        page += 1
+    return files
+
+
+def from_paths(files):
+    if not files:
+        return None
+    if all(f.startswith(LOCALIZATION) for f in files):
+        return "translations"
+    if all(f.startswith(".github/") for f in files):
+        return "ci"
+    if all(f.endswith(".md") or f.startswith("docs/") for f in files):
+        return "documentation"
+    return None
+
+
+def from_title(title):
+    lowered = title.strip().lower()
+    for pattern, label in TITLE_RULES:
+        if re.match(pattern, lowered):
+            return label
+    return None
+
+
+def from_branch(branch):
+    for prefix, label in BRANCH_RULES:
+        if branch.lower().startswith(prefix):
+            return label
+    return None
+
+
+def main():
+    with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
+        event = json.load(handle)
+
+    pr = event["pull_request"]
+    repo = event["repository"]["full_name"]
+    number = pr["number"]
+
+    existing = {label["name"] for label in pr.get("labels", [])}
+    if existing & CATEGORIES:
+        print(f"#{number} already has {sorted(existing & CATEGORIES)} - leaving it alone.")
+        return 0
+
+    if pr.get("user", {}).get("login", "").startswith("dependabot"):
+        label = "dependencies"
+        why = "dependabot"
+    else:
+        files = changed_files(repo, number)
+        label = from_paths(files)
+        why = f"the diff ({len(files)} file(s))"
+        if not label:
+            label, why = from_title(pr["title"]), "the title"
+        if not label:
+            label, why = from_branch(pr["head"]["ref"]), "the branch name"
+
+    if not label:
+        print(f"#{number} {pr['title']!r}: nothing conclusive - leaving it for a person.")
+        return 0
+
+    call(f"/repos/{repo}/issues/{number}/labels", method="POST", body={"labels": [label]})
+    print(f"#{number} labelled '{label}' from {why}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -1,0 +1,39 @@
+name: Label pull requests
+
+# Puts a changelog category on a pull request so the release notes sort themselves.
+#
+# .github/release.yml groups the generated notes by label, and nothing was labelled - so every
+# release came out as one flat "Other changes" list with a new feature and a CI tweak side by
+# side. The labels it groups by didn't even exist in the repo until they were created by hand.
+#
+# The script labels only what it can tell for certain and stays quiet otherwise; see the comment
+# at the top of it. A label already on the pull request always wins.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+
+# Only ever reads the pull request's metadata through the API - it does not check out or run any
+# code from the branch, which is what makes pull_request_target safe to use here. The elevated
+# token is needed so the label also lands on pull requests opened from a fork.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out the base branch, not the pull request - the script that runs is this repo's.
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
+      - name: Choose a label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .github/scripts/label_pull_request.py


### PR DESCRIPTION
`.github/release.yml` groups the generated release notes by label — and nothing was labelled, so every release came out as one flat **"🔀 Other changes"** list with the Remote page and a CI tweak side by side. Six of the ten labels it groups by (`ci`, `chore`, `translations`, `l10n`, `feature`, `fix`) didn't exist in the repo at all, so those categories could never have received anything.

The labels exist now and everything since v2.7.8 is labelled, which is why [v2.7.9-beta's generated list](https://github.com/Apps2Samsung/Apps2Samsung/releases/tag/v2.7.9-beta) splits cleanly. This keeps it that way without anyone having to remember.

## What it labels

In order of confidence, stopping at the first answer:

1. **Already labelled** → leave it alone. A person decided; that beats a regex.
2. **What the diff touches** — only language files is a translation, only `.github/` is CI, only prose is documentation, *whatever the title says*. The Crowdin sync tooling was titled `i18n:` and belonged under CI; this is that case exactly.
3. **Title prefix** already in use here: `docs:`, `CI:`, `deps:`, `i18n:`, `fix:`, `feat:`.
4. **Branch prefix**: `fix/`, `feature/`, `ci/`, `docs/`.

Anything else is **left unlabelled on purpose**. "Remote: use the phone or the desktop as a TV remote" is a feature and "Mobile: pick files through SAF so cloud sources stop throwing" is a fix, and nothing in either sentence says so. Guessing puts the wrong thing in front of a reader, which is worse than the one click it saves.

## Checked against reality

Replayed over the ten pull requests labelled by hand today, using their real titles, branches and file lists:

```
 ok  #612  -> ci             (from the diff: .github/ only)
 ok  #617  -> translations   (from the title: i18n:)
 ok  #621  -> translations   (from the diff: language files only)
 ok  #605  -> documentation  (from the diff: README + docs/)
 ok  #588  -> dependencies   (from the title: deps:)
 ok  #583  -> feature        (from the branch: feat/tv-remote)
 ok  #576  -> fix            (from the branch: fix/mobile-cloud-file-picker)
 ok  #608  -> fix            (from the branch: fix/samsung-account-missing-email)
 ok  #575  -> ci             (from the diff: .github/ only)
 ok  #999  -> None           (nothing conclusive — left for a person)

10/10 agree
```

Also exercised end to end against a stubbed API, including the "already labelled, hands off" path.

## On `pull_request_target`

Needed so a pull request opened **from a fork** gets labelled — `GITHUB_TOKEN` is read-only on `pull_request` for forks. It reads the pull request's metadata through the API and never checks out or runs the branch's code; `actions/checkout` takes the base branch, so the script that runs is this repo's.

This PR should label itself `ci` once merged — from the diff, since it only touches `.github/`.