### PR TITLE
IP Mismatch popup: show the chosen interface, and re-read the TV's Developer Mode IP before comparing

### DIFF
--- a/Apps2Samsung.Core/Network/InstallGuards.cs
+++ b/Apps2Samsung.Core/Network/InstallGuards.cs
@@ -53,7 +53,8 @@ namespace Apps2Samsung.Services
         public IReadOnlyCollection<string> LocalIps { get; init; } = Array.Empty<string>();
 
         /// <summary>The local IP the user picked (desktop NIC selection) or the phone's own IP.
-        /// Only used for the subnet comparison; empty skips it.</summary>
+        /// Used for the subnet comparison (empty skips it) and named as "this device" in the
+        /// IP-mismatch guard instead of the whole <see cref="LocalIps"/> list.</summary>
         public string? ConfiguredLocalIp { get; init; }
 
         /// <summary>The desktop's "Reverse IP (for Arabic/Hebrew)" setting: those TVs render the IP
@@ -162,11 +163,19 @@ namespace Apps2Samsung.Services
 
             if (ipMismatch)
             {
+                // Name the interface the user picked in settings as "this device". Listing every
+                // adapter (Hyper-V/WSL virtual switches, VPNs) reads as if the machine has three IPs
+                // and hides the one that matters. The full list is only the fallback when nothing is
+                // picked, or the picked address no longer exists on this machine.
+                var configured = options.ConfiguredLocalIp;
+                var thisDevice = !string.IsNullOrEmpty(configured) && localIps.Contains(configured!)
+                    ? configured!
+                    : string.Join(", ", localIps);
                 guards.Add(new InstallGuard(
                     InstallGuardKind.DeveloperIpMismatch,
                     "guardIpMismatchTitle", "DeveloperIPMismatch",
                     "IP Mismatch", DeveloperIpMismatchDefault,
-                    $"TV Developer Mode IP: {device.DeveloperIP} • this device: {string.Join(", ", localIps)}"));
+                    $"TV Developer Mode IP: {device.DeveloperIP} • this device: {thisDevice}"));
             }
 
             return new InstallGuardResult(guards, correctedTvIp);

--- a/Apps2Samsung.Core/Network/TizenDeveloperInfo.cs
+++ b/Apps2Samsung.Core/Network/TizenDeveloperInfo.cs
@@ -83,6 +83,76 @@ namespace Apps2Samsung.Services
         }
 
         /// <summary>
+        /// Re-reads the Developer-Mode fields of a TV the user is about to install to and updates
+        /// <paramref name="device"/> in place. The device list comes from a scan that may be minutes
+        /// old, and the Developer-Mode IP is exactly what people change between scanning and
+        /// installing: they see the "IP Mismatch" warning, correct the IP on the TV, and press
+        /// Install again. Judged by the scan's snapshot, the guards then keep warning about an IP the
+        /// TV no longer has. Call this right before <see cref="InstallGuards.Evaluate"/>.
+        ///
+        /// Only ever improves on the snapshot: a TV that doesn't answer keeps its scanned values, and
+        /// the debug-port state is re-probed only when the scan saw it closed, so a TV restarted since
+        /// then loses its stale "restart required" — a slow probe can never add one.
+        /// </summary>
+        public static async Task RefreshAsync(INetworkService network, NetworkDevice? device, CancellationToken cancellationToken = default)
+        {
+            // Placeholder picker entries ("Other…") carry no address to ask.
+            if (device is null || !IPAddress.TryParse(device.IpAddress, out _))
+                return;
+
+            try
+            {
+                if (!device.DebugPortOpen &&
+                    await IsPortOpenAsync(network, device.IpAddress, Constants.Ports.TizenDevPort, cancellationToken))
+                {
+                    device.DebugPortOpen = true;
+                }
+
+                if (!await IsPortOpenAsync(network, device.IpAddress, Constants.Ports.SamsungTvApiPort, cancellationToken))
+                    return;
+
+                var fresh = await ReadAsync(device, cancellationToken);
+
+                // ReadAsync's fallback (no/invalid answer) leaves DeveloperMode blank; a real Samsung
+                // answer always carries "0" or "1". Don't wipe good scan data with a failed read.
+                if (string.IsNullOrEmpty(fresh.DeveloperMode))
+                    return;
+
+                if (fresh.DeveloperMode != device.DeveloperMode || fresh.DeveloperIP != device.DeveloperIP)
+                {
+                    Trace.WriteLine($"[TizenApi] {device.IpAddress}: Developer Mode changed since the scan " +
+                                    $"(mode {device.DeveloperMode}→{fresh.DeveloperMode}, IP {device.DeveloperIP}→{fresh.DeveloperIP}).");
+                }
+                device.DeveloperMode = fresh.DeveloperMode;
+                device.DeveloperIP = fresh.DeveloperIP;
+                if (string.IsNullOrEmpty(device.DeviceName))
+                    device.DeviceName = fresh.DeviceName;
+                if (string.IsNullOrEmpty(device.ModelName))
+                    device.ModelName = fresh.ModelName;
+                if (string.IsNullOrEmpty(device.MacAddress))
+                    device.MacAddress = fresh.MacAddress;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Best effort: the guards fall back to the scan's snapshot.
+                Trace.WriteLine($"[TizenApi] Couldn't refresh Developer Mode info for {device.IpAddress}: {ex.Message}");
+            }
+        }
+
+        // One port probe with the scan's per-probe budget, so a TV that has gone to standby since the
+        // scan can't stall the Install button for the full TCP connect timeout.
+        private static async Task<bool> IsPortOpenAsync(INetworkService network, string ip, int port, CancellationToken cancellationToken)
+        {
+            using var timeout = new CancellationTokenSource(Constants.Defaults.NetworkScanTimeoutMs);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token, cancellationToken);
+            return await network.IsPortOpenAsync(ip, port, linked.Token);
+        }
+
+        /// <summary>
         /// Reads <c>/api/v2/</c> for one device. Never throws: a host that doesn't answer, or answers
         /// with something that isn't the Samsung TV API, comes back as a copy of the input with the
         /// Developer-Mode fields blank.

