### PR TITLE
Smoke test: does the labeller run

### DIFF
--- a/.github/scripts/label_pull_request.py
+++ b/.github/scripts/label_pull_request.py
@@ -139,3 +139,5 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
+
+# (smoke test - this branch is thrown away)


### PR DESCRIPTION
Throwaway. Touches only .github/, so the labeller should apply 'ci' from the diff. Closing straight after.