### PR TITLE
Android: derive versionCode from the commit count so it can never go backwards

### DIFF
--- a/.github/scripts/android-version-code.sh
+++ b/.github/scripts/android-version-code.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+#
+# Android versionCode — one source of truth for both release channels.
+#
+# versionCode is the only number Android compares when deciding whether an install
+# is an upgrade. It must never go down on *either* channel, or users get
+#
+#     Cannot install an older version of an app (versionCode 273 -> 58)
+#
+# and are stuck with what they have until they uninstall (losing their settings).
+#
+# Both channels derive it from the same repo-wide, monotonically growing number —
+# the commit count — plus a small per-channel offset:
+#
+#     beta   = commits * 10 + 0
+#     stable = commits * 10 + 9
+#
+# Why it cannot invert:
+#   * the commit count is a property of the REPO, so both workflows compute the
+#     same base for the same commit;
+#   * stable (+9) outranks the beta built from that same commit, so beta -> stable
+#     is always an upgrade;
+#   * a beta cut after that stable sits on at least one more commit, i.e. at least
+#     +10, so it outranks that stable too — stable -> beta is also an upgrade.
+#
+# What went wrong before: both workflows used ${{ github.run_number }}, which
+# counts runs PER WORKFLOW FILE, not per repo. Beta reached 298 while stable was
+# still on 58, so every beta user hit the dialog above when moving to stable.
+#
+# Usage:
+#   android-version-code.sh compute beta|stable
+#       Prints the versionCode and exports it as ANDROID_VERSION_CODE (through
+#       $GITHUB_ENV / $GITHUB_OUTPUT when running in Actions). Refuses to hand back
+#       a code that would downgrade anything already published.
+#
+#   android-version-code.sh verify <apk> [expected-code]
+#       Asserts the built APK really carries that code — an MSBuild or .csproj
+#       change must not be able to quietly override it — and logs the signing
+#       certificate. Set EXPECTED_SIGNER_SHA256 to also pin the signing key.
+#
+# Both subcommands also run locally, e.g.:
+#   .github/scripts/android-version-code.sh compute stable
+#
+set -euo pipefail
+
+# Distance between two consecutive commits' codes. Also the width of the "same
+# commit, other channel" window that compute is allowed to step over (see below).
+STRIDE=10
+
+# Offsets must be < STRIDE, and stable must be the highest, so that stable
+# outranks every beta built from the same commit.
+OFFSET_BETA=0
+OFFSET_STABLE=9
+
+# A shallow checkout reports 1 commit, which would produce versionCode 10 and
+# downgrade every install out there. Anything under this means the job lost its
+# `fetch-depth: 0` on actions/checkout.
+MIN_COMMITS=100
+
+# High-water mark of the retired github.run_number scheme (beta was at 298 when it
+# was replaced). Any code at or below this is a downgrade for somebody, so it is a
+# hard floor. It also covers every release published before this script existed,
+# which is why the published-release check below only has to look at the newest
+# release per channel.
+LEGACY_FLOOR=1000
+
+# Android's own ceiling for versionCode.
+ANDROID_MAX_CODE=2100000000
+
+log()  { printf '%s\n' "$*"; }
+warn() { if [ -n "${GITHUB_ACTIONS:-}" ]; then printf '::warning::%s\n' "$*"; else printf 'WARNING: %s\n' "$*"; fi; }
+die()  { if [ -n "${GITHUB_ACTIONS:-}" ]; then printf '::error::%s\n' "$*"; else printf 'ERROR: %s\n' "$*"; fi; exit 1; }
+
+WORKDIR=""
+cleanup() { if [ -n "$WORKDIR" ]; then rm -rf "$WORKDIR"; fi; }
+trap cleanup EXIT
+
+# Locate a build-tools binary (aapt2, apksigner). The GitHub runners ship the
+# Android SDK but do not put build-tools on PATH, and the version bundled in the
+# image changes, so pick the newest one actually installed.
+find_sdk_tool() {
+  local name="$1" sdk found
+  for sdk in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "$HOME/Android/Sdk" /usr/local/lib/android/sdk; do
+    if [ -n "$sdk" ] && [ -d "$sdk/build-tools" ]; then
+      found=$(find "$sdk/build-tools" -maxdepth 2 -name "$name" -type f 2>/dev/null | sort -V | tail -n1 || true)
+      if [ -n "$found" ]; then printf '%s\n' "$found"; return 0; fi
+    fi
+  done
+  command -v "$name" 2>/dev/null || return 1
+}
+
+# Read one field out of `aapt2 dump badging`. Tolerates a failing aapt2 and prints
+# nothing in that case — callers validate the result. `sed -n 1p` rather than
+# `head -n1` so nothing closes the pipe early and trips `pipefail`.
+badging_field() {
+  local aapt2="$1" apk="$2" field="$3"
+  { "$aapt2" dump badging "$apk" 2>/dev/null || true; } \
+    | sed -n "s/.*${field}='\([^']*\)'.*/\1/p" | sed -n 1p
+}
+
+# Highest versionCode already published on GitHub Releases -> HIGHEST/HIGHEST_TAG.
+#
+# Codes are monotone by construction, so the highest one lives in the newest
+# release of one of the two channels — two small downloads instead of trawling the
+# whole release history. Everything older is covered by LEGACY_FLOOR.
+HIGHEST=0
+HIGHEST_TAG="(none)"
+compute_highest_published_code() {
+  local gh_args=() newest tag apk code aapt2
+
+  command -v gh >/dev/null 2>&1 || die "gh CLI not found — cannot check published versionCodes"
+  if [ -n "${GITHUB_REPOSITORY:-}" ]; then gh_args=(--repo "$GITHUB_REPOSITORY"); fi
+
+  # Newest non-draft prerelease (beta) and newest non-draft release (stable).
+  if ! newest=$(gh release list "${gh_args[@]+"${gh_args[@]}"}" --limit 60 \
+        --json tagName,isPrerelease,isDraft \
+        --jq '[ .[] | select(.isDraft == false and .isPrerelease == true)  ][0].tagName // empty,
+               [ .[] | select(.isDraft == false and .isPrerelease == false) ][0].tagName // empty' 2>&1); then
+    die "could not list releases (\`gh release list\` failed): $newest"
+  fi
+
+  aapt2=$(find_sdk_tool aapt2) || die "aapt2 not found — cannot read published versionCodes"
+
+  if [ -z "$newest" ]; then
+    log "  no published releases yet"
+    return 0
+  fi
+
+  WORKDIR=$(mktemp -d)
+  for tag in $newest; do
+    rm -f "$WORKDIR"/*.apk
+    if ! gh release download "$tag" "${gh_args[@]+"${gh_args[@]}"}" \
+          -p '*-android.apk' -D "$WORKDIR" --clobber >/dev/null 2>&1; then
+      log "  $tag -> no android APK asset, skipped"
+      continue
+    fi
+    for apk in "$WORKDIR"/*.apk; do
+      [ -f "$apk" ] || continue
+      code=$(badging_field "$aapt2" "$apk" versionCode)
+      case "$code" in
+        ''|*[!0-9]*)
+          log "  $tag -> could not read a versionCode from $(basename "$apk"), skipped"
+          continue ;;
+      esac
+      log "  $tag -> versionCode $code"
+      if [ "$code" -gt "$HIGHEST" ]; then HIGHEST=$code; HIGHEST_TAG=$tag; fi
+    done
+  done
+  rm -rf "$WORKDIR"; WORKDIR=""
+}
+
+cmd_compute() {
+  local channel="${1:-}" offset commits code behind
+
+  case "$channel" in
+    beta)   offset=$OFFSET_BETA ;;
+    stable) offset=$OFFSET_STABLE ;;
+    *) die "usage: $0 compute beta|stable" ;;
+  esac
+
+  commits=$(git rev-list --count HEAD)
+  if [ "$commits" -lt "$MIN_COMMITS" ]; then
+    die "commit count $commits looks like a shallow checkout — this job needs 'fetch-depth: 0' on actions/checkout"
+  fi
+
+  code=$(( commits * STRIDE + offset ))
+  log "channel=$channel commits=$commits offset=$offset -> candidate versionCode $code"
+
+  if [ "$code" -le "$LEGACY_FLOOR" ]; then
+    die "versionCode $code is at or below the retired run_number scheme's high-water mark ($LEGACY_FLOOR) — publishing it would downgrade existing installs"
+  fi
+
+  log "versionCodes already published on GitHub Releases:"
+  compute_highest_published_code
+  log "highest published:  $HIGHEST ($HIGHEST_TAG)"
+
+  if [ "$code" -le "$HIGHEST" ]; then
+    behind=$(( HIGHEST - code ))
+    if [ "$behind" -lt "$STRIDE" ]; then
+      # The one case the formula cannot rank on its own: building one channel from
+      # the very same commit the other channel was already published from —
+      # typically cutting a beta straight after a stable with no commit in
+      # between. Step over the published code instead of failing the release; the
+      # result is still strictly increasing, and the next commit's code is higher
+      # again either way.
+      code=$(( HIGHEST + 1 ))
+      warn "candidate versionCode was $behind behind the published $HIGHEST ($HIGHEST_TAG — same commit, other channel), so using $code instead. Land a commit before re-cutting this channel to keep codes aligned with the commit count."
+    else
+      die "versionCode $code is $behind behind the highest published code ($HIGHEST in $HIGHEST_TAG) — users on that build could not update, so refusing to publish. This normally means the release is building an older ref or a stale checkout; release from the tip of the branch instead."
+    fi
+  fi
+
+  if [ "$code" -gt "$ANDROID_MAX_CODE" ]; then
+    die "versionCode $code exceeds Android's maximum ($ANDROID_MAX_CODE)"
+  fi
+
+  log "==> versionCode $code"
+  if [ -n "${GITHUB_ENV:-}" ]; then    echo "ANDROID_VERSION_CODE=$code" >> "$GITHUB_ENV"; fi
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then echo "version-code=$code" >> "$GITHUB_OUTPUT"; fi
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "Android \`versionCode\` for **$channel**: \`$code\` (commits=$commits, offset=$offset)" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+cmd_verify() {
+  local apk="${1:-}" expected="${2:-${ANDROID_VERSION_CODE:-}}"
+  local aapt2 apksigner actual name fingerprint expected_signer
+
+  [ -n "$apk" ] || die "usage: $0 verify <apk> [expected-code]"
+  [ -f "$apk" ] || die "APK not found: $apk"
+  [ -n "$expected" ] || die "no expected versionCode given and ANDROID_VERSION_CODE is not set"
+
+  aapt2=$(find_sdk_tool aapt2) || die "aapt2 not found — cannot verify the APK"
+  actual=$(badging_field "$aapt2" "$apk" versionCode)
+  name=$(badging_field "$aapt2" "$apk" versionName)
+
+  log "apk:                  $apk"
+  log "versionName:          ${name:-(none)}"
+  log "expected versionCode: $expected"
+  log "actual   versionCode: ${actual:-(unreadable)}"
+
+  [ -n "$actual" ] || die "could not read a versionCode from $apk"
+  if [ "$actual" != "$expected" ]; then
+    die "APK versionCode is $actual but should be $expected — something is overriding ApplicationVersion (check Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj)"
+  fi
+  if [ -z "$name" ]; then
+    warn "APK has no versionName — ApplicationDisplayVersion did not make it into the build"
+  fi
+
+  # A signing-key change breaks in-place updates just as hard as a versionCode
+  # downgrade, only with a different dialog ("App not installed"). Log the
+  # certificate so it stays greppable across runs when a user reports that.
+  if apksigner=$(find_sdk_tool apksigner); then
+    fingerprint=$({ "$apksigner" verify --print-certs "$apk" 2>/dev/null || true; } \
+      | sed -n 's/.*SHA-256 digest: *\([0-9a-fA-F]*\).*/\1/p' | sed -n 1p \
+      | tr 'A-F' 'a-f')
+    log "signer SHA-256:       ${fingerprint:-(unreadable)}"
+    if [ -n "${EXPECTED_SIGNER_SHA256:-}" ]; then
+      # Accept the value with or without the colons keytool/openssl like to print.
+      expected_signer=$(printf '%s' "$EXPECTED_SIGNER_SHA256" | tr -d ': ' | tr 'A-F' 'a-f')
+      [ -n "$fingerprint" ] || die "could not read the signing certificate of $apk, but EXPECTED_SIGNER_SHA256 is set"
+      if [ "$fingerprint" != "$expected_signer" ]; then
+        die "APK is signed with $fingerprint but must be signed with $expected_signer — Android refuses an update signed by a different key, so existing installs would be stuck. The ANDROID_KEYSTORE_* secrets were probably replaced; restore the original keystore."
+      fi
+      log "signer matches the pinned release certificate"
+    fi
+  else
+    warn "apksigner not found — skipped the signing-certificate check"
+  fi
+
+  log "✅ APK carries versionCode $expected"
+}
+
+case "${1:-}" in
+  compute) shift; cmd_compute "$@" ;;
+  verify)  shift; cmd_verify  "$@" ;;
+  *) die "usage: $0 {compute beta|stable | verify <apk> [expected-code]}" ;;
+esac

