### PR TITLE
Partner signing for on-boot/auto-restart packages, and TizenTube as a provider

### DIFF
--- a/Apps2Samsung.Core/Packaging/WgtPrivileges.cs
+++ b/Apps2Samsung.Core/Packaging/WgtPrivileges.cs
@@ -8,6 +8,9 @@ namespace Apps2Samsung.Packaging
     /// Partner-level distributor certificate. This is how the installer auto-selects the signing level
     /// without any per-package metadata: a package that needs a restricted API (e.g. VPN, DRM info)
     /// must declare the matching privilege to work, so the declaration itself is the source of truth.
+    /// The same goes for the launch settings <c>on-boot="true"</c> and <c>auto-restart="true"</c>:
+    /// Tizen only honours them for Partner-signed apps, so a manifest that sets them needs Partner
+    /// signing even when it declares no restricted privilege at all.
     /// Handles both package shapes — web apps (.wgt, config.xml) and .NET/native apps (.tpk,
     /// tizen-manifest.xml).
     /// </summary>
@@ -38,39 +41,57 @@ namespace Apps2Samsung.Packaging
             @"<privilege>\s*(?<name>[^<\s][^<]*?)\s*</privilege>",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+        // Launch settings that Tizen only honours for Partner-signed apps. They are attributes on the
