### PR TITLE
Remote: keep the pairing across address changes, and explain a TV that asks again

### DIFF
--- a/Apps2Samsung.Core/Remote/RemoteSession.cs
+++ b/Apps2Samsung.Core/Remote/RemoteSession.cs
@@ -8,12 +8,16 @@ namespace Apps2Samsung.Remote
     /// Where a head keeps the two things the remote channel can't rediscover on its own: the pairing
     /// token (without it the TV re-prompts every session) and the MAC captured while the set was awake
     /// (without it a sleeping set can't be woken). The desktop head stores them in settings.json, the
-    /// mobile head in Preferences.
+    /// mobile head in Preferences. Both are plain string maps; <see cref="RemoteSession"/> decides
+    /// what the key is. The MAC is filed under the IP, because it is looked up when the set is asleep
+    /// and the IP is all that's known. The token is filed under the set's own id from the probe
+    /// (falling back to the IP on a set that reports none), so a new DHCP lease doesn't cost the
+    /// user another pairing prompt (#545).
     /// </summary>
     public interface IRemoteCredentialStore
     {
-        string? GetToken(string tvIpAddress);
-        void SetToken(string tvIpAddress, string token);
+        string? GetToken(string tvKey);
+        void SetToken(string tvKey, string token);
         string? GetMac(string tvIpAddress);
         void SetMac(string tvIpAddress, string macAddress);
     }
@@ -30,7 +34,10 @@ namespace Apps2Samsung.Remote
         /// <summary>A magic packet went out and the TV still didn't come up.</summary>
         WakeFailed,
 
-        /// <summary>The TV prompted and the prompt wasn't accepted (declined, or nobody was there).</summary>
+        /// <summary>
+        /// The TV prompted and the prompt wasn't accepted (declined, or nobody was there). Also the
+        /// outcome when a set prompted <i>again</i> despite a stored token and that went unanswered.
+        /// </summary>
         PairingRefused,
 
         /// <summary>The set answers on the network but wouldn't open the remote channel.</summary>
@@ -74,11 +81,17 @@ namespace Apps2Samsung.Remote
         public const string StatusConnecting = "lblRemoteConnecting";
         public const string StatusWaking = "lblRemoteWaking";
         public const string StatusPairPrompt = "lblRemotePairPrompt";
+        public const string StatusPairPromptAgain = "lblRemotePairPromptAgain";
 
-        // A first pairing needs someone to walk to the TV and accept the prompt; a reconnect with a
-        // stored token is silent and shouldn't hang the UI if the set has gone away.
+        // A pairing needs someone to walk to the TV and accept the prompt. That is expected on the
+        // first connection; it also happens on every later one when the set's "Access Notification"
+        // is left on "Always" rather than "First Time Only" (#545), a setting the API can't read or
+        // change. So the wait is the same either way — the socket itself fails fast if the set has
+        // gone, and the only thing that hangs a handshake after a good probe is an unanswered prompt.
         private static readonly TimeSpan PairingTimeout = TimeSpan.FromSeconds(60);