--- a/.github/workflows/beta-prerelease.yml
+++ b/.github/workflows/beta-prerelease.yml
@@ -344,7 +344,26 @@ jobs:
     if: ${{ always() && needs.beta-release.result == 'success' }}
 
     steps:
+      # fetch-depth: 0 is REQUIRED — the Android versionCode below is derived from the
+      # commit count, and a shallow checkout reports 1. The script fails the build if
+      # this is ever dropped rather than silently shipping versionCode 10.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # ---------------- ANDROID versionCode ----------------
+      # Derived from the repo's commit count, so both channels stay strictly
+      # increasing and beta <-> stable can always update in place. See the header of
+      # .github/scripts/android-version-code.sh for the formula and why the old
+      # github.run_number could (and did) go backwards.
+      #
+      # Runs before the build so a bad code fails in seconds instead of after a
+      # ten-minute publish.
+      - name: Compute Android versionCode
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/android-version-code.sh compute beta
 
       # Fresh checkout — stamp the beta marker again (see the beta-release job). The APK's own
       # versionName comes from the -p:ApplicationDisplayVersion below, not from this file.
@@ -364,34 +383,28 @@ jobs:
       - name: Install MAUI Android workload
         run: dotnet workload install maui-android
 
-      # A signing key is required for an installable Release APK. Prefer repo secrets
-      # (stable key across builds); otherwise generate an ephemeral key so the APK is at
-      # least installable — a fresh key means users must uninstall before updating, so set
-      # ANDROID_KEYSTORE_BASE64 / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS for a
-      # persistent signing identity.
+      # The persistent signing key is required. The old fallback minted a throwaway
+      # key, which produces an APK that installs but can never update in place —
+      # Android rejects a signing-key change — so it is the same "users are stuck"
+      # failure as a versionCode downgrade, just with a different dialog.
       - name: Prepare Android signing key
         run: |