--- a/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
+++ b/Apps2Samsung.Mobile/Pages/InstallerPage.xaml.cs
@@ -414,6 +414,10 @@ public partial class InstallerPage : ContentPage
 
 		var tvIp = _tvIps[TvPicker.SelectedIndex];
 
+		// The device list is a scan snapshot; re-read the TV's Developer-Mode fields now so a
+		// Developer-Mode IP corrected on the TV since the scan isn't still flagged as a mismatch.
+		await TizenDeveloperInfo.RefreshAsync(_networkService, _tvDevices[TvPicker.SelectedIndex]);
+
 		// Shared pre-install guards (Core): a TV that still needs a restart, Developer Mode off, a
 		// Developer-Mode IP pointing at another device or typed back to front, a TV on another subnet.
 		// Same checks and wording as the desktop head — each one is Continue/Stop, never a hard block.

--- a/Jellyfin2Samsung-CrossOS/Helpers/Core/PackageHelper.cs
+++ b/Jellyfin2Samsung-CrossOS/Helpers/Core/PackageHelper.cs
@@ -56,6 +56,10 @@ namespace Apps2Samsung.Helpers.Core
                 return false;
             }
 
+            // The device list is a scan snapshot; re-read the TV's Developer-Mode fields now so a
+            // Developer-Mode IP corrected on the TV since the scan isn't still flagged as a mismatch.
+            await TizenDeveloperInfo.RefreshAsync(_networkService, selectedDevice, cancellationToken);
+
             // Shared pre-install guards: Developer Mode off, a Developer-Mode IP pointing at another
             // machine (or typed back to front), a TV on another subnet, and a TV whose install service
             // isn't up yet. Same checks and wording as the mobile head — see Core InstallGuards.
@@ -63,7 +67,13 @@ namespace Apps2Samsung.Helpers.Core
                 selectedDevice,
                 new InstallGuardOptions
                 {
-                    LocalIps = _networkService.GetRelevantLocalIPs().Select(ip => ip.ToString()).ToList(),
+                    // GetRelevantLocalIPs folds the hand-typed TV address (UserCustomIP) into the list
+                    // for the scan's benefit; it is not one of this machine's IPs, so keep it out of
+                    // the "this device" side of the comparison.
+                    LocalIps = _networkService.GetRelevantLocalIPs()
+                        .Select(ip => ip.ToString())
+                        .Where(ip => ip != AppSettings.Default.UserCustomIP)
+                        .ToList(),
                     ConfiguredLocalIp = AppSettings.Default.LocalIp,
                     ReversedIpReading = AppSettings.Default.RTLReading,
                 },


### PR DESCRIPTION
## What

The "IP Mismatch" popup listed every local adapter as "this device":

> TV Developer Mode IP: 192.168.2.21 • this device: 192.168.2.22, 192.168.32.1, 172.29.144.1

Two of those are Hyper-V/WSL virtual switches. The popup now names the interface picked in Settings → Local IP:

> TV Developer Mode IP: 192.168.2.21 • this device: 192.168.2.22

The full list is only the fallback when no interface is picked or the picked address no longer exists on the machine. The mobile head passes the phone's own IP, so it shows just that.

The comparison rule is unchanged: the TV's `developerIP` is authoritative, and the guard fires only when it matches none of this machine's addresses.

## Also

- `InstallGuards.Evaluate` was fed the `NetworkDevice` from the scan. New `TizenDeveloperInfo.RefreshAsync` re-reads `/api/v2/` for the selected TV right before the guards run (both heads), so the comparison uses the TV's current `developerIP` rather than the scan snapshot. It only improves on the snapshot: no answer keeps the scanned values, the debug port is re-probed only when the scan saw it closed, each probe runs on the scan's 1 s budget, and placeholder picker entries are skipped.
- Desktop: `GetRelevantLocalIPs()` folds the hand-typed TV address (`UserCustomIP`) in for the scan's benefit. It no longer ends up on the "this device" side of the comparison.

## Notes

Desktop builds locally (`Apps2Samsung.csproj`, .NET 10). Mobile head only builds in CI.