-        private static readonly TimeSpan ReconnectTimeout = TimeSpan.FromSeconds(10);
+        // A token reconnect the TV lets through answers within a second or so. Past this, the set
+        // has put its prompt up, and the user should be told what it is and how to stop it.
+        private static readonly TimeSpan RepromptGrace = TimeSpan.FromSeconds(3);
         private static readonly TimeSpan WakeTimeout = TimeSpan.FromSeconds(40);
 
         public static async Task<RemoteSessionResult> ConnectAsync(
@@ -118,9 +131,20 @@ namespace Apps2Samsung.Remote
             if (!string.IsNullOrEmpty(capability.MacAddress))
                 store.SetMac(tvIpAddress, capability.MacAddress);
 
-            var stored = store.GetToken(tvIpAddress);
+            // The token is filed under the set's own id when it reports one, so a TV that moved to
+            // another address keeps its pairing. Tokens stored under the IP by earlier builds are
+            // picked up once and re-filed.
+            var tokenKey = string.IsNullOrEmpty(capability.DeviceId) ? tvIpAddress : capability.DeviceId;
+            var stored = store.GetToken(tokenKey);
+            if (string.IsNullOrEmpty(stored) && tokenKey != tvIpAddress)
+            {
+                stored = store.GetToken(tvIpAddress);
+                if (!string.IsNullOrEmpty(stored))
+                    store.SetToken(tokenKey, stored);
+            }
+
             var client = new SamsungRemoteClient(tvIpAddress, token: stored, secure: capability.UsesToken);
-            client.TokenIssued += token => store.SetToken(tvIpAddress, token);
+            client.TokenIssued += token => store.SetToken(tokenKey, token);
 
             // No stored token on a token-auth set means the TV is about to prompt.
             var firstPairing = capability.UsesToken && string.IsNullOrEmpty(stored);
@@ -128,13 +152,27 @@ namespace Apps2Samsung.Remote
                 status?.Report(StatusPairPrompt);
 
             using var connectCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            connectCts.CancelAfter(firstPairing ? PairingTimeout : ReconnectTimeout);
+            connectCts.CancelAfter(PairingTimeout);
 
-            if (!await client.ConnectAsync(connectCts.Token).ConfigureAwait(false))
+            var connect = client.ConnectAsync(connectCts.Token);
+            var prompted = firstPairing;
+            if (!firstPairing)
+            {
+                // Should have been silent. If the TV is still holding the handshake after the grace
+                // period it has put its prompt up again — say so, and name the setting behind it.
+                var first = await Task.WhenAny(connect, Task.Delay(RepromptGrace, connectCts.Token)).ConfigureAwait(false);
+                if (first != connect)
+                {
+                    prompted = true;
+                    status?.Report(StatusPairPromptAgain);
+                }
+            }
+
+            if (!await connect.ConfigureAwait(false))
             {
                 await client.DisposeAsync().ConfigureAwait(false);
                 return new RemoteSessionResult(
-                    firstPairing ? RemoteSessionOutcome.PairingRefused : RemoteSessionOutcome.NoChannel,
+                    prompted ? RemoteSessionOutcome.PairingRefused : RemoteSessionOutcome.NoChannel,
                     Client: null,
                     capability.Name,
                     firstPairing,

--- a/Apps2Samsung.Core/Remote/SamsungRemoteClient.cs
+++ b/Apps2Samsung.Core/Remote/SamsungRemoteClient.cs
@@ -96,6 +96,9 @@ namespace Apps2Samsung.Remote
                     UsesToken = string.Equals(tokenAuth, "true", StringComparison.OrdinalIgnoreCase),
                     Name = device["name"]?.ToString() ?? string.Empty,
                     Model = device["modelName"]?.ToString() ?? string.Empty,
+                    // "uuid:…", fixed for the life of the set. What the pairing token is filed
+                    // under, so a new DHCP lease doesn't cost the user another prompt.
+                    DeviceId = device["id"]?.ToString() ?? string.Empty,
                     // Absent on older sets; only "standby" is a definite "asleep".
                     IsAwake = !string.Equals(powerState, "standby", StringComparison.OrdinalIgnoreCase),
                     // Reported for wired sets too, despite the name. Worth caching: it is what a
@@ -511,6 +514,12 @@ namespace Apps2Samsung.Remote
         public string Name { get; init; } = string.Empty;
 
         public string Model { get; init; } = string.Empty;
+
+        /// <summary>
+        /// The set's own id from the probe (<c>uuid:…</c>). Stable across reboots and address
+        /// changes, unlike the IP the user picked it by. Empty when the set didn't report one.
+        /// </summary>
+        public string DeviceId { get; init; } = string.Empty;
 
         /// <summary>False when the TV reported standby — keys won't reach it until it is woken.</summary>
         public bool IsAwake { get; init; } = true;

--- a/Apps2Samsung.Mobile/Services/MobileSettings.cs
+++ b/Apps2Samsung.Mobile/Services/MobileSettings.cs
@@ -30,7 +30,7 @@ public static class MobileSettings
 	private const string KeyJellyfinCustomCss = "jellyfin_custom_css";
 	private const string KeyJellyfinPatchYoutube = "jellyfin_patch_youtube";
 	private const string KeyJellyfinAccessToken = "jellyfin_access_token"; // SecureStorage
-	private const string KeyRemoteTokenPrefix = "remote_token_"; // one per TV, keyed by IP
+	private const string KeyRemoteTokenPrefix = "remote_token_"; // one per TV, keyed by the set's id (IP on older builds/sets)
 	private const string KeyRemoteMacPrefix = "remote_mac_"; // one per TV, keyed by IP
 
 	/// <summary>Uninstall the previous version before installing (desktop: "Remove old version").</summary>
@@ -269,15 +269,15 @@ public static class MobileSettings
 	/// <see cref="Preferences"/> rather than SecureStorage: it only authorizes button presses to one
 	/// TV on the local network, and it has to be readable synchronously while the remote page opens.
 	/// </summary>
-	public static string? GetRemoteToken(string tvIpAddress)
+	public static string? GetRemoteToken(string tvKey)
 	{
-		var token = Preferences.Get(KeyRemoteTokenPrefix + tvIpAddress, string.Empty);
+		var token = Preferences.Get(KeyRemoteTokenPrefix + tvKey, string.Empty);
 		return string.IsNullOrEmpty(token) ? null : token;
 	}
 
 	/// <summary>Stores the token the TV handed back, so the next session connects without prompting.</summary>
-	public static void SetRemoteToken(string tvIpAddress, string token) =>
-		Preferences.Set(KeyRemoteTokenPrefix + tvIpAddress, token);
+	public static void SetRemoteToken(string tvKey, string token) =>
+		Preferences.Set(KeyRemoteTokenPrefix + tvKey, token);
 
 	/// <summary>
 	/// The TV's MAC, remembered from a moment when the set was awake. A sleeping TV answers nothing,

--- a/Apps2Samsung.Mobile/Services/RemoteCredentials.cs
+++ b/Apps2Samsung.Mobile/Services/RemoteCredentials.cs
@@ -11,8 +11,8 @@ public sealed class RemoteCredentials : IRemoteCredentialStore
 {
 	public static readonly RemoteCredentials Instance = new();
 
-	public string? GetToken(string tvIpAddress) => MobileSettings.GetRemoteToken(tvIpAddress);
-	public void SetToken(string tvIpAddress, string token) => MobileSettings.SetRemoteToken(tvIpAddress, token);
+	public string? GetToken(string tvKey) => MobileSettings.GetRemoteToken(tvKey);
+	public void SetToken(string tvKey, string token) => MobileSettings.SetRemoteToken(tvKey, token);
 	public string? GetMac(string tvIpAddress) => MobileSettings.GetRemoteMac(tvIpAddress);
 	public void SetMac(string tvIpAddress, string macAddress) => MobileSettings.SetRemoteMac(tvIpAddress, macAddress);
 

--- a/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/Localization/en.json
@@ -351,6 +351,7 @@
   "lblRemoteConnecting": "Connecting to the TV...",
   "lblRemoteConnected": "Connected.",
   "lblRemotePairPrompt": "Accept the prompt on the TV to pair this computer.",
+  "lblRemotePairPromptAgain": "The TV is asking to allow this device again. Accept it, then on the TV set Device Connection Manager > Access Notification to \"First Time Only\" so it stops asking.",
   "lblRemotePairFailed": "Pairing wasn't accepted. Use the reconnect button to try again.",
   "lblRemoteNoChannel": "Couldn't open the remote channel on this TV.",
   "lblRemoteNotConnected": "Not connected - use the reconnect button.",

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/RemoteStore.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/RemoteStore.cs
@@ -10,23 +10,30 @@ namespace Apps2Samsung.Helpers.Core
     /// <summary>
     /// Remembers, per TV, the two things the remote can't rediscover on its own: the pairing token
     /// (without it the TV re-prompts every session) and the MAC captured while the set was awake
-    /// (without it a sleeping set can't be woken). Stored as JSON maps keyed by IP in settings.json,
-    /// the same shape the custom-icon/title maps use. The mobile head keeps the equivalent in its
-    /// Preferences store.
+    /// (without it a sleeping set can't be woken). Stored as JSON maps in settings.json, the same
+    /// shape the custom-icon/title maps use; <see cref="RemoteSession"/> picks the key (the set's
+    /// own id for tokens, the IP for MACs). The mobile head keeps the equivalent in its Preferences
+    /// store.
     /// </summary>
     public static class RemoteStore
     {
-        public static string? GetToken(string tvIpAddress) =>
-            Read(AppSettings.Default.RemoteTokensJson).GetValueOrDefault(tvIpAddress);
+        public static string? GetToken(string tvKey) =>
+            Read(AppSettings.Default.RemoteTokensJson).GetValueOrDefault(tvKey);
 
-        public static void SetToken(string tvIpAddress, string token) =>
-            AppSettings.Default.RemoteTokensJson = Write(AppSettings.Default.RemoteTokensJson, tvIpAddress, token);
+        public static void SetToken(string tvKey, string token)
+        {
+            AppSettings.Default.RemoteTokensJson = Write(AppSettings.Default.RemoteTokensJson, tvKey, token);
+            AppSettings.Default.Save();
+        }
 
         public static string? GetMac(string tvIpAddress) =>
             Read(AppSettings.Default.RemoteMacsJson).GetValueOrDefault(tvIpAddress);
 
-        public static void SetMac(string tvIpAddress, string macAddress) =>
+        public static void SetMac(string tvIpAddress, string macAddress)
+        {
             AppSettings.Default.RemoteMacsJson = Write(AppSettings.Default.RemoteMacsJson, tvIpAddress, macAddress);
+            AppSettings.Default.Save();
+        }
 
         /// <summary>
         /// The same store behind Core's <see cref="IRemoteCredentialStore"/>, so
@@ -37,8 +44,8 @@ namespace Apps2Samsung.Helpers.Core
         {
             public static readonly Credentials Instance = new();
 
-            public string? GetToken(string tvIpAddress) => RemoteStore.GetToken(tvIpAddress);
-            public void SetToken(string tvIpAddress, string token) => RemoteStore.SetToken(tvIpAddress, token);
+            public string? GetToken(string tvKey) => RemoteStore.GetToken(tvKey);
+            public void SetToken(string tvKey, string token) => RemoteStore.SetToken(tvKey, token);
             public string? GetMac(string tvIpAddress) => RemoteStore.GetMac(tvIpAddress);
             public void SetMac(string tvIpAddress, string macAddress) => RemoteStore.SetMac(tvIpAddress, macAddress);
         }
@@ -75,13 +82,14 @@ namespace Apps2Samsung.Helpers.Core
             }
         }
 
+        // Returns the updated map; the caller assigns it and then saves. (Saving in here, before the
+        // assignment, wrote the *previous* map to disk — a token only survived a restart if some
+        // other setting happened to be saved later in the session.)
         private static string Write(string json, string key, string value)
         {
             var map = Read(json);
             map[key] = value;
-            var updated = JsonSerializer.Serialize(map);
-            AppSettings.Default.Save();
-            return updated;
+            return JsonSerializer.Serialize(map);
         }
     }
 }


### PR DESCRIPTION
Follows up on #545: the reporter is asked to allow the remote on the TV every time and wonders why SmartThings isn't.

### What was wrong
- **Token keyed by IP.** A new DHCP lease made the app a stranger to the TV, so it prompted again.
- **Desktop token didn't reach disk.** `RemoteStore.Write` called `Save()` *before* the caller assigned the new map, so the pairing only survived a restart if another setting was saved later in the session.
- **A TV that prompts on every connection was reported as "no channel".** With Access Notification on "Always" the TV prompts even with a valid token. The reconnect gave the handshake 10 s and then failed; the user never learned what was going on.

### What changes
- The token is filed under the set's own id from the `/api/v2/` probe (`uuid:…`), IP as fallback for sets that report none. A token stored under the IP by an earlier build is picked up once and re-filed. MACs stay keyed by IP (looked up while the set is asleep, when the IP is all we have).
- Desktop store saves after the assignment.
- Reconnects get the same 60 s as a first pairing. If the handshake is still open after 3 s, the status switches to a new string (`lblRemotePairPromptAgain`) telling the user the TV is asking again and to set **Device Connection Manager → Access Notification** to **First Time Only**. An unanswered re-prompt reports as `PairingRefused`.

### Why not the SmartThings route
SmartThings goes through Samsung's cloud with an account token and only exposes power, volume, source, channel and app launch. No key presses, no text input, so neither the remote nor the toolbox's service-menu sequences could work over it, and its personal access tokens now expire after 24 hours. The local channel stays; the "ask every time" behaviour is a TV setting the app can't flip, so the app now says so.

### Verified
- Core + desktop build, 0 errors, no new warnings.
- `check_localization.py` passes.
- Mobile changes are parameter renames only; the Android job compiles them.