-          if [ -n "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
-            echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$PWD/a2s.keystore"
-            echo "KS_PASS=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> "$GITHUB_ENV"
-            echo "KS_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> "$GITHUB_ENV"
-            echo "Using signing key from repo secrets."
-          else
-            keytool -genkeypair -v -keystore "$PWD/a2s.keystore" \
-              -alias a2s -keyalg RSA -keysize 2048 -validity 10000 \
-              -storepass apps2samsung -keypass apps2samsung \
-              -dname "CN=Apps2Samsung, O=MadeByPatrick, C=NL"
-            echo "KS_PASS=apps2samsung" >> "$GITHUB_ENV"
-            echo "KS_ALIAS=a2s" >> "$GITHUB_ENV"
-            echo "::warning::No ANDROID_KEYSTORE_BASE64 secret set — signed the APK with an ephemeral key."
+          set -euo pipefail
+          if [ -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set. An APK signed with a throwaway key cannot update existing installs — set ANDROID_KEYSTORE_BASE64 / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS."
+            exit 1
           fi
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$PWD/a2s.keystore"
+          echo "KS_PASS=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "KS_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> "$GITHUB_ENV"
+          echo "Using signing key from repo secrets."
 
       - name: Build APK
         run: |
           dotnet publish Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj \
             -c Release -f net10.0-android \
             -p:ApplicationDisplayVersion=${{ needs.beta-release.outputs.VERSION_BETA }} \
-            -p:ApplicationVersion=${{ github.run_number }} \
+            -p:ApplicationVersion="$ANDROID_VERSION_CODE" \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore="$PWD/a2s.keystore" \
             -p:AndroidSigningKeyAlias="$KS_ALIAS" \
@@ -406,6 +419,22 @@ jobs:
             echo "❌ No APK produced"; exit 1
           fi
           cp "$APK" "dist/${PRODUCT_NAME}-${{ needs.beta-release.outputs.VERSION_TAG }}-android.apk"
+
+      # The -p: property above is only a request: prove the APK really carries the
+      # code we computed, so an MSBuild or .csproj change can never quietly ship a
+      # different one. Also logs the signing certificate.
+      - name: Verify APK versionCode and signer
+        shell: bash
+        env:
+          # SHA-256 of the release signing certificate (CN=Apps2Samsung, O=MadeByPatrick),
+          # taken from the published APKs. Android refuses an update signed by a different
+          # key just as hard as a versionCode downgrade, so this must never change — if
+          # this step fails, the ANDROID_KEYSTORE_* secrets were swapped, and the fix is to
+          # restore the original keystore, not to update this value.
+          EXPECTED_SIGNER_SHA256: bd4dee21ebeee1b0b690c612318808d27f35c46fa53ba31d256379a7fed7e107
+        run: |
+          .github/scripts/android-version-code.sh verify \
+            "dist/${PRODUCT_NAME}-${{ needs.beta-release.outputs.VERSION_TAG }}-android.apk"
 
       - uses: softprops/action-gh-release@v3
         with:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -377,7 +377,29 @@ jobs:
     if: ${{ always() && needs.stable-release.result == 'success' }}
 
     steps:
+      # fetch-depth: 0 is REQUIRED — the Android versionCode below is derived from the
+      # commit count, and a shallow checkout reports 1. The script fails the build if
+      # this is ever dropped rather than silently shipping versionCode 10. The explicit
+      # ref matters too: without it a dispatched release built master's APK while the
+      # other jobs built the requested ref.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+
+      # ---------------- ANDROID versionCode ----------------
+      # Derived from the repo's commit count, so both channels stay strictly
+      # increasing and beta <-> stable can always update in place. See the header of
+      # .github/scripts/android-version-code.sh for the formula and why the old
+      # github.run_number could (and did) go backwards.
+      #
+      # Runs before the build so a bad code fails in seconds instead of after a
+      # ten-minute publish.
+      - name: Compute Android versionCode
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/android-version-code.sh compute stable
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -391,32 +413,28 @@ jobs:
       - name: Install MAUI Android workload
         run: dotnet workload install maui-android
 
-      # Stable APKs should use a persistent signing key so users can update in place. Set the
-      # ANDROID_KEYSTORE_BASE64 / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS secrets; without
-      # them we fall back to an ephemeral key (installable, but breaks in-place updates).
+      # The persistent signing key is required. The old fallback minted a throwaway
+      # key, which produces an APK that installs but can never update in place —
+      # Android rejects a signing-key change — so it is the same "users are stuck"
+      # failure as a versionCode downgrade, just with a different dialog.
       - name: Prepare Android signing key
         run: |
-          if [ -n "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
-            echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$PWD/a2s.keystore"
-            echo "KS_PASS=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> "$GITHUB_ENV"
-            echo "KS_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> "$GITHUB_ENV"
-            echo "Using signing key from repo secrets."
-          else
-            keytool -genkeypair -v -keystore "$PWD/a2s.keystore" \
-              -alias a2s -keyalg RSA -keysize 2048 -validity 10000 \
-              -storepass apps2samsung -keypass apps2samsung \
-              -dname "CN=Apps2Samsung, O=MadeByPatrick, C=NL"
-            echo "KS_PASS=apps2samsung" >> "$GITHUB_ENV"
-            echo "KS_ALIAS=a2s" >> "$GITHUB_ENV"
-            echo "::warning::No ANDROID_KEYSTORE_BASE64 secret set — signed the APK with an ephemeral key (in-place updates will fail)."
+          set -euo pipefail
+          if [ -z "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set. An APK signed with a throwaway key cannot update existing installs — set ANDROID_KEYSTORE_BASE64 / ANDROID_KEYSTORE_PASSWORD / ANDROID_KEY_ALIAS."
+            exit 1
           fi
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > "$PWD/a2s.keystore"
+          echo "KS_PASS=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}" >> "$GITHUB_ENV"
+          echo "KS_ALIAS=${{ secrets.ANDROID_KEY_ALIAS }}" >> "$GITHUB_ENV"
+          echo "Using signing key from repo secrets."
 
       - name: Build APK
         run: |
           dotnet publish Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj \
             -c Release -f net10.0-android \
             -p:ApplicationDisplayVersion=${{ needs.stable-release.outputs.VERSION }} \
-            -p:ApplicationVersion=${{ github.run_number }} \
+            -p:ApplicationVersion="$ANDROID_VERSION_CODE" \
             -p:AndroidKeyStore=true \
             -p:AndroidSigningKeyStore="$PWD/a2s.keystore" \
             -p:AndroidSigningKeyAlias="$KS_ALIAS" \
@@ -431,6 +449,22 @@ jobs:
             echo "❌ No APK produced"; exit 1
           fi
           cp "$APK" "dist/${PRODUCT_NAME}-${{ needs.stable-release.outputs.VERSION_TAG }}-android.apk"
+
+      # The -p: property above is only a request: prove the APK really carries the
+      # code we computed, so an MSBuild or .csproj change can never quietly ship a
+      # different one. Also logs the signing certificate.
+      - name: Verify APK versionCode and signer
+        shell: bash
+        env:
+          # SHA-256 of the release signing certificate (CN=Apps2Samsung, O=MadeByPatrick),
+          # taken from the published APKs. Android refuses an update signed by a different
+          # key just as hard as a versionCode downgrade, so this must never change — if
+          # this step fails, the ANDROID_KEYSTORE_* secrets were swapped, and the fix is to
+          # restore the original keystore, not to update this value.
+          EXPECTED_SIGNER_SHA256: bd4dee21ebeee1b0b690c612318808d27f35c46fa53ba31d256379a7fed7e107
+        run: |
+          .github/scripts/android-version-code.sh verify \
+            "dist/${PRODUCT_NAME}-${{ needs.stable-release.outputs.VERSION_TAG }}-android.apk"
 
       - uses: softprops/action-gh-release@v3
         with:

--- a/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
+++ b/Apps2Samsung.Mobile/Apps2Samsung.Mobile.csproj
@@ -43,7 +43,12 @@
 		<!-- App Identifier -->
 		<ApplicationId>nl.madebypatrick.apps2samsung</ApplicationId>
 
-		<!-- Versions -->
+		<!-- Versions. These are placeholders for local and PR builds only: both release
+		     workflows override them on the dotnet publish command line, and
+		     ApplicationVersion (the Android versionCode) is computed by
+		     .github/scripts/android-version-code.sh so it can never go backwards.
+		     A release build verifies the published APK against that value, so raising
+		     the number here has no effect on what users get. -->
 		<ApplicationDisplayVersion>2.7.9</ApplicationDisplayVersion>
 		<ApplicationVersion>5</ApplicationVersion>
 


### PR DESCRIPTION
## The bug

Both release workflows fed `${{ github.run_number }}` into `-p:ApplicationVersion` — the Android **versionCode**, the only number Android compares when deciding whether an install is an upgrade.

`run_number` counts runs **per workflow file**, not per repo, so the two channels drifted apart badly:

| channel | workflow `run_number` | versionCode shipped |
|---|---|---|
| beta | 298 | 298 |
| stable | 58 | 58 |

So every beta user who tried to move to stable got

> Cannot install an older version of an app (versionCode 273 → 58) [Apps2Samsung]

and was stuck on beta until they uninstalled — losing their settings.

## The fix

One source of truth for both channels: the repo's commit count, plus a per-channel offset.

```
beta   = commits * 10 + 0     ->  11360 for the next beta
stable = commits * 10 + 9     ->  11369 for the next stable
```

It cannot invert in either direction:

* the commit count is a property of the **repo**, so both workflows compute the same base for the same commit;
* stable (+9) outranks the beta built from that same commit → **beta → stable is always an upgrade**;
* a beta cut after that stable sits on at least one more commit, i.e. at least +10, so it outranks the stable too → **stable → beta is also an upgrade**.

The implementation is shared (`.github/scripts/android-version-code.sh`) rather than copy-pasted into both workflows, so the two channels can't drift apart again. On top of the formula it:

* **refuses a code at or below 1000**, the high-water mark of the retired `run_number` scheme — no build can land below something already installed out there;
* **fails on a shallow checkout** (which reports 1 commit → versionCode 10) instead of silently shipping it; both android jobs now use `fetch-depth: 0`;
* **checks the codes actually published** in the newest release of each channel and refuses to publish below them. It steps over the published code only in the single case the formula cannot rank on its own — cutting a channel from the very same commit the other channel was published from — and hard-fails anything further behind, which is what building a stale ref looks like;
* **verifies after the build** that the APK really carries the computed code, so an MSBuild or `.csproj` change can't quietly override it (`Apps2Samsung.Mobile.csproj` does still carry an `<ApplicationVersion>5</ApplicationVersion>` placeholder for local builds).

## Two related ways users get stuck, closed at the same time

* **The ephemeral-keystore fallback is gone.** It produced an APK that installs but can *never* update in place, because Android rejects a signing-key change — the same "users are stuck" failure as a versionCode downgrade, just with a different dialog. A missing `ANDROID_KEYSTORE_BASE64` now fails the release loudly. The release certificate (`CN=Apps2Samsung, O=MadeByPatrick`, SHA-256 `bd4dee21…e107`) is pinned and checked on every build.
* **The stable workflow's android job was the only one on a shallow, ref-less checkout**, so a dispatched release built `master`'s APK while every other job built the requested ref.

## Existing installs

Nobody has to reinstall:

* the next codes (11360 / 11369) are far above both 298 and 58, so beta **and** stable users can update in place;
* the published `v2.7.9` and `v2.7.9-beta` APKs are already signed with the same certificate (verified against both assets), so the versionCode was the only thing blocking the update;
* F-Droid picks the code out of the APK, so `apps2samsung.com/fdroid/repo` follows automatically.

## Testing

The script's paths were exercised locally against stubbed `gh`/`aapt2`/`apksigner`:

| case | result |
|---|---|
| normal beta / stable build | 11360 / 11369 |
| beta cut from a commit stable was already published from | warns, steps to 11370 |
| build running a ref 14 commits behind the published code | fails, refuses to publish |
| shallow checkout (1 commit) | fails, points at `fetch-depth: 0` |
| APK's real code ≠ computed code | fails, points at the `.csproj` |
| APK signed with a different key | fails, points at the keystore secrets |
| signer pin given colon-separated (openssl style) | accepted |