### PR TITLE
Manifest: add TizenTube as a provider

### DIFF
--- a/third-party-apps.json
+++ b/third-party-apps.json
@@ -36,6 +36,18 @@
       }
     },
     {
+      "id": "tizentube",
+      "url": "https://api.github.com/repos/reisxd/TizenTube/releases",
+      "prefix": "",
+      "displayName": "TizenTube",
+      "take": 1,
+      "buildInfo": {
+        "name": "TizenTube",
+        "description": "TizenTube enhances your favourite streaming websites viewing experience by removing ads and adding support for Sponsorblock.",
+        "previewImage": "https://raw.githubusercontent.com/reisxd/TizenTube/main/.github/assets/TizenTube%20Standalone%20Banner.png"
+      }
+    },
+    {
       "id": "jellyfin-avplay",
       "url": "https://api.github.com/repos/PatrickSt1991/tizen-jellyfin-avplay/releases",
       "prefix": "",


### PR DESCRIPTION
Adds the `tizentube` provider (reisxd/TizenTube GitHub releases) to the live `third-party-apps.json` that shipped builds fetch at runtime, next to Moonfin and Litefin. Identical to the bundled-manifest entry in #652.

TizenTube is being removed from the community package bundle by hand; merge this before that removal so users don't lose the app in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