+        // application element in both manifest shapes — <tizen:application .../> or <tizen:service .../>
+        // in config.xml, <ui-application .../> or <service-application .../> in tizen-manifest.xml —
+        // so a single attribute match covers both. Only an explicit "true" counts; "false" (or the
+        // attribute being absent) is the Public default.
+        private static readonly Regex PartnerLaunchSetting = new(
+            @"\b(?<name>on-boot|auto-restart)\s*=\s*""\s*true\s*""",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        // Commented-out markup must not trigger either check.
+        private static readonly Regex XmlComment = new(
+            @"<!--.*?-->",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
         /// <summary>The privilege names declared in the package's manifest (empty if unreadable).</summary>
         public static IReadOnlyList<string> ReadPrivileges(string packagePath)
         {
             var names = new List<string>();
-            try
-            {
-                using var zip = ZipFile.OpenRead(packagePath);
-                foreach (var entry in zip.Entries)
-                {
-                    if (entry.Name.Equals("config.xml", StringComparison.OrdinalIgnoreCase))
-                        AddMatches(entry, WebPrivilege, names);
-                    else if (entry.Name.Equals("tizen-manifest.xml", StringComparison.OrdinalIgnoreCase))
-                        AddMatches(entry, NativePrivilege, names);
-                }
-            }
-            catch
-            {
-                // Unreadable archive/manifest — treat as declaring nothing.
-            }
+            ForEachManifest(packagePath, (isWebManifest, xml) =>
+                AddMatches(xml, isWebManifest ? WebPrivilege : NativePrivilege, names));
             return names;
         }
 
-        /// <summary>True if the package declares a privilege that requires Partner-level signing.</summary>
+        /// <summary>
+        /// The Partner-only launch settings the package's manifest turns on, as <c>on-boot="true"</c> /
+        /// <c>auto-restart="true"</c> (empty if none, or if the package is unreadable).
+        /// </summary>
+        public static IReadOnlyList<string> ReadPartnerLaunchSettings(string packagePath)
+        {
+            var settings = new List<string>();
+            ForEachManifest(packagePath, (_, xml) =>
+            {
+                foreach (Match m in PartnerLaunchSetting.Matches(xml))
+                    settings.Add($"{m.Groups["name"].Value.ToLowerInvariant()}=\"true\"");
+            });
+            return settings;
+        }
+
+        /// <summary>True if the package declares a privilege or launch setting that requires Partner-level signing.</summary>
         public static bool RequiresPartner(string packagePath) =>
             FindPartnerPrivilege(packagePath) is not null;
 
         /// <summary>
-        /// The first Partner-only privilege the package declares, or <c>null</c> when Public signing is
-        /// enough. Returned instead of a bare bool so callers can tell the user *why* the level was
-        /// bumped (and log it when a TV still rejects the install).
+        /// The first Partner-only requirement the package declares — a Partner privilege name, or a
+        /// launch setting such as <c>on-boot="true"</c> — or <c>null</c> when Public signing is enough.
+        /// Returned instead of a bare bool so callers can tell the user *why* the level was bumped (and
+        /// log it when a TV still rejects the install).
         /// </summary>
         public static string? FindPartnerPrivilege(string packagePath) =>
-            FindPartnerPrivilege(ReadPrivileges(packagePath));
+            FindPartnerPrivilege(ReadPrivileges(packagePath))
+            ?? ReadPartnerLaunchSettings(packagePath).FirstOrDefault();
 
         /// <summary>Same decision for privileges that were already read.</summary>
         public static string? FindPartnerPrivilege(IEnumerable<string> privileges) =>
@@ -82,11 +103,37 @@ namespace Apps2Samsung.Packaging
             (PartnerPrivileges.Contains(privilege.Trim()) ||
              privilege.TrimEnd().EndsWith(PartnerSuffix, StringComparison.OrdinalIgnoreCase));
 
-        private static void AddMatches(ZipArchiveEntry entry, Regex regex, List<string> into)
+        /// <summary>
+        /// Runs <paramref name="visit"/> over every manifest in the package (config.xml → web,
+        /// tizen-manifest.xml → native) with XML comments already stripped. An unreadable archive or
+        /// manifest is treated as declaring nothing.
+        /// </summary>
+        private static void ForEachManifest(string packagePath, Action<bool, string> visit)
         {
-            using var stream = entry.Open();
-            using var reader = new StreamReader(stream);
-            var xml = reader.ReadToEnd();
+            try
+            {
+                using var zip = ZipFile.OpenRead(packagePath);
+                foreach (var entry in zip.Entries)
+                {
+                    bool isWebManifest = entry.Name.Equals("config.xml", StringComparison.OrdinalIgnoreCase);
+                    bool isNativeManifest = entry.Name.Equals("tizen-manifest.xml", StringComparison.OrdinalIgnoreCase);
+                    if (!isWebManifest && !isNativeManifest)
+                        continue;
+
+                    using var stream = entry.Open();
+                    using var reader = new StreamReader(stream);
+                    var xml = XmlComment.Replace(reader.ReadToEnd(), string.Empty);
+                    visit(isWebManifest, xml);
+                }
+            }
+            catch
+            {
+                // Unreadable archive/manifest — treat as declaring nothing.
+            }
+        }
+
+        private static void AddMatches(string xml, Regex regex, List<string> into)
+        {
             foreach (Match m in regex.Matches(xml))
                 into.Add(m.Groups["name"].Value.Trim());
         }

--- a/Apps2Samsung.Mobile/Resources/Raw/third-party-apps.json
+++ b/Apps2Samsung.Mobile/Resources/Raw/third-party-apps.json
@@ -36,6 +36,18 @@
       }
     },
     {
+      "id": "tizentube",
+      "url": "https://api.github.com/repos/reisxd/TizenTube/releases",
+      "prefix": "",
+      "displayName": "TizenTube",
+      "take": 1,
+      "buildInfo": {
+        "name": "TizenTube",
+        "description": "TizenTube enhances your favourite streaming websites viewing experience by removing ads and adding support for Sponsorblock.",
+        "previewImage": "https://raw.githubusercontent.com/reisxd/TizenTube/main/.github/assets/TizenTube%20Standalone%20Banner.png"
+      }
+    },
+    {
       "id": "jellyfin-avplay",
       "url": "https://api.github.com/repos/PatrickSt1991/tizen-jellyfin-avplay/releases",
       "prefix": "",

--- a/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
+++ b/Jellyfin2Samsung-CrossOS/Assets/third-party-apps.json
@@ -36,6 +36,18 @@
       }
     },
     {
+      "id": "tizentube",
+      "url": "https://api.github.com/repos/reisxd/TizenTube/releases",
+      "prefix": "",
+      "displayName": "TizenTube",
+      "take": 1,
+      "buildInfo": {
+        "name": "TizenTube",
+        "description": "TizenTube enhances your favourite streaming websites viewing experience by removing ads and adding support for Sponsorblock.",
+        "previewImage": "https://raw.githubusercontent.com/reisxd/TizenTube/main/.github/assets/TizenTube%20Standalone%20Banner.png"
+      }
+    },
+    {
       "id": "jellyfin-avplay",
       "url": "https://api.github.com/repos/PatrickSt1991/tizen-jellyfin-avplay/releases",
       "prefix": "",

--- a/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
+++ b/Jellyfin2Samsung-CrossOS/Services/TizenInstallerService.cs
@@ -457,8 +457,9 @@ namespace Apps2Samsung.Services
             // per-package via the manifest).
             // Partner if the global toggle is on, OR the selected package's manifest declares it, OR
             // the package itself declares a partner-level privilege (e.g. vpnservice in a .wgt's
-            // config.xml, drminfo in a .tpk's tizen-manifest.xml) — the automatic binding: a package
-            // that needs a restricted API must declare it, so we don't track cert levels per package.
+            // config.xml, drminfo in a .tpk's tizen-manifest.xml) or a Partner-only launch setting
+            // (on-boot="true" / auto-restart="true") — the automatic binding: a package that needs a
+            // restricted API or launch mode must declare it, so we don't track cert levels per package.
             var partnerPrivilege = Apps2Samsung.Packaging.WgtPrivileges.FindPartnerPrivilege(packageUrl);
 
             // The package can only be installed Partner-signed, and there's no Partner certificate yet:

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -76,6 +76,7 @@ property of the respective projects, and is used for identification only:
 - **Litefin** — icon, https://github.com/MoazSalem/litefin
 - **TVapp** — icon, https://github.com/KaashDev/TVapp
 - **Moonfin** — name, https://github.com/Moonfin-Client/Smart-TV
+- **TizenTube** — name and banner, https://github.com/reisxd/TizenTube
 
 *Samsung*, *Tizen* and related marks are trademarks of Samsung Electronics Co., Ltd.
 Apps2Samsung is not affiliated with, endorsed by, or sponsored by Samsung Electronics.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
   <b>Apps2Samsung</b> is a small cross-platform tool that side-loads <b>any app</b> onto <b>Samsung devices running Tizen OS</b> — Smart TVs, projectors and smart monitors —
-  <a href="https://jellyfin.org">Jellyfin</a>, Moonlight, Moonfin, Litefin and the whole <a href="https://github.com/Apps2Samsung/tizen-community-packages">community catalog</a>, or your own <code>.wgt</code>.
+  <a href="https://jellyfin.org">Jellyfin</a>, Moonlight, Moonfin, Litefin, TizenTube and the whole <a href="https://github.com/Apps2Samsung/tizen-community-packages">community catalog</a>, or your own <code>.wgt</code>.
   <br/>
   It handles device detection, certificates, and installation so you don’t have to fight with Tizen Studio or manual sideloading.
   <br/><br/>
@@ -152,6 +152,8 @@ Special thanks to:
   https://github.com/Moonfin-Client/Smart-TV
 - **@MoazSalem** — for the Litefin client and related work  
   https://github.com/MoazSalem/litefin/
+- **@reisxd** — for TizenTube and related work  
+  https://github.com/reisxd/TizenTube
 
 ---
 


### PR DESCRIPTION
## Partner certificate: `on-boot` / `auto-restart`

`WgtPrivileges` now also scans the package manifest for `on-boot="true"` and `auto-restart="true"`. Tizen only honours those launch settings for Partner-signed apps, so either one makes the package require a Partner certificate, exactly like a Partner-only privilege does.

- Covers both manifest shapes: `config.xml` (.wgt) and `tizen-manifest.xml` (.tpk). The attributes look the same on `tizen:service`, `tizen:application`, `ui-application` and `service-application`.
- Only an explicit `true` counts; `false` or an absent attribute stays Public. XML comments are stripped first so commented-out markup cannot trigger it.
- `FindPartnerPrivilege` returns the reason (e.g. `on-boot="true"`), so the desktop trace log and the auto-enable Partner flow work unchanged. Mobile goes through `RequiresPartner`, which picks it up automatically.
- Regex checked against mixed case, extra spacing, false-only, commented-out, absent, and the real TizenTube 2.0.1 `.wgt` (correctly Public).

## TizenTube as a provider

Added `tizentube` (reisxd/TizenTube GitHub releases, `take: 1`) next to Moonfin and Litefin in both bundled `third-party-apps.json` files, with `buildInfo` name, description and the repo banner as preview. Multiple `.wgt`/`.tpk` assets in one release appear in the version picker under the single TizenTube entry. README intro and credits plus the NOTICE artwork list are updated.

The live manifest on `main` gets the same entry in a separate PR. TizenTube is being removed from the community package bundle by hand.

Core and desktop build locally with 0 errors.
